### PR TITLE
refactor: make TaskEnvs::resolve accept env iterator parameter

### DIFF
--- a/crates/vite_task/src/config/mod.rs
+++ b/crates/vite_task/src/config/mod.rs
@@ -181,11 +181,8 @@ impl ResolvedTask {
         let cwd = &workspace.cwd;
         let resolved_task_config =
             ResolvedTaskConfig { config_dir: cwd.clone(), config: task_config };
-        let resolved_envs = TaskEnvs::resolve(
-            std::env::vars_os().collect::<Vec<_>>().into_iter(),
-            &workspace.root_dir,
-            &resolved_task_config,
-        )?;
+        let resolved_envs =
+            TaskEnvs::resolve(std::env::vars_os(), &workspace.root_dir, &resolved_task_config)?;
         let resolved_command = ResolvedTaskCommand {
             fingerprint: CommandFingerprint {
                 cwd: cwd.clone(),

--- a/crates/vite_task/src/config/task_command.rs
+++ b/crates/vite_task/src/config/task_command.rs
@@ -96,8 +96,7 @@ impl ResolvedTaskConfig {
                 }
             }
         };
-        let task_envs =
-            TaskEnvs::resolve(std::env::vars_os().collect::<Vec<_>>().into_iter(), base_dir, self)?;
+        let task_envs = TaskEnvs::resolve(std::env::vars_os(), base_dir, self)?;
         Ok(ResolvedTaskCommand {
             fingerprint: CommandFingerprint {
                 cwd,

--- a/crates/vite_task/src/execute.rs
+++ b/crates/vite_task/src/execute.rs
@@ -245,7 +245,7 @@ const SENSITIVE_PATTERNS: &[&str] = &[
 
 impl TaskEnvs {
     pub fn resolve(
-        current_envs: impl Iterator<Item = (OsString, OsString)> + Clone,
+        current_envs: impl Iterator<Item = (OsString, OsString)>,
         base_dir: &AbsolutePath,
         task: &ResolvedTaskConfig,
     ) -> Result<Self, Error> {


### PR DESCRIPTION
refactor: make TaskEnvs::resolve accept env iterator parameter

Change TaskEnvs::resolve to accept environment variables as an iterator
parameter instead of reading from std::env::vars_os() directly. This makes
tests cleaner and more isolated.

Changes:
- Update resolve_envs_with_patterns to accept env_vars iterator
- Update TaskEnvs::resolve to accept current_envs iterator parameter
- Update production call sites to pass std::env::vars_os()
- Refactor all tests to use clean mock environment vectors
- Remove all unsafe std::env::set_var/remove_var calls from tests

Benefits:
- Tests are isolated and don't modify global process environment
- No unsafe code needed in tests
- Tests can run safely in parallel
- More functional and easier to test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

remove unnecessary code