### PR TITLE
chore: Adjust `vp run` output styling.

### DIFF
--- a/crates/vite_task/src/session/reporter/labeled.rs
+++ b/crates/vite_task/src/session/reporter/labeled.rs
@@ -46,7 +46,7 @@ struct SharedReporterState {
 ///
 /// ## Compact Summary (default)
 /// - Single task + not cache hit → no summary at all
-/// - Single task + cache hit → thin line + "[vp run] cache hit, {duration} saved."
+/// - Single task + cache hit → thin line + "vp run: cache hit, {duration} saved."
 /// - Multi-task → thin line + one-liner with stats
 ///
 /// ## Full Summary (`--verbose`)

--- a/crates/vite_task/src/session/reporter/mod.rs
+++ b/crates/vite_task/src/session/reporter/mod.rs
@@ -227,13 +227,25 @@ fn format_command_with_cache_status(
     format_cache_status_inline(cache_status).map_or_else(
         || vite_str::format!("{}\n", command_str.style(COMMAND_STYLE)),
         |inline_status| {
-            // Apply styling based on cache status type
-            let styled_status = match cache_status {
-                CacheStatus::Hit { .. } => inline_status.style(Style::new().green().dimmed()),
-                CacheStatus::Miss(_) => inline_status.style(CACHE_MISS_STYLE.dimmed()),
-                CacheStatus::Disabled(_) => inline_status.style(Style::new().bright_black()),
-            };
-            vite_str::format!("{} {}\n", command_str.style(COMMAND_STYLE), styled_status)
+            let styled_status = inline_status.split_once(' ').map_or_else(
+                || inline_status.style(Style::new().bright_black()).to_string(),
+                |(symbol, text)| {
+                    let (symbol_style, text_style) = match cache_status {
+                        CacheStatus::Hit { .. } => {
+                            (Style::new().green(), Style::new().bright_black())
+                        }
+                        CacheStatus::Miss(_) => (CACHE_MISS_STYLE, Style::new().bright_black()),
+                        CacheStatus::Disabled(_) => {
+                            (Style::new().black(), Style::new().bright_black())
+                        }
+                    };
+
+                    vite_str::format!("{} {}", symbol.style(symbol_style), text.style(text_style))
+                        .to_string()
+                },
+            );
+
+            vite_str::format!("{} {styled_status}\n", command_str.style(COMMAND_STYLE))
         },
     )
 }

--- a/crates/vite_task/src/session/reporter/summary.rs
+++ b/crates/vite_task/src/session/reporter/summary.rs
@@ -316,6 +316,20 @@ fn duration_to_ms(d: Duration) -> u64 {
     d.as_millis().min(u128::from(u64::MAX)) as u64
 }
 
+fn format_summary_duration(d: Duration) -> Str {
+    let formatted = vite_str::format!("{d:.2?}");
+
+    for (suffix, unit) in
+        [(".00ms", "ms"), (".00s", "s"), (".00us", "us"), (".00µs", "µs"), (".00ns", "ns")]
+    {
+        if let Some(prefix) = formatted.as_str().strip_suffix(suffix) {
+            return vite_str::format!("{prefix}{unit}");
+        }
+    }
+
+    formatted
+}
+
 impl LastRunSummary {
     // ── Persistence ──────────────────────────────────────────────────────
 
@@ -404,7 +418,8 @@ impl TaskResult {
         match self {
             Self::CacheHit { saved_duration_ms } => {
                 let d = Duration::from_millis(*saved_duration_ms);
-                vite_str::format!("→ Cache hit - output replayed - {d:.2?} saved")
+                let formatted_duration = format_summary_duration(d);
+                vite_str::format!("→ Cache hit - output replayed - {formatted_duration} saved")
             }
             Self::InProcess => Str::from("→ Cache disabled for built-in command"),
             Self::Spawned { cache_status, .. } => match cache_status {
@@ -559,10 +574,11 @@ pub fn format_full_summary(summary: &LastRunSummary) -> Vec<u8> {
     );
 
     if stats.total_saved > Duration::ZERO {
+        let formatted_total_saved = format_summary_duration(stats.total_saved);
         let _ = write!(
             buf,
-            ", {:.2?} saved in total",
-            stats.total_saved.style(Style::new().green().bold())
+            ", {} saved in total",
+            formatted_total_saved.style(Style::new().green().bold())
         );
     }
     let _ = writeln!(buf);
@@ -647,8 +663,8 @@ pub fn format_full_summary(summary: &LastRunSummary) -> Vec<u8> {
 ///
 /// Rules:
 /// - Single task + not cache hit → empty (no summary at all)
-/// - Single task + cache hit → thin line + "[vp run] cache hit, {duration} saved."
-/// - Multi-task → thin line + "[vp run] {hits}/{total} cache hit ({rate}%), {duration} saved."
+/// - Single task + cache hit → thin line + "vp run: cache hit, {duration} saved."
+/// - Multi-task → thin line + "vp run: {hits}/{total} cache hit ({rate}%), {duration} saved."
 ///   with optional failure count and `--verbose` hint.
 pub fn format_compact_summary(summary: &LastRunSummary) -> Vec<u8> {
     let stats = SummaryStats::compute(&summary.tasks);
@@ -667,11 +683,12 @@ pub fn format_compact_summary(summary: &LastRunSummary) -> Vec<u8> {
 
     if is_single_task {
         // Single task cache hit
+        let formatted_total_saved = format_summary_duration(stats.total_saved);
         let _ = writeln!(
             buf,
-            "{} cache hit, {:.2?} saved.",
-            "[vp run]".style(Style::new().bright_black()),
-            stats.total_saved.style(Style::new().green().bold()),
+            "{} cache hit, {} saved.",
+            "vp run:".style(Style::new().blue().bold()),
+            formatted_total_saved.style(Style::new().green().bold()),
         );
     } else {
         // Multi-task
@@ -692,14 +709,15 @@ pub fn format_compact_summary(summary: &LastRunSummary) -> Vec<u8> {
         let _ = write!(
             buf,
             "{} {hits}/{total} cache hit ({rate}%)",
-            "[vp run]".style(Style::new().bright_black()),
+            "vp run:".style(Style::new().blue().bold()),
         );
 
         if stats.total_saved > Duration::ZERO {
+            let formatted_total_saved = format_summary_duration(stats.total_saved);
             let _ = write!(
                 buf,
-                ", {:.2?} saved",
-                stats.total_saved.style(Style::new().green().bold()),
+                ", {} saved",
+                formatted_total_saved.style(Style::new().green().bold()),
             );
         }
 
@@ -708,11 +726,9 @@ pub fn format_compact_summary(summary: &LastRunSummary) -> Vec<u8> {
             let _ = write!(buf, ", {} failed", n.style(Style::new().red()));
         }
 
-        let _ = write!(
-            buf,
-            ". {}",
-            "(Run `vp run --last-details` for full details)".style(Style::new().bright_black()),
-        );
+        let _ = write!(buf, ". {}", "(Run ".style(Style::new().bright_black()));
+        let _ = write!(buf, "{}", "`vp run --last-details`".style(COMMAND_STYLE));
+        let _ = write!(buf, "{}", " for full details)".style(Style::new().bright_black()));
         let _ = writeln!(buf);
     }
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/associate-existing-cache/snapshots/associate existing cache.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/associate-existing-cache/snapshots/associate existing cache.snap
@@ -10,7 +10,7 @@ $ print hello ✓ cache hit, replaying
 hello
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.
 > json-edit package.json '_.scripts.script2 = "print world"' # change script2
 
 > vp run script2 # cache miss

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/builtin-different-cwd/snapshots/builtin different cwd.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/builtin-different-cwd/snapshots/builtin different cwd.snap
@@ -42,7 +42,7 @@ Found 2 warnings and 0 errors.
 Finished in <duration> on 2 files with 90 rules using <n> threads.
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.
 > echo 'console.log(1);' > folder2/a.js # modify folder2
 
 > cd folder1 && vp run lint # cache hit
@@ -71,4 +71,4 @@ Found 1 warning and 0 errors.
 Finished in <duration> on 2 files with 90 rules using <n> threads.
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache-disabled/snapshots/task with cache enabled.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache-disabled/snapshots/task with cache enabled.snap
@@ -10,4 +10,4 @@ $ print-file test.txt ✓ cache hit, replaying
 test content
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache-miss-command-change/snapshots/cache miss command change.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache-miss-command-change/snapshots/cache miss command change.snap
@@ -10,7 +10,7 @@ $ print bar
 bar
 
 ---
-[vp run] 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
 > json-edit package.json '_.scripts.task = "print baz && print bar"' # change first subtask
 
 > vp run task # first: cache miss, second: cache hit
@@ -21,7 +21,7 @@ $ print bar ✓ cache hit, replaying
 bar
 
 ---
-[vp run] 1/2 cache hit (50%), <duration> saved. (Run `vp run --last-details` for full details)
+vp run: 1/2 cache hit (50%), <duration> saved. (Run `vp run --last-details` for full details)
 > json-edit package.json '_.scripts.task = "print bar"' # remove first subtask
 
 > vp run task # cache hit
@@ -29,4 +29,4 @@ $ print bar ✓ cache hit, replaying
 bar
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache-subcommand/snapshots/cache clean.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache-subcommand/snapshots/cache clean.snap
@@ -10,7 +10,7 @@ $ print-file test.txt ✓ cache hit, replaying
 test content
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.
 > vp cache clean
 
 > vp run cached-task # cache miss after clean

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/colon-in-name/snapshots/read file with colon in name.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/colon-in-name/snapshots/read file with colon in name.snap
@@ -8,4 +8,4 @@ $ node read_node_fs.js
 $ node read_node_fs.js ✓ cache hit, replaying
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit-codes/snapshots/multiple task failures returns exit code 1.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit-codes/snapshots/multiple task failures returns exit code 1.snap
@@ -8,4 +8,4 @@ expression: e2e_outputs
 ~/packages/pkg-b$ node -e "process.exit(7)"
 
 ---
-[vp run] 0/2 cache hit (0%), 2 failed. (Run `vp run --last-details` for full details)
+vp run: 0/2 cache hit (0%), 2 failed. (Run `vp run --last-details` for full details)

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob-base-test/snapshots/root glob - subpackage path unmatched by relative glob.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob-base-test/snapshots/root glob - subpackage path unmatched by relative glob.snap
@@ -12,4 +12,4 @@ $ print-file src/root.ts ✓ cache hit, replaying
 export const root = 'initial';
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob-base-test/snapshots/root glob - unmatched directory.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob-base-test/snapshots/root glob - unmatched directory.snap
@@ -12,4 +12,4 @@ $ print-file src/root.ts ✓ cache hit, replaying
 export const root = 'initial';
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob-base-test/snapshots/subpackage glob - root path unmatched by relative glob.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob-base-test/snapshots/subpackage glob - root path unmatched by relative glob.snap
@@ -12,4 +12,4 @@ export const sub = 'initial';
 export const sub = 'initial';
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob-base-test/snapshots/subpackage glob - unmatched directory in subpackage.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob-base-test/snapshots/subpackage glob - unmatched directory in subpackage.snap
@@ -12,4 +12,4 @@ export const sub = 'initial';
 export const sub = 'initial';
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/individual-cache-for-adt-args/snapshots/individual cache for extra args.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/individual-cache-for-adt-args/snapshots/individual cache for extra args.snap
@@ -13,10 +13,10 @@ $ print a ✓ cache hit, replaying
 a
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.
 > vp run say b # cache hit
 $ print b ✓ cache hit, replaying
 b
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/individual-cache-for-envs/snapshots/individual cache for envs.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/individual-cache-for-envs/snapshots/individual cache for envs.snap
@@ -13,10 +13,10 @@ $ print-env FOO ✓ cache hit, replaying
 1
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.
 > FOO=2 vp run hello # cache hit
 $ print-env FOO ✓ cache hit, replaying
 2
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/auto only - hit on non-inferred file change.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/auto only - hit on non-inferred file change.snap
@@ -12,4 +12,4 @@ $ print-file src/main.ts ✓ cache hit, replaying
 export const main = 'initial';
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/auto with negative - hit on excluded inferred file.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/auto with negative - hit on excluded inferred file.snap
@@ -14,4 +14,4 @@ export const main = 'initial';
 // initial output
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/empty inputs - hit despite file changes.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/empty inputs - hit despite file changes.snap
@@ -12,4 +12,4 @@ $ print-file src/main.ts ✓ cache hit, replaying
 export const main = 'initial';
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/folder input - hit despite file changes and folder deletion.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/folder input - hit despite file changes and folder deletion.snap
@@ -12,7 +12,7 @@ $ print-file src/main.ts ✓ cache hit, replaying
 export const main = 'initial';
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.
 > rm -rf src
 
 > vp run folder-input
@@ -20,4 +20,4 @@ $ print-file src/main.ts ✓ cache hit, replaying
 export const main = 'initial';
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/folder slash input - hit on file outside directory.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/folder slash input - hit on file outside directory.snap
@@ -12,4 +12,4 @@ $ print-file src/main.ts ✓ cache hit, replaying
 export const main = 'initial';
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/positive auto negative - hit on excluded file.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/positive auto negative - hit on excluded file.snap
@@ -12,4 +12,4 @@ $ print-file src/main.ts ✓ cache hit, replaying
 export const main = 'initial';
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/positive globs - hit on read but unmatched file.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/positive globs - hit on read but unmatched file.snap
@@ -14,4 +14,4 @@ export const main = 'initial';
 export const utils = 'initial';
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/positive globs only - cache hit on second run.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/positive globs only - cache hit on second run.snap
@@ -10,4 +10,4 @@ $ print-file src/main.ts ✓ cache hit, replaying
 export const main = 'initial';
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/positive globs only - hit on unmatched file change.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/positive globs only - hit on unmatched file change.snap
@@ -12,4 +12,4 @@ $ print-file src/main.ts ✓ cache hit, replaying
 export const main = 'initial';
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/positive negative globs - hit on excluded file.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-cache-test/snapshots/positive negative globs - hit on excluded file.snap
@@ -12,4 +12,4 @@ $ print-file src/main.ts ✓ cache hit, replaying
 export const main = 'initial';
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-glob-meta-in-path/snapshots/cache hit then miss on file change.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-glob-meta-in-path/snapshots/cache hit then miss on file change.snap
@@ -10,7 +10,7 @@ export const lib = 'initial';
 export const lib = 'initial';
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.
 > replace-file-content packages/[lib]/src/main.ts initial modified
 
 > vp run [lib]#build

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-negative-glob-subpackage/snapshots/dotdot auto negative - hit on excluded sibling inferred file.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-negative-glob-subpackage/snapshots/dotdot auto negative - hit on excluded sibling inferred file.snap
@@ -14,4 +14,4 @@ export const shared = 'initial';
 // initial output
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-negative-glob-subpackage/snapshots/dotdot positive glob - hit on unmatched file change.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-negative-glob-subpackage/snapshots/dotdot positive glob - hit on unmatched file change.snap
@@ -12,4 +12,4 @@ export const shared = 'initial';
 export const shared = 'initial';
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-negative-glob-subpackage/snapshots/dotdot positive negative - hit on excluded sibling file.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-negative-glob-subpackage/snapshots/dotdot positive negative - hit on excluded sibling file.snap
@@ -14,4 +14,4 @@ export const shared = 'initial';
 // initial output
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-negative-glob-subpackage/snapshots/subpackage auto with negative - hit on excluded inferred file.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/inputs-negative-glob-subpackage/snapshots/subpackage auto with negative - hit on excluded inferred file.snap
@@ -14,4 +14,4 @@ export const main = 'initial';
 // initial output
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/lint-dot-git/snapshots/lint dot git.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/lint-dot-git/snapshots/lint dot git.snap
@@ -32,4 +32,4 @@ Found 1 warning and 0 errors.
 Finished in <duration> on 1 file with 90 rules using <n> threads.
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/replay-logs-chronological-order/snapshots/replay logs chronological order.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/replay-logs-chronological-order/snapshots/replay logs chronological order.snap
@@ -194,7 +194,7 @@ $ node build.js ✓ cache hit, replaying
 [build.js] main process end
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.
 > vp run build # cache hit
 $ node build.js ✓ cache hit, replaying
 [build.js] --------------------------------
@@ -292,4 +292,4 @@ $ node build.js ✓ cache hit, replaying
 [build.js] main process end
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/shared-caching-inputs/snapshots/shared caching inputs.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/shared-caching-inputs/snapshots/shared caching inputs.snap
@@ -10,7 +10,7 @@ $ print-file foo.txt ✓ cache hit, replaying
 initial content
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.
 > replace-file-content foo.txt initial modified # modify shared input
 
 > vp run script2 # cache miss, input changed
@@ -21,4 +21,4 @@ $ print-file foo.txt ✓ cache hit, replaying
 modified content
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/stdin-inheritance/snapshots/multiple tasks get null stdin.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/stdin-inheritance/snapshots/multiple tasks get null stdin.snap
@@ -8,4 +8,4 @@ expression: e2e_outputs
 $ read-stdin ⊘ cache disabled
 
 ---
-[vp run] 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/stdio-detection/snapshots/multiple tasks, cache disabled.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/stdio-detection/snapshots/multiple tasks, cache disabled.snap
@@ -14,4 +14,4 @@ stdout:not-tty
 stderr:not-tty
 
 ---
-[vp run] 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/stdio-detection/snapshots/multiple tasks, cache hit.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/stdio-detection/snapshots/multiple tasks, cache hit.snap
@@ -14,7 +14,7 @@ stdout:not-tty
 stderr:not-tty
 
 ---
-[vp run] 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
 > vp run -r check-tty-cached
 ~/packages/other$ check-tty ✓ cache hit, replaying
 stdin:not-tty
@@ -27,4 +27,4 @@ stdout:not-tty
 stderr:not-tty
 
 ---
-[vp run] 2/2 cache hit (100%), <duration> saved. (Run `vp run --last-details` for full details)
+vp run: 2/2 cache hit (100%), <duration> saved. (Run `vp run --last-details` for full details)

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/stdio-detection/snapshots/multiple tasks, cache miss.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/stdio-detection/snapshots/multiple tasks, cache miss.snap
@@ -14,4 +14,4 @@ stdout:not-tty
 stderr:not-tty
 
 ---
-[vp run] 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/stdio-detection/snapshots/single task, cache hit.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/stdio-detection/snapshots/single task, cache hit.snap
@@ -14,4 +14,4 @@ stdout:not-tty
 stderr:not-tty
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/stdio-graph-criteria/snapshots/multi-node ancestor forces piped for nested single-node graph.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/stdio-graph-criteria/snapshots/multi-node ancestor forces piped for nested single-node graph.snap
@@ -14,4 +14,4 @@ stdout:not-tty
 stderr:not-tty
 
 ---
-[vp run] 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/stdio-graph-criteria/snapshots/single-node chains inherit even with multi-node sibling graph.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/stdio-graph-criteria/snapshots/single-node chains inherit even with multi-node sibling graph.snap
@@ -24,4 +24,4 @@ stdout:not-tty
 stderr:not-tty
 
 ---
-[vp run] 0/4 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/4 cache hit (0%). (Run `vp run --last-details` for full details)

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary-output/snapshots/last details after multi task run shows saved summary.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary-output/snapshots/last details after multi task run shows saved summary.snap
@@ -10,7 +10,7 @@ built-a
 built-b
 
 ---
-[vp run] 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
 > vp run --last-details # display saved summary
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary-output/snapshots/multi task all cache miss shows compact summary.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary-output/snapshots/multi task all cache miss shows compact summary.snap
@@ -10,4 +10,4 @@ built-a
 built-b
 
 ---
-[vp run] 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary-output/snapshots/multi task verbose with cache hits shows full summary.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary-output/snapshots/multi task verbose with cache hits shows full summary.snap
@@ -10,7 +10,7 @@ built-a
 built-b
 
 ---
-[vp run] 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
 > vp run -r -v build # second run, verbose with cache hits
 ~/packages/a$ print built-a ✓ cache hit, replaying
 built-a

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary-output/snapshots/multi task with cache hits shows compact summary.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary-output/snapshots/multi task with cache hits shows compact summary.snap
@@ -10,7 +10,7 @@ built-a
 built-b
 
 ---
-[vp run] 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
 > vp run -r build # second run, all hit
 ~/packages/a$ print built-a ✓ cache hit, replaying
 built-a
@@ -19,4 +19,4 @@ built-a
 built-b
 
 ---
-[vp run] 2/2 cache hit (100%), <duration> saved. (Run `vp run --last-details` for full details)
+vp run: 2/2 cache hit (100%), <duration> saved. (Run `vp run --last-details` for full details)

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary-output/snapshots/single task cache hit shows compact summary.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary-output/snapshots/single task cache hit shows compact summary.snap
@@ -12,4 +12,4 @@ built-a
 built-a
 
 ---
-[vp run] cache hit, <duration> saved.
+vp run: cache hit, <duration> saved.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-no-trailing-newline/snapshots/no trailing newline.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-no-trailing-newline/snapshots/no trailing newline.snap
@@ -9,4 +9,4 @@ $ echo bar ⊘ cache disabled
 bar
 
 ---
-[vp run] 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological-execution-order/snapshots/recursive build runs dependencies before dependents.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological-execution-order/snapshots/recursive build runs dependencies before dependents.snap
@@ -13,4 +13,4 @@ Building lib
 Building app
 
 ---
-[vp run] 0/3 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/3 cache hit (0%). (Run `vp run --last-details` for full details)

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological-execution-order/snapshots/transitive build from app runs all dependencies.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological-execution-order/snapshots/transitive build from app runs all dependencies.snap
@@ -15,4 +15,4 @@ Building lib
 Building app
 
 ---
-[vp run] 0/3 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/3 cache hit (0%). (Run `vp run --last-details` for full details)

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological-execution-order/snapshots/transitive build from lib runs only its dependencies.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological-execution-order/snapshots/transitive build from lib runs only its dependencies.snap
@@ -12,4 +12,4 @@ Building core
 Building lib
 
 ---
-[vp run] 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite-task-smoke/snapshots/cache hit after file modification.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite-task-smoke/snapshots/cache hit after file modification.snap
@@ -10,7 +10,7 @@ $ print-file main.js
 console.log('foo');
 
 ---
-[vp run] 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
 > replace-file-content main.js foo bar # modify input file
 
 > vp run test-task # cache miss, main.js changed
@@ -21,4 +21,4 @@ $ print-file main.js ✗ cache miss: 'main.js' modified, executing
 console.log('bar');
 
 ---
-[vp run] 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/workspace-root-self-reference/snapshots/build from root prunes root from nested expansion.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/workspace-root-self-reference/snapshots/build from root prunes root from nested expansion.snap
@@ -10,4 +10,4 @@ building-a
 building-b
 
 ---
-[vp run] 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/workspace-root-self-reference/snapshots/recursive build skips root self-reference.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/workspace-root-self-reference/snapshots/recursive build skips root self-reference.snap
@@ -10,4 +10,4 @@ building-a
 building-b
 
 ---
-[vp run] 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)


### PR DESCRIPTION
This PR aligns the output of `vp run` with what's on the website, see https://github.com/voidzero-dev/vite-plus/pull/758