### PR TITLE
fix: remove no longer relevant bootstrap-cli command from init task

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,7 +10,6 @@ alias r := ready
 
 init:
   cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear@1.11.1 taplo-cli -y
-  pnpm run bootstrap-cli
 
 ready:
   git diff --exit-code --quiet


### PR DESCRIPTION
## Description

Was trying to set up the repo by following the instructions in `CONTRIBUTING.md`, but encountered an error

```sh
➜  vite-task git:(main) just init
cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear@1.11.1 taplo-cli -y
 INFO resolve: Resolving package: 'typos-cli'
 # Omitted
  ...
    Finished [`release` profile [optimized]](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles) target(s) in 47.13s
  Installing /Users/yangshun/.cargo/bin/taplo
   Installed package `taplo-cli v0.10.0` (executable `taplo`)
 INFO Cargo finished successfully
 INFO Done in 53.617422084s
pnpm run bootstrap-cli
 ERR_PNPM_NO_SCRIPT  Missing script: bootstrap-cli
```

## Issue

`justfile` references  `pnpm run bootstrap-cli` under `init`, but there's no longer such a script in the `package.json`.

1. This line was originally added to the root `package.json` in https://github.com/voidzero-dev/vite-task/commit/f0829037cd26669c694275a1a12980feb402583f
2. The root `package.json` was removed in https://github.com/voidzero-dev/vite-task/commit/dda69c722a4751667e66f180d6f291f7f93f9577, but the setup instructions in `justinit` weren't updated.

The new `package.json` doesn't contain the script `bootstrap-cli`.

## Test plan

1. Removed that line from `justfile`
2. Ran `just init`
3. Command completed successfully