### PR TITLE
ci: use Dev Drive to speed up Windows builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,14 @@ jobs:
           persist-credentials: false
           submodules: true
 
-      # Disable Windows Defender real-time scanning to speed up I/O-heavy builds (~30-50% faster)
-      - name: Disable Windows Defender
+      - name: Setup Dev Drive
+        uses: samypr100/setup-dev-drive@30f0f98ae5636b2b6501e181dfb3631b9974818d # v4.0.0
         if: runner.os == 'Windows'
-        shell: powershell
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        with:
+          drive-size: 10GB
+          env-mapping: |
+            CARGO_HOME,{{ DEV_DRIVE }}/.cargo
+            RUSTUP_HOME,{{ DEV_DRIVE }}/.rustup
 
       - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.0
         with:


### PR DESCRIPTION
## Summary

- Replace the `Disable Windows Defender` workaround with `samypr100/setup-dev-drive@v4`, which creates a ReFS Dev Drive and places `CARGO_HOME` and `RUSTUP_HOME` on it
- ReFS Dev Drives are optimized for developer workloads and should provide ~25%+ improvement for I/O-heavy Rust compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)