### PR TITLE
feat: add vite_shell crate for bash script parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3361,7 +3361,6 @@ version = "0.0.0"
 dependencies = [
  "ast-grep-core",
  "thiserror 2.0.17",
- "tree-sitter",
  "tree-sitter-bash",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,14 +108,12 @@ toml = "0.9.5"
 tracing = "0.1.41"
 tracing-error = "0.2.1"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "serde"] }
-tree-sitter = "0.24.7"
 tree-sitter-bash = "0.23.1"
 tui-term = "0.2.0"
 twox-hash = "2.1.1"
 uuid = "1.18.1"
 vite_glob = { path = "crates/vite_glob" }
 vite_path = { path = "crates/vite_path" }
-vite_shell = { path = "crates/vite_shell" }
 vite_str = { path = "crates/vite_str" }
 vite_workspace = { path = "crates/vite_workspace" }
 wax = "0.6.0"

--- a/crates/vite_shell/Cargo.toml
+++ b/crates/vite_shell/Cargo.toml
@@ -10,7 +10,6 @@ rust-version.workspace = true
 [dependencies]
 ast-grep-core = { workspace = true }
 thiserror = { workspace = true }
-tree-sitter = { workspace = true }
 tree-sitter-bash = { workspace = true }
 
 [lints]

--- a/crates/vite_shell/src/lib.rs
+++ b/crates/vite_shell/src/lib.rs
@@ -2,8 +2,6 @@
 //!
 //! This crate provides functionality to parse and split bash scripts by top-level operators.
 
-use std::iter;
-
 use ast_grep_core::{AstGrep, Doc, Language};
 use thiserror::Error;
 


### PR DESCRIPTION
Create a new vite_shell crate that uses ast-grep to parse and split
bash scripts by top-level && operators. The implementation properly
handles operator precedence and mixed operators (|| and &&).

Key features:
- Splits bash scripts by top-level && operators only
- Preserves nested structures (subshells, functions, etc.)
- Correctly handles || operators (left-associative precedence)
- Comprehensive test coverage (12 tests) including edge cases

Examples:
- "a && b && c" → ["a", "b", "c"]
- "a || b && c" → ["a || b", "c"]
- "a && b || c" → ["a && b || c"]

Dependencies:
- ast-grep-core 0.32.2 for AST-based parsing
- tree-sitter-bash 0.23.1 for bash grammar
- thiserror for error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>