### PR TITLE
Hide "Did you mean:" when there are no fuzzy match suggestions

### DIFF
--- a/crates/vite_select/src/lib.rs
+++ b/crates/vite_select/src/lib.rs
@@ -95,6 +95,16 @@ fn non_interactive(
     before_render(&mut filtered, query.unwrap_or_default());
     let len = filtered.len();
 
+    // When there are no matching items, just print the header (if any) and
+    // return early — avoids showing a redundant "No matching tasks." line
+    // after a "not found" header.
+    if filtered.is_empty() {
+        if let Some(h) = header {
+            writeln!(writer, "{h}")?;
+        }
+        return Ok(());
+    }
+
     render_items(
         writer,
         &RenderParams {

--- a/crates/vite_task/src/session/mod.rs
+++ b/crates/vite_task/src/session/mod.rs
@@ -378,12 +378,20 @@ impl<'a> Session<'a> {
             })
             .collect();
 
-        // Build header: interactive says "not found.", non-interactive "did you mean:" suffix
+        // Build header: interactive says "not found.", non-interactive adds
+        // "Did you mean:" suffix only when there are fuzzy matches to show.
         let header = not_found_name.map(|name| {
             if is_interactive {
                 vite_str::format!("Task \"{name}\" not found.")
             } else {
-                vite_str::format!("Task \"{name}\" not found. Did you mean:")
+                let labels: Vec<&str> =
+                    select_items.iter().map(|item| item.label.as_str()).collect();
+                let has_suggestions = !vite_select::fuzzy_match(name, &labels).is_empty();
+                if has_suggestions {
+                    vite_str::format!("Task \"{name}\" not found. Did you mean:")
+                } else {
+                    vite_str::format!("Task \"{name}\" not found.")
+                }
             }
         });
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots.toml
@@ -12,6 +12,13 @@ steps = [
   "echo '' | vp run buid",
 ]
 
+# Non-interactive: typo with no fuzzy matches hides "did you mean"
+[[e2e]]
+name = "non-interactive no suggestions"
+steps = [
+  "echo '' | vp run zzzzz",
+]
+
 # Non-interactive: typo with -r flag errors (not cwd_only)
 [[e2e]]
 name = "non-interactive recursive typo errors"

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/non-interactive no suggestions.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/non-interactive no suggestions.snap
@@ -1,0 +1,6 @@
+---
+source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
+expression: e2e_outputs
+---
+[1]> echo '' | vp run zzzzz
+Task "zzzzz" not found.


### PR DESCRIPTION
## Summary
Improved the user experience when a task name is not found by only showing the "Did you mean:" suffix when there are actual fuzzy match suggestions to display. Previously, the suffix would appear even when no matching tasks existed, creating a confusing empty suggestion list.

## Key Changes
- **vite_task/src/session/mod.rs**: Modified the non-interactive error header generation to check if fuzzy matches exist before appending "Did you mean:" suffix. When no suggestions are available, the header now simply states "Task not found." without the misleading suffix.
- **vite_select/src/lib.rs**: Added early return in non-interactive mode when the filtered items list is empty. This prevents rendering a redundant "No matching tasks." message after the "not found" header, keeping the output clean and focused.
- **tests/e2e_snapshots/**: Added a new test case "non-interactive no suggestions" to verify the behavior when a typo has no fuzzy matches, ensuring the output only shows the "not found" message without suggestions.

## Implementation Details
The fix involves two coordinated changes:
1. Before rendering the "Did you mean:" header, the code now performs a fuzzy match against available task labels to determine if suggestions actually exist
2. The select module's non-interactive path now exits early when no matches are found, preventing the display of unhelpful "No matching tasks." text

https://claude.ai/code/session_01QVjgsRa8uw66PsSyAJNBjp