### PR TITLE
fix: handle Windows path stripping failures gracefully

### DIFF
--- a/crates/vite_task/src/session/execute/spawn.rs
+++ b/crates/vite_task/src/session/execute/spawn.rs
@@ -178,8 +178,9 @@ where
             let Ok(stripped_path) = strip_result else {
                 return None;
             };
-            // On Windows, path stripping may fail due to case sensitivity or path format
-            // differences. Treat these as outside workspace rather than failing.
+            // On Windows, paths are possible to be still absolute after stripping the workspace root.
+            // For example: c:\workspace\subdir\c:\workspace\subdir
+            // Just ignore those accesses.
             RelativePathBuf::new(stripped_path).ok()
         });
 


### PR DESCRIPTION
## Summary
- Fix Windows path handling that caused "Invalid relative path" errors
- On Windows, path stripping may fail due to case sensitivity or path format differences
- Instead of failing with an error, treat such paths as outside the workspace (like other unmatched paths)

## Problem
When running vite-task on Windows, paths tracked by fspy might have different formats or casing than the workspace root. This caused errors like:
```
Invalid relative path 'D:\a\vite-plus\vite-plus\ecosystem-ci\tanstack-start-helloworld': path is not relative
```

## Solution
Changed the error handling to use `.ok()` instead of `.map_err()` followed by `.transpose()?`, treating conversion failures as paths outside the workspace.

## Test plan
- [x] Ran `cargo test -p vite_task` locally
- Testing in vite-plus E2E CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)