### PR TITLE
revert: undo per-crate --test-threads=1 split for musl CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,9 @@ jobs:
       # -crt-static: vite-task is shipped as a NAPI module in vite+, and musl Node
       # with native modules links to musl libc dynamically, so we must do the same.
       RUSTFLAGS: --cfg tokio_unstable -D warnings -C target-feature=-crt-static
+      # On musl, concurrent PTY operations can trigger SIGSEGV in musl internals.
+      # Run test threads sequentially to avoid the race.
+      RUST_TEST_THREADS: 1
     steps:
       - name: Install Alpine dependencies
         shell: sh {0}
@@ -172,14 +175,7 @@ jobs:
           corepack enable
           pnpm install
 
-      # Use cargo-nextest: it runs each test in its own process, avoiding
-      # musl's fork()-in-multithreaded-process SIGSEGV while keeping parallel
-      # execution (across processes instead of threads within one process).
-      # Exclude packages with custom test harnesses (harness = false) since
-      # nextest can't discover their tests; run those with cargo test instead.
-      - run: cargo install cargo-nextest --locked
-      - run: cargo nextest run --workspace --exclude vite_task_bin --exclude vite_task_plan
-      - run: cargo test -p vite_task_bin -p vite_task_plan
+      - run: cargo test
 
   fmt:
     name: Format and Check Deps


### PR DESCRIPTION
## Summary

Reverts fa42ef9adca03f9b793fd09e0286151cdf8b6f38 ("ci: replace global RUST_TEST_THREADS=1 with per-crate --test-threads=1 (#280)").

The change replaced the simple `RUST_TEST_THREADS=1` env var with `cargo-nextest` installation and split test commands. This actually **regressed** musl CI performance:

### CI Time Comparison (musl job)

| | Before (7a8ad8b) | After (fa42ef9) | Delta |
|---|---|---|---|
| **Test (musl)** | **4m 31s** | **12m 32s** | **+8m 01s (+177%)** |

The overhead comes from installing `cargo-nextest` and running two separate `cargo` invocations instead of one.

This revert restores the global `RUST_TEST_THREADS=1` approach, bringing the musl CI job back to ~4.5 minutes.

## Test plan

- [ ] Verify musl CI job passes
- [ ] Verify musl CI job completes in ~4-5 minutes instead of ~12 minutes

https://claude.ai/code/session_01LGzZqKECkrqipZfmmU9L3U