### PR TITLE
fix: skip self-referential package dependency edges in workspace graph

### DIFF
--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/package-self-dependency/package.json
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/package-self-dependency/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test-workspace",
+  "private": true
+}

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/package-self-dependency/packages/self-dep/package.json
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/package-self-dependency/packages/self-dep/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "self-dep",
+  "version": "1.0.0",
+  "dependencies": {
+    "self-dep": "workspace:*"
+  },
+  "scripts": {
+    "build": "echo building"
+  }
+}

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/package-self-dependency/pnpm-workspace.yaml
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/package-self-dependency/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/package-self-dependency/snapshots.toml
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/package-self-dependency/snapshots.toml
@@ -1,0 +1,13 @@
+# Tests that a package with a self-referential workspace dependency (e.g. for
+# testing purposes) does not produce a false cycle-dependency error.
+
+[[plan]]
+name = "build in self-referential package"
+args = ["run", "build"]
+cwd = "packages/self-dep"
+compact = true
+
+[[plan]]
+name = "recursive build across workspace"
+args = ["run", "-r", "build"]
+compact = true

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/package-self-dependency/snapshots/query - build in self-referential package.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/package-self-dependency/snapshots/query - build in self-referential package.snap
@@ -1,0 +1,13 @@
+---
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
+expression: "&compact_plan"
+info:
+  args:
+    - run
+    - build
+  cwd: packages/self-dep
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/package-self-dependency
+---
+{
+  "packages/self-dep#build": []
+}

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/package-self-dependency/snapshots/query - recursive build across workspace.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/package-self-dependency/snapshots/query - recursive build across workspace.snap
@@ -1,0 +1,13 @@
+---
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
+expression: "&compact_plan"
+info:
+  args:
+    - run
+    - "-r"
+    - build
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/package-self-dependency
+---
+{
+  "packages/self-dep#build": []
+}

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/package-self-dependency/snapshots/task graph.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/package-self-dependency/snapshots/task graph.snap
@@ -1,0 +1,41 @@
+---
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
+expression: task_graph_json
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/package-self-dependency
+---
+[
+  {
+    "key": [
+      "<workspace>/packages/self-dep",
+      "build"
+    ],
+    "node": {
+      "task_display": {
+        "package_name": "self-dep",
+        "task_name": "build",
+        "package_path": "<workspace>/packages/self-dep"
+      },
+      "resolved_config": {
+        "command": "echo building",
+        "resolved_options": {
+          "cwd": "<workspace>/packages/self-dep",
+          "cache_config": {
+            "env_config": {
+              "fingerprinted_envs": [],
+              "untracked_env": [
+                "<default untracked envs>"
+              ]
+            },
+            "input_config": {
+              "includes_auto": true,
+              "positive_globs": [],
+              "negative_globs": []
+            }
+          }
+        }
+      },
+      "source": "PackageJsonScript"
+    },
+    "neighbors": []
+  }
+]

--- a/crates/vite_workspace/src/lib.rs
+++ b/crates/vite_workspace/src/lib.rs
@@ -164,7 +164,11 @@ impl PackageGraphBuilder {
                             path2: dep_path2.clone(),
                         });
                     }
-                    self.graph.add_edge(*id, *dep_id, *dep_type);
+                    // Skip self-referential edges: a package listing itself as a dependency
+                    // (e.g. for testing purposes) must not create a cycle in the task graph.
+                    if *id != *dep_id {
+                        self.graph.add_edge(*id, *dep_id, *dep_type);
+                    }
                 }
                 // Silently skip if dependency not found - it might be an external package
             }


### PR DESCRIPTION
## What

When a package listed itself as a workspace dependency (e.g. `"rolldown": "workspace:*"` inside `rolldown`'s own `package.json`), running any task in that package would fail with:

```
Cycle dependency detected: rolldown#build-binding:release -> rolldown#build-binding:release
```

## Why

The workspace package graph is built by reading each `package.json` and adding a directed edge for every workspace dependency that resolves to another package in the monorepo. There was no guard against the case where a package names itself — the edge `A → A` was added unconditionally, producing a self-loop.

That self-loop is a cycle by definition, so the task planner's acyclicity check correctly rejected it — but the error was misleading because the "cycle" was entirely artificial and had nothing to do with the task definitions.

## Fix

Skip any edge where the source and destination package are the same. A package depending on itself carries no ordering information, so dropping it is safe and matches how tools like pnpm handle this in practice.

Includes a new plan snapshot test with a fixture that reproduces the scenario.