### PR TITLE
refactor(fspy): gate ipc_channel_conf on non-musl targets

### DIFF
--- a/crates/fspy/src/unix/mod.rs
+++ b/crates/fspy/src/unix/mod.rs
@@ -93,8 +93,7 @@ impl SpyImpl {
         let (ipc_channel_conf, ipc_receiver) =
             channel(SHM_CAPACITY).map_err(SpawnError::ChannelCreation)?;
         #[cfg(target_env = "musl")]
-        let (_, ipc_receiver) =
-            channel(SHM_CAPACITY).map_err(SpawnError::ChannelCreation)?;
+        let (_, ipc_receiver) = channel(SHM_CAPACITY).map_err(SpawnError::ChannelCreation)?;
 
         let payload = Payload {
             #[cfg(not(target_env = "musl"))]

--- a/crates/fspy/src/unix/mod.rs
+++ b/crates/fspy/src/unix/mod.rs
@@ -89,10 +89,15 @@ impl SpyImpl {
         #[cfg(target_os = "linux")]
         let supervisor = supervise::<SyscallHandler>().map_err(SpawnError::Supervisor)?;
 
+        #[cfg(not(target_env = "musl"))]
         let (ipc_channel_conf, ipc_receiver) =
+            channel(SHM_CAPACITY).map_err(SpawnError::ChannelCreation)?;
+        #[cfg(target_env = "musl")]
+        let (_, ipc_receiver) =
             channel(SHM_CAPACITY).map_err(SpawnError::ChannelCreation)?;
 
         let payload = Payload {
+            #[cfg(not(target_env = "musl"))]
             ipc_channel_conf,
 
             #[cfg(target_os = "macos")]

--- a/crates/fspy_shared_unix/src/payload.rs
+++ b/crates/fspy_shared_unix/src/payload.rs
@@ -5,10 +5,12 @@ use bincode::{Decode, Encode, config::standard};
 use bstr::BString;
 #[cfg(not(target_env = "musl"))]
 use fspy_shared::ipc::NativeStr;
+#[cfg(not(target_env = "musl"))]
 use fspy_shared::ipc::channel::ChannelConf;
 
 #[derive(Debug, Encode, Decode)]
 pub struct Payload {
+    #[cfg(not(target_env = "musl"))]
     pub ipc_channel_conf: ChannelConf,
 
     #[cfg(not(target_env = "musl"))]


### PR DESCRIPTION
## Summary

The IPC channel sender is only used by the preload library, which isn't built on musl targets (only seccomp-based tracking is used there). Gate `Payload::ipc_channel_conf`, its `ChannelConf` import, and its creation/assignment site with `#[cfg(not(target_env = "musl"))]` so musl builds no longer carry the unused configuration.

- Field & import in `crates/fspy_shared_unix/src/payload.rs`
- Creation and struct-init in `crates/fspy/src/unix/mod.rs` — the `channel(SHM_CAPACITY)` call is still made (the `ipc_receiver` half is consumed downstream), but the conf half is bound to `_` on musl

The other reference in `crates/fspy_preload_unix/src/client/mod.rs` is already effectively gated — the entire `client` module is `#[cfg(all(unix, not(target_env = "musl")))]` via `crates/fspy_preload_unix/src/lib.rs`.

## Test plan

- [x] `cargo check --workspace --all-features` (host glibc target)
- [x] `cargo check --workspace --all-features --target x86_64-unknown-linux-musl`
- [x] `cargo clippy -p fspy_shared_unix -p fspy --all-features --all-targets -- -D warnings`

https://claude.ai/code/session_01VqiMHiGeViu1pGhWwJ67Qc