### PR TITLE
refactor(fspy): gate ipc channel module on non-musl targets

### DIFF
--- a/crates/fspy/src/lib.rs
+++ b/crates/fspy/src/lib.rs
@@ -8,6 +8,7 @@ mod artifact;
 
 pub mod error;
 
+#[cfg(not(target_env = "musl"))]
 mod ipc;
 
 #[cfg(unix)]

--- a/crates/fspy/src/unix/mod.rs
+++ b/crates/fspy/src/unix/mod.rs
@@ -8,9 +8,9 @@ use std::{io, path::Path};
 
 #[cfg(target_os = "linux")]
 use fspy_seccomp_unotify::supervisor::supervise;
+use fspy_shared::ipc::PathAccess;
 #[cfg(not(target_env = "musl"))]
-use fspy_shared::ipc::NativeStr;
-use fspy_shared::ipc::{PathAccess, channel::channel};
+use fspy_shared::ipc::{NativeStr, channel::channel};
 #[cfg(target_os = "macos")]
 use fspy_shared_unix::payload::Artifacts;
 use fspy_shared_unix::{
@@ -24,12 +24,9 @@ use syscall_handler::SyscallHandler;
 use tokio::task::spawn_blocking;
 use tokio_util::sync::CancellationToken;
 
-use crate::{
-    ChildTermination, Command, TrackedChild,
-    arena::PathAccessArena,
-    error::SpawnError,
-    ipc::{OwnedReceiverLockGuard, SHM_CAPACITY},
-};
+#[cfg(not(target_env = "musl"))]
+use crate::ipc::{OwnedReceiverLockGuard, SHM_CAPACITY};
+use crate::{ChildTermination, Command, TrackedChild, arena::PathAccessArena, error::SpawnError};
 
 #[derive(Debug)]
 pub struct SpyImpl {
@@ -92,8 +89,6 @@ impl SpyImpl {
         #[cfg(not(target_env = "musl"))]
         let (ipc_channel_conf, ipc_receiver) =
             channel(SHM_CAPACITY).map_err(SpawnError::ChannelCreation)?;
-        #[cfg(target_env = "musl")]
-        let (_, ipc_receiver) = channel(SHM_CAPACITY).map_err(SpawnError::ChannelCreation)?;
 
         let payload = Payload {
             #[cfg(not(target_env = "musl"))]
@@ -174,9 +169,14 @@ impl SpyImpl {
 
                 // Lock the ipc channel after the child has exited.
                 // We are not interested in path accesses from descendants after the main child has exited.
+                #[cfg(not(target_env = "musl"))]
                 let ipc_receiver_lock_guard =
                     OwnedReceiverLockGuard::lock_async(ipc_receiver).await?;
-                let path_accesses = PathAccessIterable { arenas, ipc_receiver_lock_guard };
+                let path_accesses = PathAccessIterable {
+                    arenas,
+                    #[cfg(not(target_env = "musl"))]
+                    ipc_receiver_lock_guard,
+                };
 
                 io::Result::Ok(ChildTermination { status, path_accesses })
             })
@@ -188,6 +188,7 @@ impl SpyImpl {
 
 pub struct PathAccessIterable {
     arenas: Vec<PathAccessArena>,
+    #[cfg(not(target_env = "musl"))]
     ipc_receiver_lock_guard: OwnedReceiverLockGuard,
 }
 
@@ -196,7 +197,14 @@ impl PathAccessIterable {
         let accesses_in_arena =
             self.arenas.iter().flat_map(|arena| arena.borrow_accesses().iter()).copied();
 
-        let accesses_in_shm = self.ipc_receiver_lock_guard.iter_path_accesses();
-        accesses_in_shm.chain(accesses_in_arena)
+        #[cfg(not(target_env = "musl"))]
+        {
+            let accesses_in_shm = self.ipc_receiver_lock_guard.iter_path_accesses();
+            accesses_in_shm.chain(accesses_in_arena)
+        }
+        #[cfg(target_env = "musl")]
+        {
+            accesses_in_arena
+        }
     }
 }

--- a/crates/fspy_shared/src/ipc/mod.rs
+++ b/crates/fspy_shared/src/ipc/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_env = "musl"))]
 pub mod channel;
 mod native_path;
 pub(crate) mod native_str;

--- a/crates/fspy_shared_unix/src/payload.rs
+++ b/crates/fspy_shared_unix/src/payload.rs
@@ -20,7 +20,10 @@ pub struct Payload {
     pub artifacts: Artifacts,
 
     #[cfg(target_os = "linux")]
-    #[expect(clippy::struct_field_names, reason = "descriptive field name for clarity")]
+    #[cfg_attr(
+        not(target_env = "musl"),
+        expect(clippy::struct_field_names, reason = "descriptive field name for clarity")
+    )]
     pub seccomp_payload: fspy_seccomp_unotify::payload::SeccompPayload,
 }
 


### PR DESCRIPTION
## Summary

Gate the entire `fspy_shared::ipc::channel` module behind `#[cfg(not(target_env = "musl"))]`. The shared-memory IPC channel exists to move path accesses from the preload library to the supervisor, but on musl targets the preload library isn't built (seccomp-only tracking is used). With no senders, the channel produces no data, and creating it on musl just wastes a 4 GiB shared-memory region, a lock file, and a blocking receiver-lock step after the child exits.

### Changes
- `fspy_shared::ipc::channel` module is now non-musl only
- `fspy::ipc` (re-exports `OwnedReceiverLockGuard`, `SHM_CAPACITY`) is non-musl only
- `fspy::unix::SpyImpl::spawn` skips channel creation on musl
- `PathAccessIterable` drops its `ipc_receiver_lock_guard` field on musl; `iter()` only yields arena-collected accesses there
- Fixed latent issue exposed by this PR: `Payload::seccomp_payload`'s `struct_field_names` `#[expect]` is now `#[cfg_attr(not(target_env = "musl"), ...)]` since on musl `Payload` has only this one field and clippy's `struct_field_names` lint no longer fires

Windows paths are untouched — they never satisfy `target_env = "musl"`.

## Test plan

- [x] `cargo check --workspace --all-features` on host (glibc)
- [x] `cargo check --workspace --all-features --target x86_64-unknown-linux-musl`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` on host
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --document-private-items`
- [x] `cargo test -p fspy_shared -p fspy_shared_unix` (24 pass)
- [x] `cargo test -p fspy --test node_fs` — exercises the full spawn + IPC pipeline (8 pass)

https://claude.ai/code/session_01VqiMHiGeViu1pGhWwJ67Qc