### PR TITLE
docs: add RFC for enhanced `dependsOn` syntax

### DIFF
--- a/crates/vite_task_plan/src/error.rs
+++ b/crates/vite_task_plan/src/error.rs
@@ -119,7 +119,7 @@ pub enum Error {
     #[error(transparent)]
     TaskRecursionDetected(#[from] TaskRecursionError),
 
-    #[error("Invalid vite task command: {program} with args {args:?} under cwd {cwd:?}")]
+    #[error("Invalid vite task command: {program} with args {args:?} under cwd \"{cwd}\"")]
     ParsePlanRequest {
         program: Str,
         args: Arc<[Str]>,

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/package.json
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test-workspace",
+  "private": true
+}

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/packages/app/package.json
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/packages/app/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@test/app",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "echo 'Building @test/app'"
+  },
+  "dependencies": {
+    "@test/utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@test/core": "workspace:*"
+  }
+}

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/packages/core/package.json
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/packages/core/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@test/core",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "echo 'Building @test/core'"
+  }
+}

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/packages/utils/package.json
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/packages/utils/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@test/utils",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "echo 'Building @test/utils'"
+  },
+  "dependencies": {
+    "@test/core": "workspace:*"
+  }
+}

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/pnpm-workspace.yaml
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots.toml
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots.toml
@@ -1,0 +1,61 @@
+# Tests --direct / -d flag: select direct dependencies only (one hop).
+# Topology: app → utils (dependency), app → core (devDependency), utils → core
+# Both dependency types are traversed.
+
+# -d from app: should select utils (dep) and core (devDep), NOT app itself.
+[[plan]]
+compact = true
+name = "dependencies from app"
+args = ["run", "-d", "build"]
+cwd = "packages/app"
+
+# -d from utils: should select core only (direct dep), NOT utils itself.
+[[plan]]
+compact = true
+name = "dependencies from utils"
+args = ["run", "-d", "build"]
+cwd = "packages/utils"
+
+# -d from core: core has no deps, so no packages selected.
+[[plan]]
+compact = true
+name = "dependencies from leaf package"
+args = ["run", "-d", "build"]
+cwd = "packages/core"
+
+# Contrast with -t from app: should select app, utils, AND core (full transitive).
+[[plan]]
+compact = true
+name = "transitive from app for comparison"
+args = ["run", "-t", "build"]
+cwd = "packages/app"
+
+# -d with package specifier: direct deps of @test/app.
+[[plan]]
+compact = true
+name = "dependencies with package specifier"
+args = ["run", "-d", "@test/app#build"]
+
+# -d with --workspace-root: direct deps of the workspace root package.
+[[plan]]
+compact = true
+name = "dependencies with workspace root"
+args = ["run", "-d", "-w", "build"]
+
+# Error: -d and -r conflict.
+[[plan]]
+compact = true
+name = "direct with recursive conflict"
+args = ["run", "-d", "-r", "build"]
+
+# Error: -d and -t conflict.
+[[plan]]
+compact = true
+name = "direct with transitive conflict"
+args = ["run", "-d", "-t", "build"]
+
+# Error: -d and --filter conflict.
+[[plan]]
+compact = true
+name = "direct with filter conflict"
+args = ["run", "-d", "--filter", "@test/app", "build"]

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - dependencies from app.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - dependencies from app.snap
@@ -1,0 +1,17 @@
+---
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
+expression: "&compact_plan"
+info:
+  args:
+    - run
+    - "-d"
+    - build
+  cwd: packages/app
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies
+---
+{
+  "packages/core#build": [],
+  "packages/utils#build": [
+    "packages/core#build"
+  ]
+}

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - dependencies from leaf package.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - dependencies from leaf package.snap
@@ -1,0 +1,12 @@
+---
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
+expression: "&compact_plan"
+info:
+  args:
+    - run
+    - "-d"
+    - build
+  cwd: packages/core
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies
+---
+{}

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - dependencies from utils.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - dependencies from utils.snap
@@ -1,0 +1,14 @@
+---
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
+expression: "&compact_plan"
+info:
+  args:
+    - run
+    - "-d"
+    - build
+  cwd: packages/utils
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies
+---
+{
+  "packages/core#build": []
+}

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - dependencies with package specifier.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - dependencies with package specifier.snap
@@ -1,0 +1,16 @@
+---
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
+expression: "&compact_plan"
+info:
+  args:
+    - run
+    - "-d"
+    - "@test/app#build"
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies
+---
+{
+  "packages/core#build": [],
+  "packages/utils#build": [
+    "packages/core#build"
+  ]
+}

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - dependencies with workspace root.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - dependencies with workspace root.snap
@@ -1,0 +1,12 @@
+---
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
+expression: "&compact_plan"
+info:
+  args:
+    - run
+    - "-d"
+    - "-w"
+    - build
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies
+---
+{}

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - direct with filter conflict.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - direct with filter conflict.snap
@@ -10,4 +10,4 @@ info:
     - build
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies
 ---
-Invalid vite task command: vt with args [] under cwd "<workspace>/": --direct and --filter cannot be used together
+Invalid vite task command: vt with args [] under cwd "<workspace>/": --filter and --direct cannot be used together

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - direct with filter conflict.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - direct with filter conflict.snap
@@ -1,0 +1,13 @@
+---
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
+expression: err_str.as_ref()
+info:
+  args:
+    - run
+    - "-d"
+    - "--filter"
+    - "@test/app"
+    - build
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies
+---
+Invalid vite task command: vt with args [] under cwd "<workspace>/": --direct and --filter cannot be used together

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - direct with recursive conflict.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - direct with recursive conflict.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
-expression: err_str.as_ref()
+expression: err
 info:
   args:
     - run
@@ -9,4 +9,8 @@ info:
     - build
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies
 ---
-Invalid vite task command: vt with args [] under cwd "<workspace>/": --direct and --recursive cannot be used together
+error: the argument '--direct' cannot be used with '--recursive'
+
+Usage: vt run --direct <TASK_SPECIFIER> <ADDITIONAL_ARGS>...
+
+For more information, try '--help'.

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - direct with recursive conflict.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - direct with recursive conflict.snap
@@ -1,0 +1,12 @@
+---
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
+expression: err_str.as_ref()
+info:
+  args:
+    - run
+    - "-d"
+    - "-r"
+    - build
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies
+---
+Invalid vite task command: vt with args [] under cwd "<workspace>/": --direct and --recursive cannot be used together

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - direct with transitive conflict.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - direct with transitive conflict.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/vite_task_plan/tests/plan_snapshots/main.rs
-expression: err_str.as_ref()
+expression: err
 info:
   args:
     - run
@@ -9,4 +9,8 @@ info:
     - build
 input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies
 ---
-Invalid vite task command: vt with args [] under cwd "<workspace>/": --direct and --transitive cannot be used together
+error: the argument '--direct' cannot be used with '--transitive'
+
+Usage: vt run --direct <TASK_SPECIFIER> <ADDITIONAL_ARGS>...
+
+For more information, try '--help'.

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - direct with transitive conflict.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - direct with transitive conflict.snap
@@ -1,0 +1,12 @@
+---
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
+expression: err_str.as_ref()
+info:
+  args:
+    - run
+    - "-d"
+    - "-t"
+    - build
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies
+---
+Invalid vite task command: vt with args [] under cwd "<workspace>/": --direct and --transitive cannot be used together

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - transitive from app for comparison.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/query - transitive from app for comparison.snap
@@ -1,0 +1,21 @@
+---
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
+expression: "&compact_plan"
+info:
+  args:
+    - run
+    - "-t"
+    - build
+  cwd: packages/app
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies
+---
+{
+  "packages/app#build": [
+    "packages/core#build",
+    "packages/utils#build"
+  ],
+  "packages/core#build": [],
+  "packages/utils#build": [
+    "packages/core#build"
+  ]
+}

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/task graph.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies/snapshots/task graph.snap
@@ -1,0 +1,109 @@
+---
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
+expression: task_graph_json
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/direct-dependencies
+---
+[
+  {
+    "key": [
+      "<workspace>/packages/app",
+      "build"
+    ],
+    "node": {
+      "task_display": {
+        "package_name": "@test/app",
+        "task_name": "build",
+        "package_path": "<workspace>/packages/app"
+      },
+      "resolved_config": {
+        "command": "echo 'Building @test/app'",
+        "resolved_options": {
+          "cwd": "<workspace>/packages/app",
+          "cache_config": {
+            "env_config": {
+              "fingerprinted_envs": [],
+              "untracked_env": [
+                "<default untracked envs>"
+              ]
+            },
+            "input_config": {
+              "includes_auto": true,
+              "positive_globs": [],
+              "negative_globs": []
+            }
+          }
+        }
+      },
+      "source": "PackageJsonScript"
+    },
+    "neighbors": []
+  },
+  {
+    "key": [
+      "<workspace>/packages/core",
+      "build"
+    ],
+    "node": {
+      "task_display": {
+        "package_name": "@test/core",
+        "task_name": "build",
+        "package_path": "<workspace>/packages/core"
+      },
+      "resolved_config": {
+        "command": "echo 'Building @test/core'",
+        "resolved_options": {
+          "cwd": "<workspace>/packages/core",
+          "cache_config": {
+            "env_config": {
+              "fingerprinted_envs": [],
+              "untracked_env": [
+                "<default untracked envs>"
+              ]
+            },
+            "input_config": {
+              "includes_auto": true,
+              "positive_globs": [],
+              "negative_globs": []
+            }
+          }
+        }
+      },
+      "source": "PackageJsonScript"
+    },
+    "neighbors": []
+  },
+  {
+    "key": [
+      "<workspace>/packages/utils",
+      "build"
+    ],
+    "node": {
+      "task_display": {
+        "package_name": "@test/utils",
+        "task_name": "build",
+        "package_path": "<workspace>/packages/utils"
+      },
+      "resolved_config": {
+        "command": "echo 'Building @test/utils'",
+        "resolved_options": {
+          "cwd": "<workspace>/packages/utils",
+          "cache_config": {
+            "env_config": {
+              "fingerprinted_envs": [],
+              "untracked_env": [
+                "<default untracked envs>"
+              ]
+            },
+            "input_config": {
+              "includes_auto": true,
+              "positive_globs": [],
+              "negative_globs": []
+            }
+          }
+        }
+      },
+      "source": "PackageJsonScript"
+    },
+    "neighbors": []
+  }
+]

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/transitive-skip-intermediate/snapshots.toml
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/transitive-skip-intermediate/snapshots.toml
@@ -40,3 +40,18 @@ cwd = "packages/middle"
 compact = true
 name = "transitive with package specifier lacking task"
 args = ["run", "-t", "@test/middle#build"]
+
+# -d from top: direct deps are {middle}. middle lacks build → empty.
+# Unlike -t which walks transitively through middle to find bottom.
+[[plan]]
+compact = true
+name = "direct from top stops at direct deps"
+args = ["run", "-d", "build"]
+cwd = "packages/top"
+
+# -d from middle: direct dep is {bottom}. bottom has build → bottom#build.
+[[plan]]
+compact = true
+name = "direct from middle finds direct dep"
+args = ["run", "-d", "build"]
+cwd = "packages/middle"

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/transitive-skip-intermediate/snapshots/query - direct from middle finds direct dep.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/transitive-skip-intermediate/snapshots/query - direct from middle finds direct dep.snap
@@ -1,0 +1,14 @@
+---
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
+expression: "&compact_plan"
+info:
+  args:
+    - run
+    - "-d"
+    - build
+  cwd: packages/middle
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/transitive-skip-intermediate
+---
+{
+  "packages/bottom#build": []
+}

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/transitive-skip-intermediate/snapshots/query - direct from top stops at direct deps.snap
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/transitive-skip-intermediate/snapshots/query - direct from top stops at direct deps.snap
@@ -1,0 +1,12 @@
+---
+source: crates/vite_task_plan/tests/plan_snapshots/main.rs
+expression: "&compact_plan"
+info:
+  args:
+    - run
+    - "-d"
+    - build
+  cwd: packages/top
+input_file: crates/vite_task_plan/tests/plan_snapshots/fixtures/transitive-skip-intermediate
+---
+{}

--- a/crates/vite_task_plan/tests/plan_snapshots/main.rs
+++ b/crates/vite_task_plan/tests/plan_snapshots/main.rs
@@ -272,15 +272,8 @@ fn run_case_inner(
                     // and redact workspace paths for snapshot stability.
                     let anyhow_err: anyhow::Error = err.into();
                     let err_formatted = vite_str::format!("{anyhow_err:#}");
-                    // On Windows, paths printed via `{path:?}` are Debug-formatted
-                    // with each backslash escaped as `\\`. Unescape them before
-                    // redacting so the raw `workspace_root_str` matches.
-                    let err_str = if cfg!(windows) {
-                        err_formatted.as_str().cow_replace("\\\\", "\\")
-                    } else {
-                        std::borrow::Cow::Borrowed(err_formatted.as_str())
-                    };
-                    let err_str = err_str.as_ref().cow_replace(workspace_root_str, "<workspace>");
+                    let err_str =
+                        err_formatted.as_str().cow_replace(workspace_root_str, "<workspace>");
                     let err_str = if cfg!(windows) {
                         err_str.as_ref().cow_replace('\\', "/")
                     } else {

--- a/crates/vite_task_plan/tests/plan_snapshots/main.rs
+++ b/crates/vite_task_plan/tests/plan_snapshots/main.rs
@@ -272,8 +272,15 @@ fn run_case_inner(
                     // and redact workspace paths for snapshot stability.
                     let anyhow_err: anyhow::Error = err.into();
                     let err_formatted = vite_str::format!("{anyhow_err:#}");
-                    let err_str =
-                        err_formatted.as_str().cow_replace(workspace_root_str, "<workspace>");
+                    // On Windows, paths printed via `{path:?}` are Debug-formatted
+                    // with each backslash escaped as `\\`. Unescape them before
+                    // redacting so the raw `workspace_root_str` matches.
+                    let err_str = if cfg!(windows) {
+                        err_formatted.as_str().cow_replace("\\\\", "\\")
+                    } else {
+                        std::borrow::Cow::Borrowed(err_formatted.as_str())
+                    };
+                    let err_str = err_str.as_ref().cow_replace(workspace_root_str, "<workspace>");
                     let err_str = if cfg!(windows) {
                         err_str.as_ref().cow_replace('\\', "/")
                     } else {

--- a/crates/vite_workspace/src/package_filter.rs
+++ b/crates/vite_workspace/src/package_filter.rs
@@ -221,8 +221,8 @@ pub enum PackageFilterParseError {
 /// Errors that can occur when converting [`PackageQueryArgs`] into a [`PackageQuery`].
 #[derive(Debug, thiserror::Error)]
 pub enum PackageQueryError {
-    #[error("--recursive and --transitive cannot be used together")]
-    RecursiveTransitiveConflict,
+    #[error("--recursive, --transitive, and --direct are mutually exclusive")]
+    ConflictingTraversalModes,
 
     #[error("--filter and --transitive cannot be used together")]
     FilterWithTransitive,
@@ -230,13 +230,7 @@ pub enum PackageQueryError {
     #[error("--filter and --recursive cannot be used together")]
     FilterWithRecursive,
 
-    #[error("--direct and --recursive cannot be used together")]
-    DirectWithRecursive,
-
-    #[error("--direct and --transitive cannot be used together")]
-    DirectWithTransitive,
-
-    #[error("--direct and --filter cannot be used together")]
+    #[error("--filter and --direct cannot be used together")]
     DirectWithFilter,
 
     #[error("cannot specify package name with --recursive")]
@@ -255,23 +249,58 @@ pub enum PackageQueryError {
     InvalidFilter(#[from] PackageFilterParseError),
 }
 
+/// How to traverse the package dependency graph when selecting packages.
+///
+/// These modes are mutually exclusive at the CLI level (`-r`, `-t`, `-d`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TraversalMode {
+    /// `--recursive` / `-r`: select all packages in the workspace.
+    Recursive,
+    /// `--transitive` / `-t`: select the current package and its full transitive dependencies.
+    Transitive,
+    /// `--direct` / `-d`: select only the direct dependencies of the current package (one hop, excluding self).
+    Direct,
+}
+
+impl TraversalMode {
+    /// Convert to the internal graph traversal specification.
+    pub(crate) fn to_graph_traversal(self) -> GraphTraversal {
+        match self {
+            Self::Recursive => GraphTraversal {
+                direction: TraversalDirection::Dependencies,
+                exclude_self: false,
+                direct_only: false,
+            },
+            Self::Transitive => GraphTraversal {
+                direction: TraversalDirection::Dependencies,
+                exclude_self: false,
+                direct_only: false,
+            },
+            Self::Direct => GraphTraversal {
+                direction: TraversalDirection::Dependencies,
+                exclude_self: true,
+                direct_only: true,
+            },
+        }
+    }
+}
+
 /// CLI arguments for selecting which packages a command applies to.
 ///
 /// Use `#[clap(flatten)]` to embed these in a parent clap struct.
 /// Call [`into_package_query`](Self::into_package_query) to convert into an opaque [`PackageQuery`].
 #[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
-#[expect(clippy::struct_excessive_bools, reason = "CLI flags are naturally boolean")]
 pub struct PackageQueryArgs {
     /// Select all packages in the workspace.
-    #[clap(default_value = "false", short, long)]
+    #[clap(default_value = "false", short, long, group = "traversal")]
     recursive: bool,
 
     /// Select the current package and its transitive dependencies.
-    #[clap(default_value = "false", short, long)]
+    #[clap(default_value = "false", short, long, group = "traversal")]
     transitive: bool,
 
     /// Select the direct dependencies of the current package.
-    #[clap(default_value = "false", short, long)]
+    #[clap(default_value = "false", short, long, group = "traversal")]
     direct: bool,
 
     /// Select the workspace root package.
@@ -297,6 +326,27 @@ Match packages by name, directory, or glob pattern.
     filters: Vec<Str>,
 }
 
+impl TraversalMode {
+    /// Resolve three mutually exclusive traversal flags into an `Option<TraversalMode>`.
+    ///
+    /// Clap's `group = "traversal"` enforces mutual exclusivity at parse time.
+    /// This function also handles direct struct construction (e.g. in tests).
+    fn from_flags(
+        recursive: bool,
+        transitive: bool,
+        direct: bool,
+    ) -> Result<Option<Self>, PackageQueryError> {
+        match (recursive, transitive, direct) {
+            (false, false, false) => Ok(None),
+            (true, false, false) => Ok(Some(Self::Recursive)),
+            (false, true, false) => Ok(Some(Self::Transitive)),
+            (false, false, true) => Ok(Some(Self::Direct)),
+            // Clap group prevents this from CLI; guard for direct construction.
+            _ => Err(PackageQueryError::ConflictingTraversalModes),
+        }
+    }
+}
+
 impl PackageQueryArgs {
     /// Convert CLI arguments into an opaque [`PackageQuery`].
     ///
@@ -304,20 +354,20 @@ impl PackageQueryArgs {
     /// `cwd` is the working directory (used as fallback when no package name or filter is given).
     ///
     /// Returns `(query, is_cwd_only)` where `is_cwd_only` is `true` when the query
-    /// falls through to the implicit-cwd path (no `-r`, `-t`, `-w`, `--filter`,
+    /// falls through to the implicit-cwd path (no `-r`, `-t`, `-d`, `-w`, `--filter`,
     /// or explicit package name).
     ///
     /// # Errors
     ///
     /// Returns [`PackageQueryError`] if conflicting flags are set, a package name
     /// is specified with `--recursive` or `--filter`, or a filter expression is invalid.
-    #[expect(clippy::too_many_lines, reason = "single exhaustive match")]
     pub fn into_package_query(
         self,
         package_name: Option<Str>,
         cwd: &Arc<AbsolutePath>,
     ) -> Result<(PackageQuery, bool), PackageQueryError> {
         let Self { recursive, transitive, direct, workspace_root, filters } = self;
+        let traversal_mode = TraversalMode::from_flags(recursive, transitive, direct)?;
 
         // Collect filter tokens from all `--filter` arguments, splitting on whitespace.
         let mut filter_tokens = Vec::<Str>::with_capacity(filters.len());
@@ -338,40 +388,42 @@ impl PackageQueryArgs {
 
         // Error arms only match the conflicting fields (wildcards for the rest).
         // Success arms explicitly match every field — no wildcards.
-        match (recursive, transitive, direct, workspace_root, filter_tokens, package_name) {
+        match (traversal_mode, workspace_root, filter_tokens, package_name) {
             // ------------------------- error cases --------------------------------
 
-            // --recursive --transitive
-            (true, true, _, _, _, _) => Err(PackageQueryError::RecursiveTransitiveConflict),
-            // --recursive --direct
-            (true, _, true, _, _, _) => Err(PackageQueryError::DirectWithRecursive),
-            // --transitive --direct
-            (_, true, true, _, _, _) => Err(PackageQueryError::DirectWithTransitive),
             // --recursive --filter
-            (true, _, _, _, Some(_), _) => Err(PackageQueryError::FilterWithRecursive),
-            // --direct --filter
-            (_, _, true, _, Some(_), _) => Err(PackageQueryError::DirectWithFilter),
+            (Some(TraversalMode::Recursive), _, Some(_), _) => {
+                Err(PackageQueryError::FilterWithRecursive)
+            }
             // --recursive <pkg>#<task>
-            (true, false, false, _, _, Some(package_name)) => {
+            (Some(TraversalMode::Recursive), _, _, Some(package_name)) => {
                 Err(PackageQueryError::PackageNameWithRecursive { package_name })
             }
             // --transitive --filter
-            (false, true, false, _, Some(_), _) => Err(PackageQueryError::FilterWithTransitive),
+            (Some(TraversalMode::Transitive), _, Some(_), _) => {
+                Err(PackageQueryError::FilterWithTransitive)
+            }
+            // --direct --filter
+            (Some(TraversalMode::Direct), _, Some(_), _) => {
+                Err(PackageQueryError::DirectWithFilter)
+            }
             // --filter <pkg>#<task>
-            (_, _, _, _, Some(_), Some(package_name)) => {
+            (_, _, Some(_), Some(package_name)) => {
                 Err(PackageQueryError::PackageNameWithFilter { package_name })
             }
             // --workspace-root <pkg>#<task>
-            (_, _, _, true, _, Some(package_name)) => {
+            (_, true, _, Some(package_name)) => {
                 Err(PackageQueryError::PackageNameWithWorkspaceRoot { package_name })
             }
 
             // ------------------------ success cases -------------------------------
 
             // --recursive (--workspace-root is redundant)
-            (true, false, false, true | false, None, None) => Ok((PackageQuery::all(), false)),
+            (Some(TraversalMode::Recursive), true | false, None, None) => {
+                Ok((PackageQuery::all(), false))
+            }
             // --filter [--workspace-root]
-            (false, false, false, workspace_root, Some(filter_tokens), None) => {
+            (None, workspace_root, Some(filter_tokens), None) => {
                 let mut parsed: Vec1<PackageFilter> =
                     filter_tokens.try_mapped(|f| parse_filter(&f, cwd))?;
                 if workspace_root {
@@ -385,16 +437,13 @@ impl PackageQueryArgs {
                 Ok((PackageQuery::filters(parsed), false))
             }
             // --workspace-root [--transitive|--direct]
-            (false, transitive, direct, true, None, None) => {
-                let traversal = if transitive || direct {
-                    Some(GraphTraversal {
-                        direction: TraversalDirection::Dependencies,
-                        exclude_self: direct,
-                        direct_only: direct,
-                    })
-                } else {
-                    None
-                };
+            (
+                mode @ (None | Some(TraversalMode::Transitive | TraversalMode::Direct)),
+                true,
+                None,
+                None,
+            ) => {
+                let traversal = mode.map(TraversalMode::to_graph_traversal);
                 Ok((
                     PackageQuery::filters(Vec1::new(PackageFilter {
                         exclude: false,
@@ -406,16 +455,13 @@ impl PackageQueryArgs {
                 ))
             }
             // [--transitive|--direct] <pkg>#<task>
-            (false, transitive, direct, false, None, Some(name)) => {
-                let traversal = if transitive || direct {
-                    Some(GraphTraversal {
-                        direction: TraversalDirection::Dependencies,
-                        exclude_self: direct,
-                        direct_only: direct,
-                    })
-                } else {
-                    None
-                };
+            (
+                mode @ (None | Some(TraversalMode::Transitive | TraversalMode::Direct)),
+                false,
+                None,
+                Some(name),
+            ) => {
+                let traversal = mode.map(TraversalMode::to_graph_traversal);
                 Ok((
                     PackageQuery::filters(Vec1::new(PackageFilter {
                         exclude: false,
@@ -429,36 +475,23 @@ impl PackageQueryArgs {
                     false,
                 ))
             }
-            // --transitive
-            (false, true, false, false, None, None) => Ok((
-                PackageQuery::filters(Vec1::new(PackageFilter {
-                    exclude: false,
-                    selector: PackageSelector::ContainingPackage(Arc::clone(cwd)),
-                    traversal: Some(GraphTraversal {
-                        direction: TraversalDirection::Dependencies,
-                        exclude_self: false,
-                        direct_only: false,
-                    }),
-                    source: None,
-                })),
+            // --transitive | --direct (from cwd)
+            (
+                Some(mode @ (TraversalMode::Transitive | TraversalMode::Direct)),
                 false,
-            )),
-            // --direct
-            (false, false, true, false, None, None) => Ok((
+                None,
+                None,
+            ) => Ok((
                 PackageQuery::filters(Vec1::new(PackageFilter {
                     exclude: false,
                     selector: PackageSelector::ContainingPackage(Arc::clone(cwd)),
-                    traversal: Some(GraphTraversal {
-                        direction: TraversalDirection::Dependencies,
-                        exclude_self: true,
-                        direct_only: true,
-                    }),
+                    traversal: Some(mode.to_graph_traversal()),
                     source: None,
                 })),
                 false,
             )),
             // (no flags, implicit cwd)
-            (false, false, false, false, None, None) => Ok((
+            (None, false, None, None) => Ok((
                 PackageQuery::filters(Vec1::new(PackageFilter {
                     exclude: false,
                     selector: PackageSelector::ContainingPackage(Arc::clone(cwd)),

--- a/crates/vite_workspace/src/package_filter.rs
+++ b/crates/vite_workspace/src/package_filter.rs
@@ -264,14 +264,13 @@ pub enum TraversalMode {
 
 impl TraversalMode {
     /// Convert to the internal graph traversal specification.
-    pub(crate) fn to_graph_traversal(self) -> GraphTraversal {
+    ///
+    /// `Recursive` and `Transitive` produce the same graph traversal; they differ
+    /// in how seeds are chosen (all packages vs. the current package), which is
+    /// decided by the caller in [`PackageQueryArgs::into_package_query`].
+    pub(crate) const fn to_graph_traversal(self) -> GraphTraversal {
         match self {
-            Self::Recursive => GraphTraversal {
-                direction: TraversalDirection::Dependencies,
-                exclude_self: false,
-                direct_only: false,
-            },
-            Self::Transitive => GraphTraversal {
+            Self::Recursive | Self::Transitive => GraphTraversal {
                 direction: TraversalDirection::Dependencies,
                 exclude_self: false,
                 direct_only: false,
@@ -289,6 +288,12 @@ impl TraversalMode {
 ///
 /// Use `#[clap(flatten)]` to embed these in a parent clap struct.
 /// Call [`into_package_query`](Self::into_package_query) to convert into an opaque [`PackageQuery`].
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "clap requires separate bool fields for the mutually-exclusive traversal flags \
+              (-r/-t/-d) plus the independent -w flag; they are resolved into `TraversalMode` \
+              via `TraversalMode::from_flags`"
+)]
 #[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
 pub struct PackageQueryArgs {
     /// Select all packages in the workspace.
@@ -331,7 +336,7 @@ impl TraversalMode {
     ///
     /// Clap's `group = "traversal"` enforces mutual exclusivity at parse time.
     /// This function also handles direct struct construction (e.g. in tests).
-    fn from_flags(
+    const fn from_flags(
         recursive: bool,
         transitive: bool,
         direct: bool,
@@ -368,23 +373,7 @@ impl PackageQueryArgs {
     ) -> Result<(PackageQuery, bool), PackageQueryError> {
         let Self { recursive, transitive, direct, workspace_root, filters } = self;
         let traversal_mode = TraversalMode::from_flags(recursive, transitive, direct)?;
-
-        // Collect filter tokens from all `--filter` arguments, splitting on whitespace.
-        let mut filter_tokens = Vec::<Str>::with_capacity(filters.len());
-        for filter in filters {
-            let mut is_empty = true;
-            for filter_token in filter.split_ascii_whitespace() {
-                is_empty = false;
-                filter_tokens.push(filter_token.into());
-            }
-            // Error if any --filter value is empty or whitespace-only.
-            if is_empty {
-                return Err(PackageQueryError::EmptyFilter);
-            }
-        }
-        // We have checked that filter_tokens is non-empty if any filters were provided,
-        // If no tokens are collected, it means no filters were provided.
-        let filter_tokens: Option<Vec1<Str>> = Vec1::try_from_vec(filter_tokens).ok();
+        let filter_tokens = collect_filter_tokens(filters)?;
 
         // Error arms only match the conflicting fields (wildcards for the rest).
         // Success arms explicitly match every field — no wildcards.
@@ -502,6 +491,27 @@ impl PackageQueryArgs {
             )),
         }
     }
+}
+
+/// Collect filter tokens from all `--filter` arguments, splitting each on whitespace.
+///
+/// Returns `None` if no filters were provided, `Some` if at least one token was collected.
+/// Errors with [`PackageQueryError::EmptyFilter`] if any `--filter` value is empty or
+/// whitespace-only.
+fn collect_filter_tokens(filters: Vec<Str>) -> Result<Option<Vec1<Str>>, PackageQueryError> {
+    let mut filter_tokens = Vec::<Str>::with_capacity(filters.len());
+    for filter in filters {
+        let mut is_empty = true;
+        for filter_token in filter.split_ascii_whitespace() {
+            is_empty = false;
+            filter_tokens.push(filter_token.into());
+        }
+        if is_empty {
+            return Err(PackageQueryError::EmptyFilter);
+        }
+    }
+    // If no tokens were collected, no filters were provided.
+    Ok(Vec1::try_from_vec(filter_tokens).ok())
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/crates/vite_workspace/src/package_filter.rs
+++ b/crates/vite_workspace/src/package_filter.rs
@@ -170,6 +170,12 @@ pub(crate) struct GraphTraversal {
     /// Produced by `^` in `foo^...` (keep dependencies, drop foo)
     /// or `...^foo` (keep dependents, drop foo).
     pub(crate) exclude_self: bool,
+
+    /// When `true`, only traverse one hop (direct dependencies/dependents).
+    /// When `false`, traverse the full transitive closure.
+    ///
+    /// Produced by `--dependencies` / `-d`.
+    pub(crate) direct_only: bool,
 }
 
 /// A single package filter, corresponding to one `--filter` argument.
@@ -224,6 +230,15 @@ pub enum PackageQueryError {
     #[error("--filter and --recursive cannot be used together")]
     FilterWithRecursive,
 
+    #[error("--direct and --recursive cannot be used together")]
+    DirectWithRecursive,
+
+    #[error("--direct and --transitive cannot be used together")]
+    DirectWithTransitive,
+
+    #[error("--direct and --filter cannot be used together")]
+    DirectWithFilter,
+
     #[error("cannot specify package name with --recursive")]
     PackageNameWithRecursive { package_name: Str },
 
@@ -245,6 +260,7 @@ pub enum PackageQueryError {
 /// Use `#[clap(flatten)]` to embed these in a parent clap struct.
 /// Call [`into_package_query`](Self::into_package_query) to convert into an opaque [`PackageQuery`].
 #[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
+#[expect(clippy::struct_excessive_bools, reason = "CLI flags are naturally boolean")]
 pub struct PackageQueryArgs {
     /// Select all packages in the workspace.
     #[clap(default_value = "false", short, long)]
@@ -253,6 +269,10 @@ pub struct PackageQueryArgs {
     /// Select the current package and its transitive dependencies.
     #[clap(default_value = "false", short, long)]
     transitive: bool,
+
+    /// Select the direct dependencies of the current package.
+    #[clap(default_value = "false", short, long)]
+    direct: bool,
 
     /// Select the workspace root package.
     #[clap(default_value = "false", short = 'w', long = "workspace-root")]
@@ -297,7 +317,7 @@ impl PackageQueryArgs {
         package_name: Option<Str>,
         cwd: &Arc<AbsolutePath>,
     ) -> Result<(PackageQuery, bool), PackageQueryError> {
-        let Self { recursive, transitive, workspace_root, filters } = self;
+        let Self { recursive, transitive, direct, workspace_root, filters } = self;
 
         // Collect filter tokens from all `--filter` arguments, splitting on whitespace.
         let mut filter_tokens = Vec::<Str>::with_capacity(filters.len());
@@ -318,34 +338,40 @@ impl PackageQueryArgs {
 
         // Error arms only match the conflicting fields (wildcards for the rest).
         // Success arms explicitly match every field — no wildcards.
-        match (recursive, transitive, workspace_root, filter_tokens, package_name) {
+        match (recursive, transitive, direct, workspace_root, filter_tokens, package_name) {
             // ------------------------- error cases --------------------------------
 
             // --recursive --transitive
-            (true, true, _, _, _) => Err(PackageQueryError::RecursiveTransitiveConflict),
+            (true, true, _, _, _, _) => Err(PackageQueryError::RecursiveTransitiveConflict),
+            // --recursive --direct
+            (true, _, true, _, _, _) => Err(PackageQueryError::DirectWithRecursive),
+            // --transitive --direct
+            (_, true, true, _, _, _) => Err(PackageQueryError::DirectWithTransitive),
             // --recursive --filter
-            (true, _, _, Some(_), _) => Err(PackageQueryError::FilterWithRecursive),
+            (true, _, _, _, Some(_), _) => Err(PackageQueryError::FilterWithRecursive),
+            // --direct --filter
+            (_, _, true, _, Some(_), _) => Err(PackageQueryError::DirectWithFilter),
             // --recursive <pkg>#<task>
-            (true, false, _, _, Some(package_name)) => {
+            (true, false, false, _, _, Some(package_name)) => {
                 Err(PackageQueryError::PackageNameWithRecursive { package_name })
             }
             // --transitive --filter
-            (false, true, _, Some(_), _) => Err(PackageQueryError::FilterWithTransitive),
+            (false, true, false, _, Some(_), _) => Err(PackageQueryError::FilterWithTransitive),
             // --filter <pkg>#<task>
-            (_, _, _, Some(_), Some(package_name)) => {
+            (_, _, _, _, Some(_), Some(package_name)) => {
                 Err(PackageQueryError::PackageNameWithFilter { package_name })
             }
             // --workspace-root <pkg>#<task>
-            (_, _, true, _, Some(package_name)) => {
+            (_, _, _, true, _, Some(package_name)) => {
                 Err(PackageQueryError::PackageNameWithWorkspaceRoot { package_name })
             }
 
             // ------------------------ success cases -------------------------------
 
             // --recursive (--workspace-root is redundant)
-            (true, false, true | false, None, None) => Ok((PackageQuery::all(), false)),
+            (true, false, false, true | false, None, None) => Ok((PackageQuery::all(), false)),
             // --filter [--workspace-root]
-            (false, false, workspace_root, Some(filter_tokens), None) => {
+            (false, false, false, workspace_root, Some(filter_tokens), None) => {
                 let mut parsed: Vec1<PackageFilter> =
                     filter_tokens.try_mapped(|f| parse_filter(&f, cwd))?;
                 if workspace_root {
@@ -358,12 +384,13 @@ impl PackageQueryArgs {
                 }
                 Ok((PackageQuery::filters(parsed), false))
             }
-            // --workspace-root [--transitive]
-            (false, transitive, true, None, None) => {
-                let traversal = if transitive {
+            // --workspace-root [--transitive|--direct]
+            (false, transitive, direct, true, None, None) => {
+                let traversal = if transitive || direct {
                     Some(GraphTraversal {
                         direction: TraversalDirection::Dependencies,
-                        exclude_self: false,
+                        exclude_self: direct,
+                        direct_only: direct,
                     })
                 } else {
                     None
@@ -378,12 +405,13 @@ impl PackageQueryArgs {
                     false,
                 ))
             }
-            // [--transitive] <pkg>#<task>
-            (false, transitive, false, None, Some(name)) => {
-                let traversal = if transitive {
+            // [--transitive|--direct] <pkg>#<task>
+            (false, transitive, direct, false, None, Some(name)) => {
+                let traversal = if transitive || direct {
                     Some(GraphTraversal {
                         direction: TraversalDirection::Dependencies,
-                        exclude_self: false,
+                        exclude_self: direct,
+                        direct_only: direct,
                     })
                 } else {
                     None
@@ -402,20 +430,35 @@ impl PackageQueryArgs {
                 ))
             }
             // --transitive
-            (false, true, false, None, None) => Ok((
+            (false, true, false, false, None, None) => Ok((
                 PackageQuery::filters(Vec1::new(PackageFilter {
                     exclude: false,
                     selector: PackageSelector::ContainingPackage(Arc::clone(cwd)),
                     traversal: Some(GraphTraversal {
                         direction: TraversalDirection::Dependencies,
                         exclude_self: false,
+                        direct_only: false,
+                    }),
+                    source: None,
+                })),
+                false,
+            )),
+            // --direct
+            (false, false, true, false, None, None) => Ok((
+                PackageQuery::filters(Vec1::new(PackageFilter {
+                    exclude: false,
+                    selector: PackageSelector::ContainingPackage(Arc::clone(cwd)),
+                    traversal: Some(GraphTraversal {
+                        direction: TraversalDirection::Dependencies,
+                        exclude_self: true,
+                        direct_only: true,
                     }),
                     source: None,
                 })),
                 false,
             )),
             // (no flags, implicit cwd)
-            (false, false, false, None, None) => Ok((
+            (false, false, false, false, None, None) => Ok((
                 PackageQuery::filters(Vec1::new(PackageFilter {
                     exclude: false,
                     selector: PackageSelector::ContainingPackage(Arc::clone(cwd)),
@@ -476,15 +519,24 @@ pub(crate) fn parse_filter(
     let exclude_self = deps_exclude_self || dependents_exclude_self;
 
     // Step 4–5: build the traversal descriptor.
+    // Filter-based traversals are always transitive (not direct_only).
     let traversal = match (include_dependencies, include_dependents) {
         (false, false) => None,
-        (true, false) => {
-            Some(GraphTraversal { direction: TraversalDirection::Dependencies, exclude_self })
-        }
-        (false, true) => {
-            Some(GraphTraversal { direction: TraversalDirection::Dependents, exclude_self })
-        }
-        (true, true) => Some(GraphTraversal { direction: TraversalDirection::Both, exclude_self }),
+        (true, false) => Some(GraphTraversal {
+            direction: TraversalDirection::Dependencies,
+            exclude_self,
+            direct_only: false,
+        }),
+        (false, true) => Some(GraphTraversal {
+            direction: TraversalDirection::Dependents,
+            exclude_self,
+            direct_only: false,
+        }),
+        (true, true) => Some(GraphTraversal {
+            direction: TraversalDirection::Both,
+            exclude_self,
+            direct_only: false,
+        }),
     };
 
     // Step 6–9: parse the remaining core selector.
@@ -1116,6 +1168,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: false,
             transitive: false,
+            direct: false,
             workspace_root: true,
             filters: Vec::new(),
         };
@@ -1142,6 +1195,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: true,
             transitive: false,
+            direct: false,
             workspace_root: true,
             filters: Vec::new(),
         };
@@ -1160,6 +1214,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: false,
             transitive: true,
+            direct: false,
             workspace_root: true,
             filters: Vec::new(),
         };
@@ -1185,6 +1240,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: false,
             transitive: false,
+            direct: false,
             workspace_root: true,
             filters: vec![Str::from("foo")],
         };
@@ -1209,6 +1265,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: false,
             transitive: false,
+            direct: false,
             workspace_root: true,
             filters: Vec::new(),
         };
@@ -1233,6 +1290,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: false,
             transitive: false,
+            direct: false,
             workspace_root: false,
             filters: vec![Str::from("a b")],
         };
@@ -1253,6 +1311,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: false,
             transitive: false,
+            direct: false,
             workspace_root: true,
             filters: vec![Str::from("foo")],
         };
@@ -1273,6 +1332,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: false,
             transitive: false,
+            direct: false,
             workspace_root: false,
             filters: Vec::new(),
         };
@@ -1294,6 +1354,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: false,
             transitive: false,
+            direct: false,
             workspace_root: false,
             filters: vec![Str::from("")],
         };
@@ -1306,6 +1367,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: false,
             transitive: false,
+            direct: false,
             workspace_root: false,
             filters: vec![Str::from("   ")],
         };
@@ -1318,6 +1380,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: false,
             transitive: false,
+            direct: false,
             workspace_root: false,
             filters: vec![Str::from("foo"), Str::from("")],
         };
@@ -1330,6 +1393,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: false,
             transitive: false,
+            direct: false,
             workspace_root: false,
             filters: vec![Str::from(""), Str::from("foo")],
         };
@@ -1342,6 +1406,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: false,
             transitive: false,
+            direct: false,
             workspace_root: false,
             filters: vec![Str::from("foo"), Str::from("  \t  ")],
         };
@@ -1356,6 +1421,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: false,
             transitive: false,
+            direct: false,
             workspace_root: false,
             filters: Vec::new(),
         };
@@ -1369,6 +1435,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: false,
             transitive: false,
+            direct: false,
             workspace_root: false,
             filters: Vec::new(),
         };
@@ -1382,6 +1449,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: false,
             transitive: true,
+            direct: false,
             workspace_root: false,
             filters: Vec::new(),
         };
@@ -1395,6 +1463,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: true,
             transitive: false,
+            direct: false,
             workspace_root: false,
             filters: Vec::new(),
         };
@@ -1408,6 +1477,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: false,
             transitive: false,
+            direct: false,
             workspace_root: false,
             filters: vec![Str::from("foo")],
         };
@@ -1421,6 +1491,7 @@ mod tests {
         let args = PackageQueryArgs {
             recursive: false,
             transitive: false,
+            direct: false,
             workspace_root: true,
             filters: Vec::new(),
         };

--- a/crates/vite_workspace/src/package_graph.rs
+++ b/crates/vite_workspace/src/package_graph.rs
@@ -431,23 +431,39 @@ impl IndexedPackageGraph {
 
         let mut reachable = FxHashSet::default();
 
-        match traversal.direction {
-            TraversalDirection::Dependencies => {
-                self.bfs_outgoing(&seeds, &mut reachable);
+        if traversal.direct_only {
+            // One-hop traversal: only direct neighbors, no recursive expansion.
+            match traversal.direction {
+                TraversalDirection::Dependencies => {
+                    self.direct_outgoing(&seeds, &mut reachable);
+                }
+                TraversalDirection::Dependents => {
+                    self.direct_incoming(&seeds, &mut reachable);
+                }
+                TraversalDirection::Both => {
+                    self.direct_outgoing(&seeds, &mut reachable);
+                    self.direct_incoming(&seeds, &mut reachable);
+                }
             }
-            TraversalDirection::Dependents => {
-                self.bfs_incoming(&seeds, &mut reachable);
-            }
-            TraversalDirection::Both => {
-                // Walk dependents first, then walk dependencies of ALL dependents found
-                // (including the original seeds).
-                // pnpm ref: <https://github.com/pnpm/pnpm/blob/491a84fb26fa716408bf6bd361680f6a450c61fc/workspace/filter-workspace-packages/src/index.ts#L265-L267>
-                let mut dependents = FxHashSet::default();
-                self.bfs_incoming(&seeds, &mut dependents);
-                let all_dep_seeds: FxHashSet<_> =
-                    seeds.iter().chain(dependents.iter()).copied().collect();
-                self.bfs_outgoing(&all_dep_seeds, &mut reachable);
-                reachable.extend(dependents);
+        } else {
+            match traversal.direction {
+                TraversalDirection::Dependencies => {
+                    self.bfs_outgoing(&seeds, &mut reachable);
+                }
+                TraversalDirection::Dependents => {
+                    self.bfs_incoming(&seeds, &mut reachable);
+                }
+                TraversalDirection::Both => {
+                    // Walk dependents first, then walk dependencies of ALL dependents found
+                    // (including the original seeds).
+                    // pnpm ref: <https://github.com/pnpm/pnpm/blob/491a84fb26fa716408bf6bd361680f6a450c61fc/workspace/filter-workspace-packages/src/index.ts#L265-L267>
+                    let mut dependents = FxHashSet::default();
+                    self.bfs_incoming(&seeds, &mut dependents);
+                    let all_dep_seeds: FxHashSet<_> =
+                        seeds.iter().chain(dependents.iter()).copied().collect();
+                    self.bfs_outgoing(&all_dep_seeds, &mut reachable);
+                    reachable.extend(dependents);
+                }
             }
         }
 
@@ -460,6 +476,36 @@ impl IndexedPackageGraph {
         }
 
         reachable
+    }
+
+    /// Collect direct (one-hop) outgoing neighbors of `seeds`.
+    ///
+    /// Seeds are NOT added to `out`.
+    fn direct_outgoing(
+        &self,
+        seeds: &FxHashSet<PackageNodeIndex>,
+        out: &mut FxHashSet<PackageNodeIndex>,
+    ) {
+        for &node in seeds {
+            for edge in self.graph.edges(node) {
+                out.insert(edge.target());
+            }
+        }
+    }
+
+    /// Collect direct (one-hop) incoming neighbors of `seeds`.
+    ///
+    /// Seeds are NOT added to `out`.
+    fn direct_incoming(
+        &self,
+        seeds: &FxHashSet<PackageNodeIndex>,
+        out: &mut FxHashSet<PackageNodeIndex>,
+    ) {
+        for &node in seeds {
+            for edge in self.graph.edges_directed(node, Direction::Incoming) {
+                out.insert(edge.source());
+            }
+        }
     }
 
     /// BFS along outgoing (dependency) edges from `seeds`, collecting all reachable nodes.

--- a/docs/depends-on.md
+++ b/docs/depends-on.md
@@ -33,7 +33,7 @@ Two equivalent styles are proposed.
 
 ### Style 1: CLI string syntax
 
-Each `dependsOn` element is a string (or array of strings) written exactly as you would type CLI arguments to `vp run`:
+Each `dependsOn` element is a string (existing syntax) or a string array written exactly as you would type CLI arguments to `vp run`:
 
 ```jsonc
 {
@@ -45,25 +45,21 @@ Each `dependsOn` element is a string (or array of strings) written exactly as yo
         "utils#build",
 
         // Run `build` across all workspace packages
-        "--recursive build",
+        ["--recursive", "build"],
 
         // Run `build` in current package and its transitive dependencies
-        "--transitive build",
+        ["--transitive", "build"],
 
         // Run `build` in packages matching a filter
-        "--filter @myorg/core build",
-        "--filter @myorg/core... build", // @myorg/core and its deps
-
-        // Array form — each element is one CLI token
         ["--filter", "@myorg/core", "build"],
-        ["--transitive", "build"],
+        ["--filter", "@myorg/core...", "build"], // @myorg/core and its deps
       ],
     },
   },
 }
 ```
 
-The parser splits a string element on whitespace (like a shell would) and interprets the tokens as `vp run` arguments. The array form avoids splitting entirely — useful when a filter value contains whitespace or for explicitness.
+Each element in the array is one CLI token, exactly as you would pass to `vp run`.
 
 **Supported flags:**
 
@@ -128,3 +124,11 @@ The same validation rules from the CLI apply:
 ## Context: "Current Package"
 
 When `--transitive` or a filter with traversal suffixes (e.g. `@myorg/core...`) resolves packages, "current package" means the package that owns the task containing this `dependsOn` entry — the same package that would be inferred from an unqualified `"build"` dependency today.
+
+## Comparison
+
+|                    | Style 1 (CLI string)                                           | Style 2 (Object)                                                   |
+| ------------------ | -------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Learning curve     | None if you already know `vp run` — identical syntax           | Minimal — same flag names, written as JSON keys                    |
+| IDE autocompletion | Yes — TypeScript tuple types can constrain each array position | Yes — TypeScript object types can validate keys and suggest fields |
+| Config consistency | Unusual — CLI syntax embedded in config arrays                 | Consistent — matches the object style used elsewhere in the config |

--- a/docs/depends-on.md
+++ b/docs/depends-on.md
@@ -1,0 +1,129 @@
+# RFC: Enhanced `dependsOn` Syntax
+
+## Background
+
+Today, `dependsOn` entries can only refer to a single task by name (`"build"`) or by package-qualified name (`"pkg#build"`). A common pattern in monorepo task runners is "run `build` in all transitive dependencies first" — tools like Nx (`^build`) and Turborepo (`^build`) support this, but each introduces its own symbol with its own meaning.
+
+The CLI already supports package selection through flags like `--recursive`, `--transitive`, and `--filter`. Rather than invent yet another DSL with new symbols, we reuse the exact same mental model and syntax from `vp run`.
+
+### Design principle
+
+**No new mental models.** If you know how to write `vp run`, you know how to write a `dependsOn` entry. The flag names, filter syntax, and task specifier format are identical.
+
+## Current Syntax
+
+```jsonc
+{
+  "tasks": {
+    "test": {
+      "dependsOn": [
+        "build", // same-package task
+        "utils#build", // task in a specific package
+      ],
+    },
+  },
+}
+```
+
+These simple forms remain valid and unchanged under both proposed styles.
+
+## Proposed Syntax
+
+### Style 1: CLI string syntax
+
+Each `dependsOn` element is a string (or array of strings) written exactly as you would type CLI arguments to `vp run`:
+
+```jsonc
+{
+  "tasks": {
+    "test": {
+      "dependsOn": [
+        // Existing syntax — still works
+        "build",
+        "utils#build",
+
+        // Run `build` across all workspace packages
+        "--recursive build",
+
+        // Run `build` in current package and its transitive dependencies
+        "--transitive build",
+
+        // Run `build` in packages matching a filter
+        "--filter @myorg/core build",
+        "--filter @myorg/core... build", // @myorg/core and its deps
+
+        // Array form — each element is one CLI token
+        ["--filter", "@myorg/core", "build"],
+        ["--transitive", "build"],
+      ],
+    },
+  },
+}
+```
+
+The parser splits a string element on whitespace (like a shell would) and interprets the tokens as `vp run` arguments. The array form avoids splitting entirely — useful when a filter value contains whitespace or for explicitness.
+
+**Supported flags:**
+
+| Flag                 | Short          | Meaning                                                            |
+| -------------------- | -------------- | ------------------------------------------------------------------ |
+| `--recursive`        | `-r`           | All workspace packages                                             |
+| `--transitive`       | `-t`           | Current package + its transitive dependencies                      |
+| `--filter <pattern>` | `-F <pattern>` | Packages matching a [filter expression](https://pnpm.io/filtering) |
+| `--workspace-root`   | `-w`           | The workspace root package                                         |
+
+Everything after the flags is the task specifier (e.g. `build`, `pkg#task`).
+
+### Style 2: Object syntax
+
+Each `dependsOn` element can be an object whose keys mirror the CLI flag names:
+
+```jsonc
+{
+  "tasks": {
+    "test": {
+      "dependsOn": [
+        // Existing syntax — still works as plain strings
+        "build",
+        "utils#build",
+
+        // Run `build` across all workspace packages
+        { "recursive": true, "task": "build" },
+
+        // Run `build` in current package and its transitive dependencies
+        { "transitive": true, "task": "build" },
+
+        // Run `build` in packages matching a filter
+        { "filter": "@myorg/core", "task": "build" },
+        { "filter": "@myorg/core...", "task": "build" },
+
+        // Multiple filters
+        { "filter": ["@myorg/core", "@myorg/utils"], "task": "build" },
+
+        // Workspace root
+        { "workspaceRoot": true, "task": "build" },
+      ],
+    },
+  },
+}
+```
+
+**Object fields:**
+
+| Field           | Type                 | Meaning                                                    |
+| --------------- | -------------------- | ---------------------------------------------------------- |
+| `task`          | `string`             | **Required.** Task specifier (`"build"` or `"pkg#build"`). |
+| `recursive`     | `boolean`            | Select all workspace packages.                             |
+| `transitive`    | `boolean`            | Select current package + transitive dependencies.          |
+| `filter`        | `string \| string[]` | Select packages by filter expression(s).                   |
+| `workspaceRoot` | `boolean`            | Select the workspace root package.                         |
+
+The same validation rules from the CLI apply:
+
+- `recursive` and `transitive` are mutually exclusive.
+- `filter` cannot be combined with `recursive` or `transitive`.
+- When `task` contains a `#` (e.g. `"pkg#build"`), it cannot be combined with `recursive` or `filter`.
+
+## Context: "Current Package"
+
+When `--transitive` or a filter with traversal suffixes (e.g. `@myorg/core...`) resolves packages, "current package" means the package that owns the task containing this `dependsOn` entry — the same package that would be inferred from an unqualified `"build"` dependency today.

--- a/docs/depends-on.md
+++ b/docs/depends-on.md
@@ -29,6 +29,8 @@ These simple forms remain valid and unchanged under both proposed styles.
 
 ## Proposed Syntax
 
+Two equivalent styles are proposed.
+
 ### Style 1: CLI string syntax
 
 Each `dependsOn` element is a string (or array of strings) written exactly as you would type CLI arguments to `vp run`:
@@ -88,10 +90,10 @@ Each `dependsOn` element can be an object whose keys mirror the CLI flag names:
         "utils#build",
 
         // Run `build` across all workspace packages
-        { "recursive": true, "task": "build" },
+        { "recursive": "build" },
 
         // Run `build` in current package and its transitive dependencies
-        { "transitive": true, "task": "build" },
+        { "transitive": "build" },
 
         // Run `build` in packages matching a filter
         { "filter": "@myorg/core", "task": "build" },
@@ -101,28 +103,27 @@ Each `dependsOn` element can be an object whose keys mirror the CLI flag names:
         { "filter": ["@myorg/core", "@myorg/utils"], "task": "build" },
 
         // Workspace root
-        { "workspaceRoot": true, "task": "build" },
+        { "workspaceRoot": "build" },
       ],
     },
   },
 }
 ```
 
-**Object fields:**
+**Object forms:**
 
-| Field           | Type                 | Meaning                                                    |
-| --------------- | -------------------- | ---------------------------------------------------------- |
-| `task`          | `string`             | **Required.** Task specifier (`"build"` or `"pkg#build"`). |
-| `recursive`     | `boolean`            | Select all workspace packages.                             |
-| `transitive`    | `boolean`            | Select current package + transitive dependencies.          |
-| `filter`        | `string \| string[]` | Select packages by filter expression(s).                   |
-| `workspaceRoot` | `boolean`            | Select the workspace root package.                         |
+| Form                                               | Meaning                                                          |
+| -------------------------------------------------- | ---------------------------------------------------------------- |
+| `{ "recursive": "<task>" }`                        | Run `<task>` across all workspace packages.                      |
+| `{ "transitive": "<task>" }`                       | Run `<task>` in current package and its transitive dependencies. |
+| `{ "filter": "<pattern>", "task": "<task>" }`      | Run `<task>` in packages matching a filter expression.           |
+| `{ "filter": ["<p1>", "<p2>"], "task": "<task>" }` | Run `<task>` in packages matching multiple filters.              |
+| `{ "workspaceRoot": "<task>" }`                    | Run `<task>` in the workspace root package.                      |
 
 The same validation rules from the CLI apply:
 
-- `recursive` and `transitive` are mutually exclusive.
-- `filter` cannot be combined with `recursive` or `transitive`.
-- When `task` contains a `#` (e.g. `"pkg#build"`), it cannot be combined with `recursive` or `filter`.
+- `recursive`, `transitive`, `filter`, and `workspaceRoot` are mutually exclusive.
+- When using `filter`, the task name goes in a separate `task` field (since `filter` takes a pattern as its value).
 
 ## Context: "Current Package"
 

--- a/docs/depends-on.md
+++ b/docs/depends-on.md
@@ -25,54 +25,11 @@ The CLI already supports package selection through flags like `--recursive`, `--
 }
 ```
 
-These simple forms remain valid and unchanged under both proposed styles.
+These simple forms remain valid and unchanged.
 
 ## Proposed Syntax
 
-Two equivalent styles are proposed.
-
-### Style 1: CLI string syntax
-
-Each `dependsOn` element is a string (existing syntax) or a string array written exactly as you would type CLI arguments to `vp run`:
-
-```jsonc
-{
-  "tasks": {
-    "test": {
-      "dependsOn": [
-        // Existing syntax — still works
-        "build",
-        "utils#build",
-
-        // Run `build` across all workspace packages
-        ["--recursive", "build"],
-
-        // Run `build` in current package and its transitive dependencies
-        ["--transitive", "build"],
-
-        // Run `build` in packages matching a filter
-        ["--filter", "@myorg/core", "build"],
-        ["--filter", "@myorg/core...", "build"], // @myorg/core and its deps
-      ],
-    },
-  },
-}
-```
-
-Each element in the array is one CLI token, exactly as you would pass to `vp run`.
-
-**Supported flags:**
-
-| Flag                 | Short          | Meaning                                                            |
-| -------------------- | -------------- | ------------------------------------------------------------------ |
-| `--recursive`        | `-r`           | All workspace packages                                             |
-| `--transitive`       | `-t`           | Current package + its transitive dependencies                      |
-| `--filter <pattern>` | `-F <pattern>` | Packages matching a [filter expression](https://pnpm.io/filtering) |
-| `--workspace-root`   | `-w`           | The workspace root package                                         |
-
-Everything after the flags is the task specifier (e.g. `build`, `pkg#task`).
-
-### Style 2: Object syntax
+### Object syntax
 
 Each `dependsOn` element can be an object whose keys mirror the CLI flag names:
 
@@ -124,11 +81,3 @@ The same validation rules from the CLI apply:
 ## Context: "Current Package"
 
 When `--transitive` or a filter with traversal suffixes (e.g. `@myorg/core...`) resolves packages, "current package" means the package that owns the task containing this `dependsOn` entry — the same package that would be inferred from an unqualified `"build"` dependency today.
-
-## Comparison
-
-|                    | Style 1 (CLI string)                                           | Style 2 (Object)                                                   |
-| ------------------ | -------------------------------------------------------------- | ------------------------------------------------------------------ |
-| Learning curve     | None if you already know `vp run` — identical syntax           | Minimal — same flag names, written as JSON keys                    |
-| IDE autocompletion | Yes — TypeScript tuple types can constrain each array position | Yes — TypeScript object types can validate keys and suggest fields |
-| Config consistency | Unusual — CLI syntax embedded in config arrays                 | Consistent — matches the object style used elsewhere in the config |


### PR DESCRIPTION
## Summary

- Proposes two styles for enhanced `dependsOn` entries that reuse the existing `vp run` CLI mental model instead of inventing new symbols
- **Style 1 (CLI string):** entries written as CLI args, e.g. `"--transitive build"`, `["--filter", "@myorg/core", "build"]`
- **Style 2 (object):** keys mirror CLI flag names, e.g. `{ "transitive": true, "task": "build" }`

## Test plan

- [ ] Review RFC content for correctness and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)