### PR TITLE
fix: resolve flaky PTY tests on macOS and Windows

### DIFF
--- a/crates/pty_terminal/src/terminal.rs
+++ b/crates/pty_terminal/src/terminal.rs
@@ -26,7 +26,7 @@ pub struct PtyReader {
 pub struct PtyWriter {
     writer: Arc<Mutex<Option<Box<dyn Write + Send>>>>,
     parser: Arc<Mutex<vt100::Parser<Vt100Callbacks>>>,
-    master: Box<dyn MasterPty + Send>,
+    master: Arc<Mutex<Option<Box<dyn MasterPty + Send>>>>,
 }
 
 /// A cloneable handle to a child process spawned in a PTY.
@@ -200,18 +200,22 @@ impl PtyWriter {
     ///
     /// # Errors
     ///
-    /// Returns an error if the PTY cannot be resized.
+    /// Returns an error if the PTY cannot be resized or the child has already exited.
     ///
     /// # Panics
     ///
     /// Panics if the parser lock is poisoned.
     pub fn resize(&self, size: ScreenSize) -> anyhow::Result<()> {
-        self.master.resize(portable_pty::PtySize {
+        let guard = self.master.lock().unwrap();
+        let master =
+            guard.as_ref().ok_or_else(|| anyhow::anyhow!("cannot resize: child has exited"))?;
+        master.resize(portable_pty::PtySize {
             rows: size.rows,
             cols: size.cols,
             pixel_width: 0,
             pixel_height: 0,
         })?;
+        drop(guard);
 
         self.parser.lock().unwrap().screen_mut().set_size(size.rows, size.cols);
 
@@ -258,24 +262,41 @@ impl Terminal {
         let reader = pty_pair.master.try_clone_reader()?;
         let writer: Arc<Mutex<Option<Box<dyn Write + Send>>>> =
             Arc::new(Mutex::new(Some(pty_pair.master.take_writer()?)));
-        // Spawn child and immediately drop slave to ensure EOF is signaled when child exits
         let mut child = pty_pair.slave.spawn_command(cmd)?;
         let child_killer = child.clone_killer();
-        drop(pty_pair.slave); // Critical: drop slave so EOF is signaled when child exits
-        let master = pty_pair.master;
+        let master: Arc<Mutex<Option<Box<dyn MasterPty + Send>>>> =
+            Arc::new(Mutex::new(Some(pty_pair.master)));
         let exit_status: Arc<OnceLock<ExitStatus>> = Arc::new(OnceLock::new());
 
-        // Background thread: wait for child to exit, set exit status, then close writer to trigger EOF
+        // Background thread: wait for child to exit, then clean up.
+        //
+        // The slave and master are kept alive until after `child.wait()` returns
+        // rather than being dropped immediately after spawn.
+        //
+        // macOS: if the parent's slave fd is closed early and the child exits
+        // quickly, all slave references close before the reader issues its first
+        // `read()`. macOS then returns EIO on the master without draining the
+        // output buffer, causing data loss.
+        //
+        // Windows (ConPTY): the reader pipe only gets EOF when the ConPTY handle
+        // is destroyed via `ClosePseudoConsole`, which requires all
+        // `Arc<Mutex<Inner>>` references (held by both master and slave) to be
+        // dropped. Dropping the master here brings that refcount to zero, ensuring
+        // the reader sees EOF promptly after the child exits.
         thread::spawn({
             let writer = Arc::clone(&writer);
+            let master = Arc::clone(&master);
             let exit_status = Arc::clone(&exit_status);
+            let slave = pty_pair.slave;
             move || {
                 // Wait for child and set exit status
                 if let Ok(status) = child.wait() {
                     let _ = exit_status.set(status);
                 }
-                // Close writer to signal EOF to the reader
+                // Close writer, master, and slave to trigger EOF on the reader.
                 *writer.lock().unwrap() = None;
+                *master.lock().unwrap() = None;
+                drop(slave);
             }
         });
 


### PR DESCRIPTION
## Summary

Fixes two flaky PTY test failures by deferring slave and master cleanup to the background thread after `child.wait()` returns, instead of dropping them eagerly during spawn.

## Bug 1: macOS `is_terminal` — empty output ([CI #22038626101](https://github.com/voidzero-dev/vite-task/actions/runs/22038626101/job/63675648683?pr=162))

**Root cause**: The parent's slave fd was dropped immediately after spawn (`drop(pty_pair.slave)`). When the child exited quickly, all slave references closed before the reader's first `read()`. macOS returns EIO on the master fd without draining the output buffer. portable-pty converts EIO → `Ok(0)`, so `read_to_end` returns empty data.

**Reproduction**: Adding `thread::sleep(2s)` before `read_to_end` in the `is_terminal` test deterministically produced empty output (child exits during the sleep, all slave refs close, reader gets EIO on first read).

**Fix**: Keep the slave alive in the background thread. It is dropped only after `child.wait()` returns, ensuring the output buffer is fully drained before EIO can occur.

## Bug 2: Windows `read_to_end_returns_exit_status_nonzero` — 5s timeout ([CI #22038894925](https://github.com/voidzero-dev/vite-task/actions/runs/22038894925/job/63676366581?pr=163))

**Root cause**: The reader pipe gets EOF only when `ClosePseudoConsole` is called, which requires all `Arc<Mutex<Inner>>` references (held by both master and slave) to reach zero. The slave was already dropped, but the master lived inside `PtyWriter` and was never explicitly dropped. EOF depended on undocumented ConPTY auto-close behavior that is unreliable under CI load.

**Reproduction**: Adding a 10s sleep in the background thread before closing the writer caused `read_to_end` to hang and the test to timeout at 5s — proving EOF depends on cleanup timing, not child exit. With the fix applied, the same test passes even with a 3s delay because the master is explicitly dropped.

**Fix**: Wrap master in `Arc<Mutex<Option<...>>>` (like writer) and drop it from the background thread after `child.wait()`. This calls `ClosePseudoConsole` → closes the stdout pipe → reader gets EOF deterministically.

## Changes

- `PtyWriter.master`: `Box<dyn MasterPty + Send>` → `Arc<Mutex<Option<Box<dyn MasterPty + Send>>>>`
- `Terminal::spawn`: background thread now drops writer, master, and slave in sequence after `child.wait()`
- `PtyWriter::resize`: handles `Option` (returns error if master already dropped)

## Validation

- macOS: 9/9 tests pass × 20 runs (180/180)
- Windows (cargo xtest): 9/9 tests pass × 20 runs (180/180)
- Clippy clean, no sleeps in final code