### PR TITLE
perf(ci): optimize Windows Rust builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,14 @@ rustflags = ["--cfg", "tokio_unstable"] # also update .github/workflows/ci.yml
 
 [unstable]
 bindeps = true
+
+# Windows static CRT linking for portable binaries
+# Note: must include --cfg tokio_unstable since target-specific rustflags override [build] rustflags
+[target.x86_64-pc-windows-msvc]
+rustflags = ["--cfg", "tokio_unstable", "-C", "target-feature=+crt-static"]
+
+[target.i686-pc-windows-msvc]
+rustflags = ["--cfg", "tokio_unstable", "-C", "target-feature=+crt-static"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["--cfg", "tokio_unstable", "-C", "target-feature=+crt-static"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,21 @@ jobs:
             target: x86_64-apple-darwin
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Set up Dev Drive
+        uses: samypr100/setup-dev-drive@30f0f98ae5636b2b6501e181dfb3631b9974818d # v4.0.0
+        if: matrix.os == 'windows-latest'
+        with:
+          workspace-copy: true
+          drive-size: 8GB
+          drive-format: NTFS
+          env-mapping: |
+            CARGO_HOME,{{ DEV_DRIVE }}/.cargo
+            RUSTUP_HOME,{{ DEV_DRIVE }}/.rustup
+
+      - name: Enable long paths
+        if: matrix.os == 'windows-latest'
+        run: git config --system core.longpaths true
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false


### PR DESCRIPTION
- Add Dev Drive setup to reduce filesystem overhead
- Enable long paths support for Windows
- Add static CRT linking for Windows MSVC targets