### PR TITLE
refactor(fspy): also gate ipc channel module out on android

### DIFF
--- a/crates/fspy/src/lib.rs
+++ b/crates/fspy/src/lib.rs
@@ -8,7 +8,7 @@ mod artifact;
 
 pub mod error;
 
-#[cfg(not(target_env = "musl"))]
+#[cfg(all(not(target_os = "android"), not(target_env = "musl")))]
 mod ipc;
 
 #[cfg(unix)]

--- a/crates/fspy/src/unix/mod.rs
+++ b/crates/fspy/src/unix/mod.rs
@@ -8,9 +8,11 @@ use std::{io, path::Path};
 
 #[cfg(target_os = "linux")]
 use fspy_seccomp_unotify::supervisor::supervise;
-use fspy_shared::ipc::PathAccess;
 #[cfg(not(target_env = "musl"))]
-use fspy_shared::ipc::{NativeStr, channel::channel};
+use fspy_shared::ipc::NativeStr;
+use fspy_shared::ipc::PathAccess;
+#[cfg(all(not(target_os = "android"), not(target_env = "musl")))]
+use fspy_shared::ipc::channel::channel;
 #[cfg(target_os = "macos")]
 use fspy_shared_unix::payload::Artifacts;
 use fspy_shared_unix::{
@@ -24,7 +26,7 @@ use syscall_handler::SyscallHandler;
 use tokio::task::spawn_blocking;
 use tokio_util::sync::CancellationToken;
 
-#[cfg(not(target_env = "musl"))]
+#[cfg(all(not(target_os = "android"), not(target_env = "musl")))]
 use crate::ipc::{OwnedReceiverLockGuard, SHM_CAPACITY};
 use crate::{ChildTermination, Command, TrackedChild, arena::PathAccessArena, error::SpawnError};
 
@@ -86,12 +88,12 @@ impl SpyImpl {
         #[cfg(target_os = "linux")]
         let supervisor = supervise::<SyscallHandler>().map_err(SpawnError::Supervisor)?;
 
-        #[cfg(not(target_env = "musl"))]
+        #[cfg(all(not(target_os = "android"), not(target_env = "musl")))]
         let (ipc_channel_conf, ipc_receiver) =
             channel(SHM_CAPACITY).map_err(SpawnError::ChannelCreation)?;
 
         let payload = Payload {
-            #[cfg(not(target_env = "musl"))]
+            #[cfg(all(not(target_os = "android"), not(target_env = "musl")))]
             ipc_channel_conf,
 
             #[cfg(target_os = "macos")]
@@ -169,12 +171,12 @@ impl SpyImpl {
 
                 // Lock the ipc channel after the child has exited.
                 // We are not interested in path accesses from descendants after the main child has exited.
-                #[cfg(not(target_env = "musl"))]
+                #[cfg(all(not(target_os = "android"), not(target_env = "musl")))]
                 let ipc_receiver_lock_guard =
                     OwnedReceiverLockGuard::lock_async(ipc_receiver).await?;
                 let path_accesses = PathAccessIterable {
                     arenas,
-                    #[cfg(not(target_env = "musl"))]
+                    #[cfg(all(not(target_os = "android"), not(target_env = "musl")))]
                     ipc_receiver_lock_guard,
                 };
 
@@ -188,7 +190,7 @@ impl SpyImpl {
 
 pub struct PathAccessIterable {
     arenas: Vec<PathAccessArena>,
-    #[cfg(not(target_env = "musl"))]
+    #[cfg(all(not(target_os = "android"), not(target_env = "musl")))]
     ipc_receiver_lock_guard: OwnedReceiverLockGuard,
 }
 
@@ -197,12 +199,12 @@ impl PathAccessIterable {
         let accesses_in_arena =
             self.arenas.iter().flat_map(|arena| arena.borrow_accesses().iter()).copied();
 
-        #[cfg(not(target_env = "musl"))]
+        #[cfg(all(not(target_os = "android"), not(target_env = "musl")))]
         {
             let accesses_in_shm = self.ipc_receiver_lock_guard.iter_path_accesses();
             accesses_in_shm.chain(accesses_in_arena)
         }
-        #[cfg(target_env = "musl")]
+        #[cfg(any(target_os = "android", target_env = "musl"))]
         {
             accesses_in_arena
         }

--- a/crates/fspy_shared/src/ipc/mod.rs
+++ b/crates/fspy_shared/src/ipc/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(not(target_env = "musl"))]
+#[cfg(all(not(target_os = "android"), not(target_env = "musl")))]
 pub mod channel;
 mod native_path;
 pub(crate) mod native_str;

--- a/crates/fspy_shared_unix/src/payload.rs
+++ b/crates/fspy_shared_unix/src/payload.rs
@@ -5,12 +5,12 @@ use bincode::{Decode, Encode, config::standard};
 use bstr::BString;
 #[cfg(not(target_env = "musl"))]
 use fspy_shared::ipc::NativeStr;
-#[cfg(not(target_env = "musl"))]
+#[cfg(all(not(target_os = "android"), not(target_env = "musl")))]
 use fspy_shared::ipc::channel::ChannelConf;
 
 #[derive(Debug, Encode, Decode)]
 pub struct Payload {
-    #[cfg(not(target_env = "musl"))]
+    #[cfg(all(not(target_os = "android"), not(target_env = "musl")))]
     pub ipc_channel_conf: ChannelConf,
 
     #[cfg(not(target_env = "musl"))]


### PR DESCRIPTION
## Summary

Extend the `not(target_env = "musl")` gate on `fspy_shared::ipc::channel` (and all downstream `ChannelConf`/`channel()` references) to also exclude `target_os = "android"`. On both musl and android, the preload library's IPC channel is unavailable, so the shared-memory channel module has no purpose there.

- `fspy_shared::ipc::channel` module gated on `all(not(target_os = "android"), not(target_env = "musl"))`
- `fspy::ipc` module (which re-exports `OwnedReceiverLockGuard` and `SHM_CAPACITY`) similarly gated
- `fspy::unix::SpyImpl::spawn` channel creation, `Payload::ipc_channel_conf` field init, `ipc_receiver_lock_guard` creation and field, `PathAccessIterable::iter()` branch — all updated
- `Payload::ipc_channel_conf` field and `ChannelConf` import in `fspy_shared_unix::payload` — updated

Preload-library gates (`preload_path`, `NativeStr` import, `PRELOAD_CDYLIB_BINARY`, `fspy_preload_unix`) are left untouched — they remain musl-only for this PR.

## Test plan

- [x] `cargo check --workspace --all-features --all-targets --locked` on host (glibc)
- [x] `cargo check --workspace --all-features --target x86_64-unknown-linux-musl`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --document-private-items`
- [x] `cargo test -p fspy --test node_fs` (exercises full spawn + IPC pipeline, 8 pass)

https://claude.ai/code/session_01VqiMHiGeViu1pGhWwJ67Qc