### PR TITLE
feat: add cwd and args info to snapshot headers

### DIFF
--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exec-api/snapshots/exec caching.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exec-api/snapshots/exec caching.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
-input_file: crates/vite_task_bin/tests/e2e_snapshots/fixtures/exec-api
 ---
 > FOO=bar vp lint # cache miss
 bar

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary-output/snapshots/last details after run shows saved summary.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary-output/snapshots/last details after run shows saved summary.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/a
 ---
 > vp run build # populate summary file
 ~/packages/a$ print built-a

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary-output/snapshots/single task cache hit shows compact summary.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary-output/snapshots/single task cache hit shows compact summary.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/a
 ---
 > vp run build # first run, cache miss
 ~/packages/a$ print built-a

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary-output/snapshots/single task cache miss shows no summary.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary-output/snapshots/single task cache miss shows no summary.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/a
 ---
 > vp run build
 ~/packages/a$ print built-a

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary-output/snapshots/single task verbose shows full summary.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary-output/snapshots/single task verbose shows full summary.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/a
 ---
 > vp run -v build
 ~/packages/a$ print built-a

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-list/snapshots/list tasks from package dir.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-list/snapshots/list tasks from package dir.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/app
 ---
 > echo '' | vp run
   build: echo build app

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select-truncate/snapshots/interactive long command truncated.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select-truncate/snapshots/interactive long command truncated.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/app
 ---
 > vp run
 @ expect-milestone: task-select::0

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive enter with no results does nothing.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive enter with no results does nothing.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/app
 ---
 > vp run
 @ expect-milestone: task-select::0

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive escape clears query.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive escape clears query.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/app
 ---
 > vp run
 @ expect-milestone: task-select::0

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive scroll long list.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive scroll long list.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/app
 ---
 > vp run
 @ expect-milestone: task-select::0

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search other package task.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search other package task.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/app
 ---
 > vp run
 @ expect-milestone: task-select::0

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search preserves rating within package.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search preserves rating within package.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/lib
 ---
 > vp run
 @ expect-milestone: task-select::0

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search then select.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search then select.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/app
 ---
 > vp run
 @ expect-milestone: task-select::0

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search with hash skips reorder.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search with hash skips reorder.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/app
 ---
 > vp run
 @ expect-milestone: task-select::0

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select task from lib.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select task from lib.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/lib
 ---
 > vp run
 @ expect-milestone: task-select::0

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select task.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select task.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/app
 ---
 > vp run
 @ expect-milestone: task-select::0

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select with recursive.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select with recursive.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/app
 ---
 > vp run -r
 @ expect-milestone: task-select::0

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select with typo and transitive.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select with typo and transitive.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/app
 ---
 > vp run -t buid
 @ expect-milestone: task-select:buid:0

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select with typo.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select with typo.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/app
 ---
 > vp run buid
 @ expect-milestone: task-select:buid:0

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/non-interactive list tasks from lib.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/non-interactive list tasks from lib.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/lib
 ---
 > echo '' | vp run
   build: echo build lib

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological-execution-order/snapshots/transitive build from app runs all dependencies.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological-execution-order/snapshots/transitive build from app runs all dependencies.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/app
 ---
 > vp run -t build # core -> lib -> app
 ~/packages/core$ echo 'Building core' ⊘ cache disabled

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological-execution-order/snapshots/transitive build from lib runs only its dependencies.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological-execution-order/snapshots/transitive build from lib runs only its dependencies.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
 expression: e2e_outputs
+info:
+  cwd: packages/lib
 ---
 > vp run -t build # core -> lib
 ~/packages/core$ echo 'Building core' ⊘ cache disabled

--- a/crates/vite_task_bin/tests/e2e_snapshots/main.rs
+++ b/crates/vite_task_bin/tests/e2e_snapshots/main.rs
@@ -311,6 +311,14 @@ fn run_case_inner(tmpdir: &AbsolutePath, fixture_path: &std::path::Path, fixture
             }
         }
 
+        let _info_guard = if e2e.cwd.as_str().is_empty() {
+            None
+        } else {
+            let mut case_settings = insta::Settings::clone_current();
+            case_settings.set_info(&serde_json::json!({ "cwd": e2e.cwd.as_str() }));
+            Some(case_settings.bind_to_scope())
+        };
+
         let e2e_stage_path = tmpdir.join(vite_str::format!("{fixture_name}_e2e_stage_{e2e_count}"));
         e2e_count += 1;
         CopyOptions::new().copy_tree(fixture_path, e2e_stage_path.as_path()).unwrap();

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/additional-envs/snapshots/query - env-test synthetic task in user task.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/additional-envs/snapshots/query - env-test synthetic task in user task.snap
@@ -1,6 +1,10 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&plan_json"
+info:
+  args:
+    - run
+    - env-test
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/additional-envs
 ---
 [

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-keys/snapshots/query - echo and lint with extra args.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-keys/snapshots/query - echo and lint with extra args.snap
@@ -1,6 +1,11 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&plan_json"
+info:
+  args:
+    - run
+    - echo-and-lint
+    - "--fix"
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-keys
 ---
 [

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-keys/snapshots/query - lint and echo with extra args.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-keys/snapshots/query - lint and echo with extra args.snap
@@ -1,6 +1,11 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&plan_json"
+info:
+  args:
+    - run
+    - lint-and-echo
+    - Linting complete
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-keys
 ---
 [

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-keys/snapshots/query - normal task with extra args.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-keys/snapshots/query - normal task with extra args.snap
@@ -1,6 +1,11 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&plan_json"
+info:
+  args:
+    - run
+    - hello
+    - a.txt
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-keys
 ---
 [

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-keys/snapshots/query - synthetic task in user task with cwd.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-keys/snapshots/query - synthetic task in user task with cwd.snap
@@ -1,6 +1,11 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&plan_json"
+info:
+  args:
+    - run
+    - lint
+  cwd: subdir
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-keys
 ---
 [

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-keys/snapshots/query - synthetic task in user task.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-keys/snapshots/query - synthetic task in user task.snap
@@ -1,6 +1,10 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&plan_json"
+info:
+  args:
+    - run
+    - lint
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-keys
 ---
 [

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-keys/snapshots/query - synthetic task with extra args in user task.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-keys/snapshots/query - synthetic task with extra args in user task.snap
@@ -1,6 +1,11 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&plan_json"
+info:
+  args:
+    - run
+    - lint
+    - "--fix"
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-keys
 ---
 [

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-scripts-error-non-root/snapshots/task graph load error.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-scripts-error-non-root/snapshots/task graph load error.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
-expression: err_str
+expression: err_str.as_ref()
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-scripts-error-non-root
 ---
 `cacheScripts` can only be set in the workspace root config, but found in <workspace>/packages/pkg-a

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-subcommand/snapshots/query - cache clean in script.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-subcommand/snapshots/query - cache clean in script.snap
@@ -1,6 +1,10 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&plan_json"
+info:
+  args:
+    - run
+    - clean-cache
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/cache-subcommand
 ---
 [

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cd-in-scripts/snapshots/query - cd before vp lint should put synthetic task under cwd.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cd-in-scripts/snapshots/query - cd before vp lint should put synthetic task under cwd.snap
@@ -1,6 +1,10 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&plan_json"
+info:
+  args:
+    - run
+    - cd-lint
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/cd-in-scripts
 ---
 [

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cd-in-scripts/snapshots/query - cd before vp run should not affect expanded task cwd.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cd-in-scripts/snapshots/query - cd before vp run should not affect expanded task cwd.snap
@@ -1,6 +1,10 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&plan_json"
+info:
+  args:
+    - run
+    - cd-build
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/cd-in-scripts
 ---
 [

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/conflict-test/snapshots/task graph.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/conflict-test/snapshots/task graph.snap
@@ -1,7 +1,7 @@
 ---
-source: crates/vite_task_bin/tests/test_snapshots/main.rs
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: task_graph_json
-input_file: crates/vite_task_bin/tests/test_snapshots/fixtures/conflict-test
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/conflict-test
 ---
 [
   {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cycle-dependency/snapshots/query - cycle dependency error.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cycle-dependency/snapshots/query - cycle dependency error.snap
@@ -1,6 +1,10 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: err_str.as_ref()
+info:
+  args:
+    - run
+    - task-a
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/cycle-dependency
 ---
 Cycle dependency detected: cycle-dependency-test#task-a -> cycle-dependency-test#task-b -> cycle-dependency-test#task-a

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/dependency-both-topo-and-explicit/snapshots/task graph.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/dependency-both-topo-and-explicit/snapshots/task graph.snap
@@ -1,7 +1,7 @@
 ---
-source: crates/vite_task_bin/tests/test_snapshots/main.rs
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: task_graph_json
-input_file: crates/vite_task_bin/tests/test_snapshots/fixtures/dependency-both-topo-and-explicit
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/dependency-both-topo-and-explicit
 ---
 [
   {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/empty-package-test/snapshots/task graph.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/empty-package-test/snapshots/task graph.snap
@@ -1,7 +1,7 @@
 ---
-source: crates/vite_task_bin/tests/test_snapshots/main.rs
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: task_graph_json
-input_file: crates/vite_task_bin/tests/test_snapshots/fixtures/empty-package-test
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/empty-package-test
 ---
 [
   {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/explicit-deps-workspace/snapshots/task graph.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/explicit-deps-workspace/snapshots/task graph.snap
@@ -1,7 +1,7 @@
 ---
-source: crates/vite_task_bin/tests/test_snapshots/main.rs
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: task_graph_json
-input_file: crates/vite_task_bin/tests/test_snapshots/fixtures/explicit-deps-workspace
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/explicit-deps-workspace
 ---
 [
   {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/fingerprint-ignore-test/snapshots/task graph.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/fingerprint-ignore-test/snapshots/task graph.snap
@@ -1,7 +1,7 @@
 ---
-source: crates/vite_task_bin/tests/test_snapshots/main.rs
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: task_graph_json
-input_file: crates/vite_task_bin/tests/test_snapshots/fixtures/fingerprint-ignore-test
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/fingerprint-ignore-test
 ---
 [
   {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested-tasks/snapshots/query - nested vp run.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested-tasks/snapshots/query - nested vp run.snap
@@ -1,6 +1,10 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&compact_plan"
+info:
+  args:
+    - run
+    - script2
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/nested-tasks
 ---
 {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/pnpm-workspace-packages-optional/snapshots/query - allow `packages` in pnpm-workspace.yaml to be optional.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/pnpm-workspace-packages-optional/snapshots/query - allow `packages` in pnpm-workspace.yaml to be optional.snap
@@ -1,6 +1,10 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&compact_plan"
+info:
+  args:
+    - run
+    - hello
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/pnpm-workspace-packages-optional
 ---
 {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/recursive-topological-workspace/snapshots/task graph.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/recursive-topological-workspace/snapshots/task graph.snap
@@ -1,7 +1,7 @@
 ---
-source: crates/vite_task_bin/tests/test_snapshots/main.rs
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: task_graph_json
-input_file: crates/vite_task_bin/tests/test_snapshots/fixtures/recursive-topological-workspace
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/recursive-topological-workspace
 ---
 [
   {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/shell-fallback/snapshots/query - shell fallback for pipe command.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/shell-fallback/snapshots/query - shell fallback for pipe command.snap
@@ -1,6 +1,10 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&plan_json"
+info:
+  args:
+    - run
+    - pipe-test
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/shell-fallback
 ---
 [

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/shell-fallback/snapshots/task graph.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/shell-fallback/snapshots/task graph.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
-assertion_line: 106
 expression: task_graph_json
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/shell-fallback
 ---

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-cache-disabled/snapshots/query - parent cache false does not affect expanded query tasks.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-cache-disabled/snapshots/query - parent cache false does not affect expanded query tasks.snap
@@ -1,6 +1,10 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&plan_json"
+info:
+  args:
+    - run
+    - run-build-no-cache
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-cache-disabled
 ---
 [

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-cache-disabled/snapshots/query - script cache false does not affect expanded synthetic cache.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-cache-disabled/snapshots/query - script cache false does not affect expanded synthetic cache.snap
@@ -1,6 +1,10 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&plan_json"
+info:
+  args:
+    - run
+    - run-build-cache-false
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-cache-disabled
 ---
 [

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-cache-disabled/snapshots/query - script without cacheScripts defaults to no cache.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-cache-disabled/snapshots/query - script without cacheScripts defaults to no cache.snap
@@ -1,6 +1,10 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&plan_json"
+info:
+  args:
+    - run
+    - lint
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-cache-disabled
 ---
 [

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-cache-disabled/snapshots/query - task passThroughEnvs inherited by synthetic.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-cache-disabled/snapshots/query - task passThroughEnvs inherited by synthetic.snap
@@ -1,6 +1,10 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&plan_json"
+info:
+  args:
+    - run
+    - lint-with-pass-through-envs
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-cache-disabled
 ---
 [

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-cache-disabled/snapshots/query - task with cache false disables synthetic cache.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-cache-disabled/snapshots/query - task with cache false disables synthetic cache.snap
@@ -1,6 +1,10 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&plan_json"
+info:
+  args:
+    - run
+    - lint-no-cache
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-cache-disabled
 ---
 [

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-cache-disabled/snapshots/query - task with cache true enables synthetic cache.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-cache-disabled/snapshots/query - task with cache true enables synthetic cache.snap
@@ -1,6 +1,10 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&plan_json"
+info:
+  args:
+    - run
+    - lint-with-cache
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-cache-disabled
 ---
 [

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-in-subpackage/snapshots/query - synthetic-in-subpackage.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-in-subpackage/snapshots/query - synthetic-in-subpackage.snap
@@ -1,6 +1,10 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&plan_json"
+info:
+  args:
+    - run
+    - lint
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic-in-subpackage
 ---
 [

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/vpr-shorthand/snapshots/query - vpr expands to vp run.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/vpr-shorthand/snapshots/query - vpr expands to vp run.snap
@@ -1,6 +1,10 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
 expression: "&compact_plan"
+info:
+  args:
+    - run
+    - all
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/vpr-shorthand
 ---
 {

--- a/crates/vite_task_plan/tests/plan_snapshots/main.rs
+++ b/crates/vite_task_plan/tests/plan_snapshots/main.rs
@@ -230,6 +230,14 @@ fn run_case_inner(
             let snapshot_name = vite_str::format!("query - {}", plan.name);
             let compact = plan.compact;
 
+            let mut case_settings = insta::Settings::clone_current();
+            let mut info = serde_json::json!({ "args": plan.args });
+            if !plan.cwd.as_str().is_empty() {
+                info["cwd"] = serde_json::json!(plan.cwd.as_str());
+            }
+            case_settings.set_info(&info);
+            let _guard = case_settings.bind_to_scope();
+
             let cli = match Cli::try_parse_from(
                 std::iter::once("vp") // dummy program name
                     .chain(plan.args.iter().map(vite_str::Str::as_str)),


### PR DESCRIPTION
## Why

Snapshot files currently only show `source`, `expression`, and `input_file` in the YAML header. To understand what a snapshot is testing, you have to cross-reference `snapshots.toml`. Adding `cwd` and `args` to the header makes each snapshot self-describing, making human review easier.

## Summary
- Add `info` field to plan snapshot headers with `args` (array) and optional `cwd`
- Add `info` field to E2E snapshot headers with `cwd` when non-default
- Makes snapshots self-describing without cross-referencing `snapshots.toml`

## Test plan
- [x] `cargo test -p vite_task_plan --test plan_snapshots` passes
- [x] `cargo test -p vite_task_bin --test e2e_snapshots` passes
- [x] Verified headers in generated `.snap` files contain correct info

🤖 Generated with [Claude Code](https://claude.com/claude-code)