### PR TITLE
fix: ts-rs warnings

### DIFF
--- a/crates/vite_str/Cargo.toml
+++ b/crates/vite_str/Cargo.toml
@@ -11,7 +11,7 @@ bincode = { workspace = true }
 compact_str = { workspace = true, features = ["serde"] }
 diff-struct = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-ts-rs = { workspace = true, optional = true }
+ts-rs = { workspace = true, optional = true, features = ["no-serde-warnings"] }
 
 [features]
 ts-rs = ["dep:ts-rs"]

--- a/crates/vite_task_graph/Cargo.toml
+++ b/crates/vite_task_graph/Cargo.toml
@@ -24,7 +24,7 @@ vite_workspace = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-ts-rs = { workspace = true }
+ts-rs = { workspace = true, features = ["no-serde-warnings"] }
 vite_path = { workspace = true, features = ["ts-rs"] }
 vite_str = { workspace = true, features = ["ts-rs"] }
 which = { workspace = true }


### PR DESCRIPTION
Enable the ts-rs feature to fix warning:
```
> cargo check --all-targets --all-features
    Checking vite_task_plan v0.1.0 (/Volumes/code/vite-plus-workspace/vite-task/crates/vite_task_plan)
warning: failed to parse serde attribute
  | 
  | deny_unknown_fields , rename_all = "camelCase"
  | 
  = note: ts-rs failed to parse this attribute. It will be ignored.
    Checking vite_task v0.0.0 (/Volumes/code/vite-plus-workspace/vite-task/crates/vite_task)
    Checking vite_task_bin v0.1.0 (/Volumes/code/vite-plus-workspace/vite-task/crates/vite_task_bin)
    Finished `dev` profile [unoptimized] target(s) in 1.33s
```