### PR TITLE
fix: match passthough envs with uppercased env names

### DIFF
--- a/crates/vite_str/src/lib.rs
+++ b/crates/vite_str/src/lib.rs
@@ -71,6 +71,14 @@ impl Str {
     pub fn push_str(&mut self, s: &str) {
         self.0.push_str(s);
     }
+
+    pub fn to_uppercase(&self) -> Self {
+        Self(self.0.to_uppercase())
+    }
+
+    pub fn to_lowercase(&self) -> Self {
+        Self(self.0.to_lowercase())
+    }
 }
 
 impl AsRef<str> for Str {

--- a/crates/vite_task/src/execute.rs
+++ b/crates/vite_task/src/execute.rs
@@ -258,7 +258,8 @@ impl TaskEnvs {
                 GlobPatternSet::new(task.config.envs.iter().filter(|s| !s.starts_with('!')))?;
             let sensitive_patterns = GlobPatternSet::new(SENSITIVE_PATTERNS)?;
             for (name, value) in &all_envs {
-                if !envs_without_pass_through_patterns.is_match(name) {
+                let upper_name = name.to_uppercase();
+                if !envs_without_pass_through_patterns.is_match(&upper_name) {
                     continue;
                 }
                 let Some(value) = value.to_str() else {
@@ -267,7 +268,7 @@ impl TaskEnvs {
                         value: value.to_os_string(),
                     });
                 };
-                let value: Str = if sensitive_patterns.is_match(name) {
+                let value: Str = if sensitive_patterns.is_match(&upper_name) {
                     let mut hasher = Sha256::new();
                     hasher.update(value.as_bytes());
                     format!("sha256:{:x}", hasher.finalize()).into()


### PR DESCRIPTION
On Windows, env names are case-insensitive. `PATH` env is sometimes named `Path`.