### PR TITLE
Remove colon separator from interactive task display

### DIFF
--- a/crates/vite_select/src/interactive.rs
+++ b/crates/vite_select/src/interactive.rs
@@ -329,8 +329,8 @@ pub fn render_items(writer: &mut impl Write, params: &RenderParams<'_>) -> anyho
     // Compute the absolute column where commands start (interactive only).
     // All items — root and grouped — align their descriptions to the same column.
     let max_prefix = if has_groups { GROUP_PREFIX_WIDTH } else { ROOT_PREFIX_WIDTH };
-    // command_col = max_prefix + max_name_width + ": "
-    let command_col = if is_interactive { max_prefix + max_name_width + 2 } else { 0 };
+    // command_col = max_prefix + max_name_width + " "
+    let command_col = if is_interactive { max_prefix + max_name_width + 1 } else { 0 };
 
     // Render visible display rows
     for ri in visible_row_range.clone() {
@@ -368,9 +368,9 @@ pub fn render_items(writer: &mut impl Write, params: &RenderParams<'_>) -> anyho
                     2
                 };
 
-                // Padding after colon to align all commands at `command_col`.
+                // Padding after name to align all commands at `command_col`.
                 let name_padding =
-                    if is_interactive { command_col - prefix_width - name_width - 2 } else { 0 };
+                    if is_interactive { command_col - prefix_width - name_width - 1 } else { 0 };
                 let max_desc_chars = params.max_line_width.saturating_sub(if is_interactive {
                     command_col
                 } else {
@@ -395,7 +395,7 @@ pub fn render_items(writer: &mut impl Write, params: &RenderParams<'_>) -> anyho
                         let bold = SetAttribute(Attribute::Bold);
                         write!(
                             writer,
-                            "{dark_grey}{prefix}{reset}{blue}{bold}{name}:{reset}{dark_grey}{:>pad$} {desc}{reset}{line_ending}",
+                            "{dark_grey}{prefix}{reset}{blue}{bold}{name}{reset}{dark_grey}{:>pad$} {desc}{reset}{line_ending}",
                             "",
                             pad = name_padding,
                             desc = display_desc,
@@ -403,7 +403,7 @@ pub fn render_items(writer: &mut impl Write, params: &RenderParams<'_>) -> anyho
                     } else {
                         write!(
                             writer,
-                            "{prefix}{name}:{dark_grey}{:>pad$} {desc}{reset}{line_ending}",
+                            "{prefix}{name}{dark_grey}{:>pad$} {desc}{reset}{line_ending}",
                             "",
                             pad = name_padding,
                             desc = display_desc,
@@ -742,8 +742,8 @@ mod tests {
         let unselected = lines.next().unwrap();
         assert_eq!(prompt, "Select a task (\u{2191}/\u{2193}, Enter to run, Esc to clear):");
         assert!(spacer.is_empty());
-        assert_eq!(selected, "  \u{203a} build: echo build");
-        assert_eq!(unselected, "    lint:  echo lint");
+        assert_eq!(selected, "  \u{203a} build echo build");
+        assert_eq!(unselected, "    lint  echo lint");
     }
 
     #[test]
@@ -753,10 +753,10 @@ mod tests {
         let output = render_interactive_to_string(&items, "", 80);
         let item_lines: Vec<&str> = output.lines().skip(2).collect();
         // max_name_width = 5 ("build")
-        // prefix(4) + max_name(5) + ":" + padding + " " + desc
-        assert_eq!(item_lines[0], "  \u{203a} build: echo build");
-        assert_eq!(item_lines[1], "    lint:  echo lint");
-        assert_eq!(item_lines[2], "    test:  vitest run");
+        // prefix(4) + max_name(5) + padding + " " + desc
+        assert_eq!(item_lines[0], "  \u{203a} build echo build");
+        assert_eq!(item_lines[1], "    lint  echo lint");
+        assert_eq!(item_lines[2], "    test  vitest run");
     }
 
     #[test]
@@ -765,7 +765,7 @@ mod tests {
             ("build", "a really long command that exceeds the width limit"),
             ("lint", "short"),
         ]);
-        // max_name_width = 5, prefix(4) + max_name(5) + sep(2) = 11
+        // max_name_width = 5, prefix(4) + max_name(5) + sep(1) = 10
         // max_line_width = 30 => max_desc = 30 - 11 = 19 chars
         let output = render_interactive_to_string(&items, "", 30);
         for line in output.lines().skip(2) {
@@ -792,15 +792,15 @@ mod tests {
         ]);
         let output = render_interactive_to_string(&items, "", 80);
         let item_lines: Vec<&str> = output.lines().skip(2).collect();
-        // max_name=5, has_groups → max_prefix=6, command_col=13
+        // max_name=5, has_groups → max_prefix=6, command_col=12
         // Root items get extra padding to align with grouped items
-        assert_eq!(item_lines[0], "  \u{203a} build:   echo build app");
-        assert_eq!(item_lines[1], "    lint:    echo lint app");
+        assert_eq!(item_lines[0], "  \u{203a} build   echo build app");
+        assert_eq!(item_lines[1], "    lint    echo lint app");
         // Group header
         assert_eq!(item_lines[2], "    lib (packages/lib)");
         // Grouped items (indented by 2 more, less padding)
-        assert_eq!(item_lines[3], "      build: echo build lib");
-        assert_eq!(item_lines[4], "      lint:  echo lint lib");
+        assert_eq!(item_lines[3], "      build echo build lib");
+        assert_eq!(item_lines[4], "      lint  echo lint lib");
     }
 
     #[test]
@@ -812,12 +812,12 @@ mod tests {
         ]);
         let output = render_interactive_to_string(&items, "", 80);
         let item_lines: Vec<&str> = output.lines().skip(2).collect();
-        // max_name=9, has_groups → max_prefix=6, command_col=17
-        // All commands start at column 17 regardless of indent level
-        assert_eq!(item_lines[0], "  \u{203a} build:       echo build");
-        assert_eq!(item_lines[1], "    typecheck:   echo tc");
+        // max_name=9, has_groups → max_prefix=6, command_col=16
+        // All commands start at column 16 regardless of indent level
+        assert_eq!(item_lines[0], "  \u{203a} build       echo build");
+        assert_eq!(item_lines[1], "    typecheck   echo tc");
         assert_eq!(item_lines[2], "    lib");
-        assert_eq!(item_lines[3], "      build:     echo build lib");
+        assert_eq!(item_lines[3], "      build     echo build lib");
     }
 
     #[test]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-list/snapshots/vp run in script.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-list/snapshots/vp run in script.snap
@@ -7,14 +7,14 @@ expression: e2e_outputs
 $ vp run ⊘ cache disabled
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-  › hello:        echo hello from root
-    list-tasks:   vp run
+  › hello        echo hello from root
+    list-tasks   vp run
     app (packages/app)
-      build:      echo build app
-      lint:       echo lint app
-      test:       echo test app
+      build      echo build app
+      lint       echo lint app
+      test       echo test app
     lib (packages/lib)
-      build:      echo build lib
+      build      echo build lib
 @ write-key: enter
 $ vp run ⊘ cache disabled
 Selected task: hello

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select-truncate/snapshots/interactive long command truncated.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select-truncate/snapshots/interactive long command truncated.snap
@@ -8,42 +8,42 @@ info:
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-  › build:    echo build app
-    lint:     echo lint app
-    long-cmd: echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…
-    test:     echo test app
+  › build    echo build app
+    lint     echo lint app
+    long-cmd echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…
+    test     echo test app
 @ write-key: down
 @ expect-milestone: task-select::1
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-    build:    echo build app
-  › lint:     echo lint app
-    long-cmd: echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…
-    test:     echo test app
+    build    echo build app
+  › lint     echo lint app
+    long-cmd echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…
+    test     echo test app
 @ write-key: down
 @ expect-milestone: task-select::2
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-    build:    echo build app
-    lint:     echo lint app
-  › long-cmd: echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…
-    test:     echo test app
+    build    echo build app
+    lint     echo lint app
+  › long-cmd echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…
+    test     echo test app
 @ write-key: down
 @ expect-milestone: task-select::3
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-    build:    echo build app
-    lint:     echo lint app
-    long-cmd: echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…
-  › test:     echo test app
+    build    echo build app
+    lint     echo lint app
+    long-cmd echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…
+  › test     echo test app
 @ write-key: up
 @ expect-milestone: task-select::2
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-    build:    echo build app
-    lint:     echo lint app
-  › long-cmd: echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…
-    test:     echo test app
+    build    echo build app
+    lint     echo lint app
+  › long-cmd echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…
+    test     echo test app
 @ write-key: enter
 Selected task: long-cmd
 ~/packages/app$ echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ⊘ cache disabled

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive enter with no results does nothing.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive enter with no results does nothing.snap
@@ -8,18 +8,18 @@ info:
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-  › build:           echo build app
-    lint:            echo lint app
-    test:            echo test app
+  › build           echo build app
+    lint            echo lint app
+    test            echo test app
     lib (packages/lib)
-      build:         echo build lib
-      lint:          echo lint lib
-      test:          echo test lib
-      typecheck:     echo typecheck lib
+      build         echo build lib
+      lint          echo lint lib
+      test          echo test lib
+      typecheck     echo typecheck lib
     task-select-test (workspace root)
-      check:         echo check root
-      clean:         echo clean root
-      deploy:        echo deploy root
+      check         echo check root
+      clean         echo clean root
+      deploy        echo deploy root
   (…5 more)
 @ write: zzzzz
 @ expect-milestone: task-select:zzzzz:0
@@ -31,18 +31,18 @@ Select a task (↑/↓, Enter to run, Esc to clear): zzzzz
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-  › build:           echo build app
-    lint:            echo lint app
-    test:            echo test app
+  › build           echo build app
+    lint            echo lint app
+    test            echo test app
     lib (packages/lib)
-      build:         echo build lib
-      lint:          echo lint lib
-      test:          echo test lib
-      typecheck:     echo typecheck lib
+      build         echo build lib
+      lint          echo lint lib
+      test          echo test lib
+      typecheck     echo typecheck lib
     task-select-test (workspace root)
-      check:         echo check root
-      clean:         echo clean root
-      deploy:        echo deploy root
+      check         echo check root
+      clean         echo clean root
+      deploy        echo deploy root
   (…5 more)
 @ write-key: enter
 Selected task: build

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive escape clears query.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive escape clears query.snap
@@ -8,42 +8,42 @@ info:
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-  › build:           echo build app
-    lint:            echo lint app
-    test:            echo test app
+  › build           echo build app
+    lint            echo lint app
+    test            echo test app
     lib (packages/lib)
-      build:         echo build lib
-      lint:          echo lint lib
-      test:          echo test lib
-      typecheck:     echo typecheck lib
+      build         echo build lib
+      lint          echo lint lib
+      test          echo test lib
+      typecheck     echo typecheck lib
     task-select-test (workspace root)
-      check:         echo check root
-      clean:         echo clean root
-      deploy:        echo deploy root
+      check         echo check root
+      clean         echo clean root
+      deploy        echo deploy root
   (…5 more)
 @ write: lin
 @ expect-milestone: task-select:lin:0
 Select a task (↑/↓, Enter to run, Esc to clear): lin
 
-  › lint:   echo lint app
+  › lint   echo lint app
     lib (packages/lib)
-      lint: echo lint lib
+      lint echo lint lib
 @ write-key: escape
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-  › build:           echo build app
-    lint:            echo lint app
-    test:            echo test app
+  › build           echo build app
+    lint            echo lint app
+    test            echo test app
     lib (packages/lib)
-      build:         echo build lib
-      lint:          echo lint lib
-      test:          echo test lib
-      typecheck:     echo typecheck lib
+      build         echo build lib
+      lint          echo lint lib
+      test          echo test lib
+      typecheck     echo typecheck lib
     task-select-test (workspace root)
-      check:         echo check root
-      clean:         echo clean root
-      deploy:        echo deploy root
+      check         echo check root
+      clean         echo clean root
+      deploy        echo deploy root
   (…5 more)
 @ write-key: enter
 Selected task: build

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive scroll long list.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive scroll long list.snap
@@ -8,18 +8,18 @@ info:
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-  › build:           echo build app
-    lint:            echo lint app
-    test:            echo test app
+  › build           echo build app
+    lint            echo lint app
+    test            echo test app
     lib (packages/lib)
-      build:         echo build lib
-      lint:          echo lint lib
-      test:          echo test lib
-      typecheck:     echo typecheck lib
+      build         echo build lib
+      lint          echo lint lib
+      test          echo test lib
+      typecheck     echo typecheck lib
     task-select-test (workspace root)
-      check:         echo check root
-      clean:         echo clean root
-      deploy:        echo deploy root
+      check         echo check root
+      clean         echo clean root
+      deploy        echo deploy root
   (…5 more)
 @ write-key: down
 @ write-key: down
@@ -32,18 +32,18 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 @ expect-milestone: task-select::8
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-    build:           echo build app
-    lint:            echo lint app
-    test:            echo test app
+    build           echo build app
+    lint            echo lint app
+    test            echo test app
     lib (packages/lib)
-      build:         echo build lib
-      lint:          echo lint lib
-      test:          echo test lib
-      typecheck:     echo typecheck lib
+      build         echo build lib
+      lint          echo lint lib
+      test          echo test lib
+      typecheck     echo typecheck lib
     task-select-test (workspace root)
-      check:         echo check root
-  ›   clean:         echo clean root
-      deploy:        echo deploy root
+      check         echo check root
+  ›   clean         echo clean root
+      deploy        echo deploy root
   (…5 more)
 @ write-key: up
 @ write-key: up
@@ -56,18 +56,18 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-  › build:           echo build app
-    lint:            echo lint app
-    test:            echo test app
+  › build           echo build app
+    lint            echo lint app
+    test            echo test app
     lib (packages/lib)
-      build:         echo build lib
-      lint:          echo lint lib
-      test:          echo test lib
-      typecheck:     echo typecheck lib
+      build         echo build lib
+      lint          echo lint lib
+      test          echo test lib
+      typecheck     echo typecheck lib
     task-select-test (workspace root)
-      check:         echo check root
-      clean:         echo clean root
-      deploy:        echo deploy root
+      check         echo check root
+      clean         echo clean root
+      deploy        echo deploy root
   (…5 more)
 @ write-key: enter
 Selected task: build

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search other package task.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search other package task.snap
@@ -8,25 +8,25 @@ info:
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-  › build:           echo build app
-    lint:            echo lint app
-    test:            echo test app
+  › build           echo build app
+    lint            echo lint app
+    test            echo test app
     lib (packages/lib)
-      build:         echo build lib
-      lint:          echo lint lib
-      test:          echo test lib
-      typecheck:     echo typecheck lib
+      build         echo build lib
+      lint          echo lint lib
+      test          echo test lib
+      typecheck     echo typecheck lib
     task-select-test (workspace root)
-      check:         echo check root
-      clean:         echo clean root
-      deploy:        echo deploy root
+      check         echo check root
+      clean         echo clean root
+      deploy        echo deploy root
   (…5 more)
 @ write: typec
 @ expect-milestone: task-select:typec:0
 Select a task (↑/↓, Enter to run, Esc to clear): typec
 
     lib (packages/lib)
-  ›   typecheck: echo typecheck lib
+  ›   typecheck echo typecheck lib
 @ write-key: enter
 Selected task: lib#typecheck
 ~/packages/lib$ echo typecheck lib ⊘ cache disabled

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search preserves rating within package.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search preserves rating within package.snap
@@ -8,35 +8,35 @@ info:
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-  › build:           echo build lib
-    lint:            echo lint lib
-    test:            echo test lib
-    typecheck:       echo typecheck lib
+  › build           echo build lib
+    lint            echo lint lib
+    test            echo test lib
+    typecheck       echo typecheck lib
     app (packages/app)
-      build:         echo build app
-      lint:          echo lint app
-      test:          echo test app
+      build         echo build app
+      lint          echo lint app
+      test          echo test app
     task-select-test (workspace root)
-      check:         echo check root
-      clean:         echo clean root
-      deploy:        echo deploy root
+      check         echo check root
+      clean         echo clean root
+      deploy        echo deploy root
   (…5 more)
 @ write: t
 @ expect-milestone: task-select:t:0
 Select a task (↑/↓, Enter to run, Esc to clear): t
 
-  › test:            echo test lib
-    typecheck:       echo typecheck lib
-    lint:            echo lint lib
+  › test            echo test lib
+    typecheck       echo typecheck lib
+    lint            echo lint lib
     task-select-test (workspace root)
-      check:         echo check root
-      clean:         echo clean root
-      deploy:        echo deploy root
-      docs:          echo docs root
-      format:        echo format root
-      hello:         echo hello from root
-      run-typo-task: vp run nonexistent-xyz
-      validate:      echo validate root
+      check         echo check root
+      clean         echo clean root
+      deploy        echo deploy root
+      docs          echo docs root
+      format        echo format root
+      hello         echo hello from root
+      run-typo-task vp run nonexistent-xyz
+      validate      echo validate root
   (…2 more)
 @ write-key: enter
 Selected task: test

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search then select.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search then select.snap
@@ -8,26 +8,26 @@ info:
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-  › build:           echo build app
-    lint:            echo lint app
-    test:            echo test app
+  › build           echo build app
+    lint            echo lint app
+    test            echo test app
     lib (packages/lib)
-      build:         echo build lib
-      lint:          echo lint lib
-      test:          echo test lib
-      typecheck:     echo typecheck lib
+      build         echo build lib
+      lint          echo lint lib
+      test          echo test lib
+      typecheck     echo typecheck lib
     task-select-test (workspace root)
-      check:         echo check root
-      clean:         echo clean root
-      deploy:        echo deploy root
+      check         echo check root
+      clean         echo clean root
+      deploy        echo deploy root
   (…5 more)
 @ write: lin
 @ expect-milestone: task-select:lin:0
 Select a task (↑/↓, Enter to run, Esc to clear): lin
 
-  › lint:   echo lint app
+  › lint   echo lint app
     lib (packages/lib)
-      lint: echo lint lib
+      lint echo lint lib
 @ write-key: enter
 Selected task: lint
 ~/packages/app$ echo lint app ⊘ cache disabled

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search with hash skips reorder.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive search with hash skips reorder.snap
@@ -8,28 +8,28 @@ info:
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-  › build:           echo build app
-    lint:            echo lint app
-    test:            echo test app
+  › build           echo build app
+    lint            echo lint app
+    test            echo test app
     lib (packages/lib)
-      build:         echo build lib
-      lint:          echo lint lib
-      test:          echo test lib
-      typecheck:     echo typecheck lib
+      build         echo build lib
+      lint          echo lint lib
+      test          echo test lib
+      typecheck     echo typecheck lib
     task-select-test (workspace root)
-      check:         echo check root
-      clean:         echo clean root
-      deploy:        echo deploy root
+      check         echo check root
+      clean         echo clean root
+      deploy        echo deploy root
   (…5 more)
 @ write: lib#
 @ expect-milestone: task-select:lib#:0
 Select a task (↑/↓, Enter to run, Esc to clear): lib#
 
     lib (packages/lib)
-  ›   build:     echo build lib
-      lint:      echo lint lib
-      test:      echo test lib
-      typecheck: echo typecheck lib
+  ›   build     echo build lib
+      lint      echo lint lib
+      test      echo test lib
+      typecheck echo typecheck lib
 @ write-key: enter
 Selected task: lib#build
 ~/packages/lib$ echo build lib ⊘ cache disabled

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select from other package.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select from other package.snap
@@ -8,18 +8,18 @@ info:
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-  › build:           echo build app
-    lint:            echo lint app
-    test:            echo test app
+  › build           echo build app
+    lint            echo lint app
+    test            echo test app
     lib (packages/lib)
-      build:         echo build lib
-      lint:          echo lint lib
-      test:          echo test lib
-      typecheck:     echo typecheck lib
+      build         echo build lib
+      lint          echo lint lib
+      test          echo test lib
+      typecheck     echo typecheck lib
     task-select-test (workspace root)
-      check:         echo check root
-      clean:         echo clean root
-      deploy:        echo deploy root
+      check         echo check root
+      clean         echo clean root
+      deploy        echo deploy root
   (…5 more)
 @ write-key: down
 @ write-key: down
@@ -27,18 +27,18 @@ Select a task (↑/↓, Enter to run, Esc to clear):
 @ expect-milestone: task-select::3
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-    build:           echo build app
-    lint:            echo lint app
-    test:            echo test app
+    build           echo build app
+    lint            echo lint app
+    test            echo test app
     lib (packages/lib)
-  ›   build:         echo build lib
-      lint:          echo lint lib
-      test:          echo test lib
-      typecheck:     echo typecheck lib
+  ›   build         echo build lib
+      lint          echo lint lib
+      test          echo test lib
+      typecheck     echo typecheck lib
     task-select-test (workspace root)
-      check:         echo check root
-      clean:         echo clean root
-      deploy:        echo deploy root
+      check         echo check root
+      clean         echo clean root
+      deploy        echo deploy root
   (…5 more)
 @ write-key: enter
 Selected task: lib#build

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select task from lib.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select task from lib.snap
@@ -8,18 +8,18 @@ info:
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-  › build:           echo build lib
-    lint:            echo lint lib
-    test:            echo test lib
-    typecheck:       echo typecheck lib
+  › build           echo build lib
+    lint            echo lint lib
+    test            echo test lib
+    typecheck       echo typecheck lib
     app (packages/app)
-      build:         echo build app
-      lint:          echo lint app
-      test:          echo test app
+      build         echo build app
+      lint          echo lint app
+      test          echo test app
     task-select-test (workspace root)
-      check:         echo check root
-      clean:         echo clean root
-      deploy:        echo deploy root
+      check         echo check root
+      clean         echo clean root
+      deploy        echo deploy root
   (…5 more)
 @ write-key: enter
 Selected task: build

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select task.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select task.snap
@@ -8,35 +8,35 @@ info:
 @ expect-milestone: task-select::0
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-  › build:           echo build app
-    lint:            echo lint app
-    test:            echo test app
+  › build           echo build app
+    lint            echo lint app
+    test            echo test app
     lib (packages/lib)
-      build:         echo build lib
-      lint:          echo lint lib
-      test:          echo test lib
-      typecheck:     echo typecheck lib
+      build         echo build lib
+      lint          echo lint lib
+      test          echo test lib
+      typecheck     echo typecheck lib
     task-select-test (workspace root)
-      check:         echo check root
-      clean:         echo clean root
-      deploy:        echo deploy root
+      check         echo check root
+      clean         echo clean root
+      deploy        echo deploy root
   (…5 more)
 @ write-key: down
 @ expect-milestone: task-select::1
 Select a task (↑/↓, Enter to run, Esc to clear):
 
-    build:           echo build app
-  › lint:            echo lint app
-    test:            echo test app
+    build           echo build app
+  › lint            echo lint app
+    test            echo test app
     lib (packages/lib)
-      build:         echo build lib
-      lint:          echo lint lib
-      test:          echo test lib
-      typecheck:     echo typecheck lib
+      build         echo build lib
+      lint          echo lint lib
+      test          echo test lib
+      typecheck     echo typecheck lib
     task-select-test (workspace root)
-      check:         echo check root
-      clean:         echo clean root
-      deploy:        echo deploy root
+      check         echo check root
+      clean         echo clean root
+      deploy        echo deploy root
   (…5 more)
 @ write-key: enter
 Selected task: lint

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select with typo.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive select with typo.snap
@@ -9,9 +9,9 @@ info:
 Task "buid" not found.
 Select a task (↑/↓, Enter to run, Esc to clear): buid
 
-  › build:   echo build app
+  › build   echo build app
     lib (packages/lib)
-      build: echo build lib
+      build echo build lib
 @ write-key: enter
 Selected task: build
 ~/packages/app$ echo build app ⊘ cache disabled

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/verbose with typo enters selector.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/verbose with typo enters selector.snap
@@ -9,9 +9,9 @@ info:
 Task "buid" not found.
 Select a task (↑/↓, Enter to run, Esc to clear): buid
 
-  › build:   echo build app
+  › build   echo build app
     lib (packages/lib)
-      build: echo build lib
+      build echo build lib
 @ write-key: enter
 Selected task: build
 ~/packages/app$ echo build app ⊘ cache disabled


### PR DESCRIPTION
The interactive task selector now displays task names without trailing colons. Previously, tasks were shown as `build: <space for alignment> echo build app`, and now they appear as `build <space for alignment> echo build app`.