### PR TITLE
fix: align package headers with top-level items in task selector

### DIFF
--- a/crates/vite_select/src/interactive.rs
+++ b/crates/vite_select/src/interactive.rs
@@ -343,7 +343,7 @@ pub fn render_items(writer: &mut impl Write, params: &RenderParams<'_>) -> anyho
                 if is_interactive {
                     write!(
                         writer,
-                        "  {dim}{name}{reset}{line_ending}",
+                        "    {dim}{name}{reset}{line_ending}",
                         dim = SetAttribute(Attribute::Dim),
                         name = group_name,
                         reset = SetAttribute(Attribute::Reset),
@@ -797,7 +797,7 @@ mod tests {
         assert_eq!(item_lines[0], "  \u{203a} build:   echo build app");
         assert_eq!(item_lines[1], "    lint:    echo lint app");
         // Group header
-        assert_eq!(item_lines[2], "  lib (packages/lib)");
+        assert_eq!(item_lines[2], "    lib (packages/lib)");
         // Grouped items (indented by 2 more, less padding)
         assert_eq!(item_lines[3], "      build: echo build lib");
         assert_eq!(item_lines[4], "      lint:  echo lint lib");
@@ -816,7 +816,7 @@ mod tests {
         // All commands start at column 17 regardless of indent level
         assert_eq!(item_lines[0], "  \u{203a} build:       echo build");
         assert_eq!(item_lines[1], "    typecheck:   echo tc");
-        assert_eq!(item_lines[2], "  lib");
+        assert_eq!(item_lines[2], "    lib");
         assert_eq!(item_lines[3], "      build:     echo build lib");
     }
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-list/snapshots/vp run in script.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-list/snapshots/vp run in script.snap
@@ -9,11 +9,11 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 
   › hello:        echo hello from root
     list-tasks:   vp run
-  app (packages/app)
+    app (packages/app)
       build:      echo build app
       lint:       echo lint app
       test:       echo test app
-  lib (packages/lib)
+    lib (packages/lib)
       build:      echo build lib
 @ write-key: enter
 $ vp run ⊘ cache disabled

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive enter with no results does nothing.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive enter with no results does nothing.snap
@@ -11,12 +11,12 @@ Select a task (↑/↓, Enter to run, Esc to clear):
   › build:           echo build app
     lint:            echo lint app
     test:            echo test app
-  lib (packages/lib)
+    lib (packages/lib)
       build:         echo build lib
       lint:          echo lint lib
       test:          echo test lib
       typecheck:     echo typecheck lib
-  task-select-test (workspace root)
+    task-select-test (workspace root)
       check:         echo check root
       clean:         echo clean root
       deploy:        echo deploy root
@@ -34,12 +34,12 @@ Select a task (↑/↓, Enter to run, Esc to clear):
   › build:           echo build app
     lint:            echo lint app
     test:            echo test app
-  lib (packages/lib)
+    lib (packages/lib)
       build:         echo build lib
       lint:          echo lint lib
       test:          echo test lib
       typecheck:     echo typecheck lib
-  task-select-test (workspace root)
+    task-select-test (workspace root)
       check:         echo check root
       clean:         echo clean root
       deploy:        echo deploy root

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive escape clears query.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive escape clears query.snap
@@ -11,12 +11,12 @@ Select a task (↑/↓, Enter to run, Esc to clear):
   › build:           echo build app
     lint:            echo lint app
     test:            echo test app
-  lib (packages/lib)
+    lib (packages/lib)
       build:         echo build lib
       lint:          echo lint lib
       test:          echo test lib
       typecheck:     echo typecheck lib
-  task-select-test (workspace root)
+    task-select-test (workspace root)
       check:         echo check root
       clean:         echo clean root
       deploy:        echo deploy root
@@ -26,7 +26,7 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 Select a task (↑/↓, Enter to run, Esc to clear): lin
 
   › lint:   echo lint app
-  lib (packages/lib)
+    lib (packages/lib)
       lint: echo lint lib
 @ write-key: escape
 @ expect-milestone: task-select::0
@@ -35,12 +35,12 @@ Select a task (↑/↓, Enter to run, Esc to clear):
   › build:           echo build app
     lint:            echo lint app
     test:            echo test app
-  lib (packages/lib)
+    lib (packages/lib)
       build:         echo build lib
       lint:          echo lint lib
       test:          echo test lib
       typecheck:     echo typecheck lib
-  task-select-test (workspace root)
+    task-select-test (workspace root)
       check:         echo check root
       clean:         echo clean root
       deploy:        echo deploy root

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive scroll long list.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive scroll long list.snap
@@ -11,12 +11,12 @@ Select a task (↑/↓, Enter to run, Esc to clear):
   › build:           echo build app
     lint:            echo lint app
     test:            echo test app
-  lib (packages/lib)
+    lib (packages/lib)
       build:         echo build lib
       lint:          echo lint lib
       test:          echo test lib
       typecheck:     echo typecheck lib
-  task-select-test (workspace root)
+    task-select-test (workspace root)
       check:         echo check root
       clean:         echo clean root
       deploy:        echo deploy root
@@ -35,12 +35,12 @@ Select a task (↑/↓, Enter to run, Esc to clear):
     build:           echo build app
     lint:            echo lint app
     test:            echo test app
-  lib (packages/lib)
+    lib (packages/lib)
       build:         echo build lib
       lint:          echo lint lib
       test:          echo test lib
       typecheck:     echo typecheck lib
-  task-select-test (workspace root)
+    task-select-test (workspace root)
       check:         echo check root
   ›   clean:         echo clean root
       deploy:        echo deploy root
@@ -59,12 +59,12 @@ Select a task (↑/↓, Enter to run, Esc to clear):
   › build:           echo build app
     lint:            echo lint app
     test:            echo test app
-  lib (packages/lib)
+    lib (packages/lib)
       build:         echo build lib
       lint:          echo lint lib
       test:          echo test lib
       typecheck:     echo typecheck lib
-  task-select-test (workspace root)
+    task-select-test (workspace root)
       check:         echo check root
       clean:         echo clean root
       deploy:        echo deploy root

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search other package task.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search other package task.snap
@@ -11,12 +11,12 @@ Select a task (↑/↓, Enter to run, Esc to clear):
   › build:           echo build app
     lint:            echo lint app
     test:            echo test app
-  lib (packages/lib)
+    lib (packages/lib)
       build:         echo build lib
       lint:          echo lint lib
       test:          echo test lib
       typecheck:     echo typecheck lib
-  task-select-test (workspace root)
+    task-select-test (workspace root)
       check:         echo check root
       clean:         echo clean root
       deploy:        echo deploy root
@@ -25,7 +25,7 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 @ expect-milestone: task-select:typec:0
 Select a task (↑/↓, Enter to run, Esc to clear): typec
 
-  lib (packages/lib)
+    lib (packages/lib)
   ›   typecheck: echo typecheck lib
 @ write-key: enter
 Selected task: lib#typecheck

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search preserves rating within package.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search preserves rating within package.snap
@@ -12,11 +12,11 @@ Select a task (↑/↓, Enter to run, Esc to clear):
     lint:            echo lint lib
     test:            echo test lib
     typecheck:       echo typecheck lib
-  app (packages/app)
+    app (packages/app)
       build:         echo build app
       lint:          echo lint app
       test:          echo test app
-  task-select-test (workspace root)
+    task-select-test (workspace root)
       check:         echo check root
       clean:         echo clean root
       deploy:        echo deploy root
@@ -28,7 +28,7 @@ Select a task (↑/↓, Enter to run, Esc to clear): t
   › test:            echo test lib
     typecheck:       echo typecheck lib
     lint:            echo lint lib
-  task-select-test (workspace root)
+    task-select-test (workspace root)
       check:         echo check root
       clean:         echo clean root
       deploy:        echo deploy root

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search then select.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search then select.snap
@@ -11,12 +11,12 @@ Select a task (↑/↓, Enter to run, Esc to clear):
   › build:           echo build app
     lint:            echo lint app
     test:            echo test app
-  lib (packages/lib)
+    lib (packages/lib)
       build:         echo build lib
       lint:          echo lint lib
       test:          echo test lib
       typecheck:     echo typecheck lib
-  task-select-test (workspace root)
+    task-select-test (workspace root)
       check:         echo check root
       clean:         echo clean root
       deploy:        echo deploy root
@@ -26,7 +26,7 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 Select a task (↑/↓, Enter to run, Esc to clear): lin
 
   › lint:   echo lint app
-  lib (packages/lib)
+    lib (packages/lib)
       lint: echo lint lib
 @ write-key: enter
 Selected task: lint

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search with hash skips reorder.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search with hash skips reorder.snap
@@ -11,12 +11,12 @@ Select a task (↑/↓, Enter to run, Esc to clear):
   › build:           echo build app
     lint:            echo lint app
     test:            echo test app
-  lib (packages/lib)
+    lib (packages/lib)
       build:         echo build lib
       lint:          echo lint lib
       test:          echo test lib
       typecheck:     echo typecheck lib
-  task-select-test (workspace root)
+    task-select-test (workspace root)
       check:         echo check root
       clean:         echo clean root
       deploy:        echo deploy root
@@ -25,7 +25,7 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 @ expect-milestone: task-select:lib#:0
 Select a task (↑/↓, Enter to run, Esc to clear): lib#
 
-  lib (packages/lib)
+    lib (packages/lib)
   ›   build:     echo build lib
       lint:      echo lint lib
       test:      echo test lib

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select from other package.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select from other package.snap
@@ -11,12 +11,12 @@ Select a task (↑/↓, Enter to run, Esc to clear):
   › build:           echo build app
     lint:            echo lint app
     test:            echo test app
-  lib (packages/lib)
+    lib (packages/lib)
       build:         echo build lib
       lint:          echo lint lib
       test:          echo test lib
       typecheck:     echo typecheck lib
-  task-select-test (workspace root)
+    task-select-test (workspace root)
       check:         echo check root
       clean:         echo clean root
       deploy:        echo deploy root
@@ -30,12 +30,12 @@ Select a task (↑/↓, Enter to run, Esc to clear):
     build:           echo build app
     lint:            echo lint app
     test:            echo test app
-  lib (packages/lib)
+    lib (packages/lib)
   ›   build:         echo build lib
       lint:          echo lint lib
       test:          echo test lib
       typecheck:     echo typecheck lib
-  task-select-test (workspace root)
+    task-select-test (workspace root)
       check:         echo check root
       clean:         echo clean root
       deploy:        echo deploy root

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select task from lib.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select task from lib.snap
@@ -12,11 +12,11 @@ Select a task (↑/↓, Enter to run, Esc to clear):
     lint:            echo lint lib
     test:            echo test lib
     typecheck:       echo typecheck lib
-  app (packages/app)
+    app (packages/app)
       build:         echo build app
       lint:          echo lint app
       test:          echo test app
-  task-select-test (workspace root)
+    task-select-test (workspace root)
       check:         echo check root
       clean:         echo clean root
       deploy:        echo deploy root

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select task.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select task.snap
@@ -11,12 +11,12 @@ Select a task (↑/↓, Enter to run, Esc to clear):
   › build:           echo build app
     lint:            echo lint app
     test:            echo test app
-  lib (packages/lib)
+    lib (packages/lib)
       build:         echo build lib
       lint:          echo lint lib
       test:          echo test lib
       typecheck:     echo typecheck lib
-  task-select-test (workspace root)
+    task-select-test (workspace root)
       check:         echo check root
       clean:         echo clean root
       deploy:        echo deploy root
@@ -28,12 +28,12 @@ Select a task (↑/↓, Enter to run, Esc to clear):
     build:           echo build app
   › lint:            echo lint app
     test:            echo test app
-  lib (packages/lib)
+    lib (packages/lib)
       build:         echo build lib
       lint:          echo lint lib
       test:          echo test lib
       typecheck:     echo typecheck lib
-  task-select-test (workspace root)
+    task-select-test (workspace root)
       check:         echo check root
       clean:         echo clean root
       deploy:        echo deploy root

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select with typo.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select with typo.snap
@@ -10,7 +10,7 @@ Task "buid" not found.
 Select a task (↑/↓, Enter to run, Esc to clear): buid
 
   › build:   echo build app
-  lib (packages/lib)
+    lib (packages/lib)
       build: echo build lib
 @ write-key: enter
 Selected task: build

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/verbose with typo enters selector.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/verbose with typo enters selector.snap
@@ -10,7 +10,7 @@ Task "buid" not found.
 Select a task (↑/↓, Enter to run, Esc to clear): buid
 
   › build:   echo build app
-  lib (packages/lib)
+    lib (packages/lib)
       build: echo build lib
 @ write-key: enter
 Selected task: build


### PR DESCRIPTION
## Summary

Adds consistent indentation to package group headers in the interactive task selector so they align with top-level task items.

### Before

```
  › build:           echo build app
    lint:            echo lint app
  lib (packages/lib)
      build:         echo build lib
```

The header `lib (packages/lib)` was indented only 2 spaces, misaligned with the 4-space task items above it.

### After

```
  › build:           echo build app
    lint:            echo lint app
    lib (packages/lib)
      build:         echo build lib
```

Headers now use 4 spaces, matching the top-level item prefix width.

## Test plan

- [x] Unit tests updated and passing (`cargo test -p vite_select`)
- [x] E2E snapshots updated and passing (`cargo test -p vite_task_bin --test e2e_snapshots -- task-select`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)