### PR TITLE
feat: add VP_* to DEFAULT_UNTRACKED_ENV

### DIFF
--- a/crates/vite_task_graph/src/config/mod.rs
+++ b/crates/vite_task_graph/src/config/mod.rs
@@ -397,6 +397,8 @@ pub const DEFAULT_UNTRACKED_ENV: &[&str] = &[
     "COMPOSE_*",
     // Playwright specific
     "PLAYWRIGHT_*",
+    // Vite+ internal (not fingerprinted — internal state, not build-affecting)
+    "VP_*",
     // Token patterns
     "*_TOKEN",
 ];


### PR DESCRIPTION
## Summary

- Add `VP_*` pattern to `DEFAULT_UNTRACKED_ENV` so that Vite+ internal environment variables (e.g. `VP_HOME`, `VP_VERSION`) are passed through to child processes without affecting cache keys.

## Context

This is a prerequisite for [voidzero-dev/vite-plus#1074](https://github.com/voidzero-dev/vite-plus/issues/1074), which renames all `VITE_PLUS_*` env vars to `VP_*` to avoid leaking internal vars through Vite's `envPrefix` (default `VITE_`).

After the rename, `VP_*` vars no longer match the `VITE_*` fingerprinted env pattern set by `vp build`. Without this change, `VP_VERSION` (and other internal state vars) would be filtered out by `EnvFingerprints::resolve()` and not reach child processes.

`VP_*` belongs in `untracked_env` (not `fingerprinted_envs`) because these are internal runtime state variables that should not affect cache keys.