### PR TITLE
fix: flush stdout/stderr after every write

### DIFF
--- a/crates/vite_task/src/execute.rs
+++ b/crates/vite_task/src/execute.rs
@@ -75,6 +75,7 @@ async fn collect_std_outputs(
         }
         let content = &buf[..n];
         parent_output_handle.write_all(content).await?;
+        parent_output_handle.flush().await?;
         let mut outputs = outputs.lock().unwrap();
         if let Some(last) = outputs.last_mut()
             && last.kind == kind


### PR DESCRIPTION
Similar to https://github.com/voidzero-dev/vite-plus/pull/82 to ensure outputs are displayed in the correct order