### PR TITLE
fix: Add extra newline between "Select a task" and the tasks to align with Vite+.

### DIFF
--- a/crates/vite_select/src/interactive.rs
+++ b/crates/vite_select/src/interactive.rs
@@ -160,7 +160,8 @@ pub fn render_items(writer: &mut impl Write, params: &RenderParams<'_>) -> anyho
                 "Select a task (\u{2191}/\u{2193}, Enter to run, Esc to clear): {q}{line_ending}",
             )?;
         }
-        lines += 1;
+        write!(writer, "{line_ending}")?;
+        lines += 2;
     }
 
     // Items
@@ -519,9 +520,11 @@ mod tests {
         let output = render_interactive_to_string(&items, "", 80);
         let mut lines = output.lines();
         let prompt = lines.next().unwrap();
+        let spacer = lines.next().unwrap();
         let selected = lines.next().unwrap();
         let unselected = lines.next().unwrap();
         assert_eq!(prompt, "Select a task (↑/↓, Enter to run, Esc to clear):");
+        assert!(spacer.is_empty());
         assert_eq!(selected, "  › build: echo build");
         assert_eq!(unselected, "    lint: echo lint");
     }

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-list/snapshots/vp run in script.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-list/snapshots/vp run in script.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
-assertion_line: 460
 expression: e2e_outputs
 ---
 > vp run list-tasks
 @ expect-milestone: task-select::0
 $ vp run ⊘ cache disabled
 Select a task (↑/↓, Enter to run, Esc to clear):
+
   › hello: echo hello from root
     list-tasks: vp run
     app#build: echo build app

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select-truncate/snapshots/interactive long command truncated.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select-truncate/snapshots/interactive long command truncated.snap
@@ -7,6 +7,7 @@ info:
 > vp run
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
+
   › build: echo build app
     lint: echo lint app
     long-cmd: echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…
@@ -14,6 +15,7 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 @ write-key: down
 @ expect-milestone: task-select::1
 Select a task (↑/↓, Enter to run, Esc to clear):
+
     build: echo build app
   › lint: echo lint app
     long-cmd: echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…
@@ -21,6 +23,7 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 @ write-key: down
 @ expect-milestone: task-select::2
 Select a task (↑/↓, Enter to run, Esc to clear):
+
     build: echo build app
     lint: echo lint app
   › long-cmd: echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…
@@ -28,6 +31,7 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 @ write-key: down
 @ expect-milestone: task-select::3
 Select a task (↑/↓, Enter to run, Esc to clear):
+
     build: echo build app
     lint: echo lint app
     long-cmd: echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…
@@ -35,6 +39,7 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 @ write-key: up
 @ expect-milestone: task-select::2
 Select a task (↑/↓, Enter to run, Esc to clear):
+
     build: echo build app
     lint: echo lint app
   › long-cmd: echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive enter with no results does nothing.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive enter with no results does nothing.snap
@@ -7,6 +7,7 @@ info:
 > vp run
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
+
   › build: echo build app
     lint: echo lint app
     test: echo test app
@@ -23,11 +24,13 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 @ write: zzzzz
 @ expect-milestone: task-select:zzzzz:0
 Select a task (↑/↓, Enter to run, Esc to clear): zzzzz
+
   No matching tasks.
 @ write-key: enter
 @ write-key: escape
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
+
   › build: echo build app
     lint: echo lint app
     test: echo test app

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive escape clears query.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive escape clears query.snap
@@ -7,6 +7,7 @@ info:
 > vp run
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
+
   › build: echo build app
     lint: echo lint app
     test: echo test app
@@ -23,11 +24,13 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 @ write: lin
 @ expect-milestone: task-select:lin:0
 Select a task (↑/↓, Enter to run, Esc to clear): lin
+
   › lint: echo lint app
     lib#lint: echo lint lib
 @ write-key: escape
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
+
   › build: echo build app
     lint: echo lint app
     test: echo test app

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive scroll long list.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive scroll long list.snap
@@ -7,6 +7,7 @@ info:
 > vp run
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
+
   › build: echo build app
     lint: echo lint app
     test: echo test app
@@ -30,6 +31,7 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 @ write-key: down
 @ expect-milestone: task-select::8
 Select a task (↑/↓, Enter to run, Esc to clear):
+
     build: echo build app
     lint: echo lint app
     test: echo test app
@@ -53,6 +55,7 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 @ write-key: up
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
+
   › build: echo build app
     lint: echo lint app
     test: echo test app

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search other package task.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search other package task.snap
@@ -7,6 +7,7 @@ info:
 > vp run
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
+
   › build: echo build app
     lint: echo lint app
     test: echo test app
@@ -23,6 +24,7 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 @ write: typec
 @ expect-milestone: task-select:typec:0
 Select a task (↑/↓, Enter to run, Esc to clear): typec
+
   › lib#typecheck: echo typecheck lib
 @ write-key: enter
 Selected task: lib#typecheck

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search preserves rating within package.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search preserves rating within package.snap
@@ -7,6 +7,7 @@ info:
 > vp run
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
+
   › build: echo build lib
     lint: echo lint lib
     test: echo test lib
@@ -23,6 +24,7 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 @ write: t
 @ expect-milestone: task-select:t:0
 Select a task (↑/↓, Enter to run, Esc to clear): t
+
   › test: echo test lib
     typecheck: echo typecheck lib
     lint: echo lint lib

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search then select.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search then select.snap
@@ -7,6 +7,7 @@ info:
 > vp run
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
+
   › build: echo build app
     lint: echo lint app
     test: echo test app
@@ -23,6 +24,7 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 @ write: lin
 @ expect-milestone: task-select:lin:0
 Select a task (↑/↓, Enter to run, Esc to clear): lin
+
   › lint: echo lint app
     lib#lint: echo lint lib
 @ write-key: enter

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search with hash skips reorder.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search with hash skips reorder.snap
@@ -7,6 +7,7 @@ info:
 > vp run
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
+
   › build: echo build app
     lint: echo lint app
     test: echo test app
@@ -23,6 +24,7 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 @ write: lib#
 @ expect-milestone: task-select:lib#:0
 Select a task (↑/↓, Enter to run, Esc to clear): lib#
+
   › lib#build: echo build lib
     lib#lint: echo lint lib
     lib#test: echo test lib

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select task from lib.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select task from lib.snap
@@ -7,6 +7,7 @@ info:
 > vp run
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
+
   › build: echo build lib
     lint: echo lint lib
     test: echo test lib

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select task.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select task.snap
@@ -7,6 +7,7 @@ info:
 > vp run
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
+
   › build: echo build app
     lint: echo lint app
     test: echo test app
@@ -23,6 +24,7 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 @ write-key: down
 @ expect-milestone: task-select::1
 Select a task (↑/↓, Enter to run, Esc to clear):
+
     build: echo build app
   › lint: echo lint app
     test: echo test app

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select with typo.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select with typo.snap
@@ -8,6 +8,7 @@ info:
 @ expect-milestone: task-select:buid:0
 Task "buid" not found.
 Select a task (↑/↓, Enter to run, Esc to clear): buid
+
   › build: echo build app
     lib#build: echo build lib
 @ write-key: enter

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/verbose with typo enters selector.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/verbose with typo enters selector.snap
@@ -8,6 +8,7 @@ info:
 @ expect-milestone: task-select:buid:0
 Task "buid" not found.
 Select a task (↑/↓, Enter to run, Esc to clear): buid
+
   › build: echo build app
     lib#build: echo build lib
 @ write-key: enter


### PR DESCRIPTION
Adding a newline to align with the design of interactive `vp`.