### PR TITLE
ux: hint Escape key when no tasks match in interactive selector

### DIFF
--- a/crates/vite_select/src/interactive.rs
+++ b/crates/vite_select/src/interactive.rs
@@ -434,7 +434,7 @@ pub fn render_items(writer: &mut impl Write, params: &RenderParams<'_>) -> anyho
 
     // Empty state
     if !has_items {
-        write!(writer, "  No matching tasks.{line_ending}")?;
+        write!(writer, "  No matching tasks. Press Escape to clear search.{line_ending}")?;
         lines += 1;
     }
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive enter with no results does nothing.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task-select/snapshots/interactive enter with no results does nothing.snap
@@ -25,7 +25,7 @@ Select a task (↑/↓, Enter to run, type to search):
 @ expect-milestone: task-select:zzzzz:0
 Select a task (↑/↓, Enter to run, type to search): zzzzz
 
-  No matching tasks.
+  No matching tasks. Press Escape to clear search.
 @ write-key: enter
 @ write-key: escape
 @ expect-milestone: task-select::0


### PR DESCRIPTION
## Summary

When a user runs a non-existent task (e.g. `vp run zzzzz`), the interactive selector pre-fills the search with the typo and shows an empty results list. Without additional context, users may think the command is hanging.

This adds an actionable hint to the empty state message:

```
Select a task (↑/↓, Enter to run, type to search): zzzzz

                                          ┌── added
                                          ▼
  No matching tasks. Press Escape to clear search.
```

This reminds users they are in a search state and gives them a clear next step to recover, rather than leaving them stuck on a seemingly unresponsive screen.

## Test plan

- [x] E2E snapshot test updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)