### PR TITLE
fix(fspy): ignore malformed tracked paths without panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- **Fixed** Windows file access tracking no longer panics when a task touches malformed paths that cannot be represented as workspace-relative inputs ([#325](https://github.com/voidzero-dev/vite-task/issues/325))
+- **Fixed** Windows file access tracking no longer panics when a task touches malformed paths that cannot be represented as workspace-relative inputs ([#325](https://github.com/voidzero-dev/vite-task/pull/330))
 - **Fixed** `vp run --cache` now supports running without a task specifier and opens the interactive task selector, matching bare `vp run` behavior ([#312](https://github.com/voidzero-dev/vite-task/pull/313))
 - **Fixed** Ctrl-C now prevents future tasks from being scheduled and prevents caching of in-flight task results ([#309](https://github.com/voidzero-dev/vite-task/pull/309))
 - **Added** `--concurrency-limit` flag to limit the number of tasks running at the same time (defaults to 4) ([#288](https://github.com/voidzero-dev/vite-task/pull/288), [#309](https://github.com/voidzero-dev/vite-task/pull/309))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- **Fixed** Windows file access tracking no longer panics when a task touches malformed paths that cannot be represented as workspace-relative inputs ([#325](https://github.com/voidzero-dev/vite-task/pull/330))
+- **Fixed** Windows file access tracking no longer panics when a task touches malformed paths that cannot be represented as workspace-relative inputs ([#330](https://github.com/voidzero-dev/vite-task/pull/330))
 - **Fixed** `vp run --cache` now supports running without a task specifier and opens the interactive task selector, matching bare `vp run` behavior ([#312](https://github.com/voidzero-dev/vite-task/pull/313))
 - **Fixed** Ctrl-C now prevents future tasks from being scheduled and prevents caching of in-flight task results ([#309](https://github.com/voidzero-dev/vite-task/pull/309))
 - **Added** `--concurrency-limit` flag to limit the number of tasks running at the same time (defaults to 4) ([#288](https://github.com/voidzero-dev/vite-task/pull/288), [#309](https://github.com/voidzero-dev/vite-task/pull/309))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- **Fixed** Windows file access tracking no longer panics when a task touches malformed paths that cannot be represented as workspace-relative inputs ([#325](https://github.com/voidzero-dev/vite-task/issues/325))
 - **Fixed** `vp run --cache` now supports running without a task specifier and opens the interactive task selector, matching bare `vp run` behavior ([#312](https://github.com/voidzero-dev/vite-task/pull/313))
 - **Fixed** Ctrl-C now prevents future tasks from being scheduled and prevents caching of in-flight task results ([#309](https://github.com/voidzero-dev/vite-task/pull/309))
 - **Added** `--concurrency-limit` flag to limit the number of tasks running at the same time (defaults to 4) ([#288](https://github.com/voidzero-dev/vite-task/pull/288), [#309](https://github.com/voidzero-dev/vite-task/pull/309))

--- a/crates/vite_path/src/relative.rs
+++ b/crates/vite_path/src/relative.rs
@@ -77,7 +77,6 @@ impl RelativePath {
     /// Returns an error if the cleaned path is no longer a valid relative path.
     /// This can happen on Windows when malformed inputs such as `foo/C:/bar`
     /// are cleaned into drive-prefixed paths.
-    #[must_use]
     pub fn clean(&self) -> Result<RelativePathBuf, FromPathError> {
         use path_clean::PathClean as _;
 

--- a/crates/vite_path/src/relative.rs
+++ b/crates/vite_path/src/relative.rs
@@ -72,16 +72,17 @@ impl RelativePath {
     /// yields `a/c` instead of the correct `x/c`. Use
     /// [`std::fs::canonicalize`] when you need symlink-correct resolution.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the cleaned path is no longer a valid relative path, which
-    /// should never happen in practice.
+    /// Returns an error if the cleaned path is no longer a valid relative path.
+    /// This can happen on Windows when malformed inputs such as `foo/C:/bar`
+    /// are cleaned into drive-prefixed paths.
     #[must_use]
-    pub fn clean(&self) -> RelativePathBuf {
+    pub fn clean(&self) -> Result<RelativePathBuf, FromPathError> {
         use path_clean::PathClean as _;
 
         let cleaned = self.as_path().clean();
-        RelativePathBuf::new(cleaned).expect("cleaning a relative path preserves relativity")
+        RelativePathBuf::new(cleaned)
     }
 
     /// Returns a path that, when joined onto `base`, yields `self`.
@@ -439,6 +440,20 @@ mod tests {
         let rel_path = RelativePathBuf::new("").unwrap();
         let joined_path = rel_path.as_relative_path().join(RelativePathBuf::new("baz").unwrap());
         assert_eq!(joined_path.as_str(), "baz");
+    }
+
+    #[test]
+    fn clean() {
+        let rel_path = RelativePathBuf::new("../foo/../bar").unwrap();
+        let cleaned = rel_path.clean().unwrap();
+        assert_eq!(cleaned.as_str(), "../bar");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn clean_malformed_drive_path() {
+        let rel_path = RelativePathBuf::new(r"foo\C:\bar").unwrap();
+        let_assert!(Err(FromPathError::NonRelative) = rel_path.clean());
     }
 
     #[test]

--- a/crates/vite_task/src/session/execute/spawn.rs
+++ b/crates/vite_task/src/session/execute/spawn.rs
@@ -3,7 +3,6 @@
 use std::{
     collections::hash_map::Entry,
     io::Write,
-    path::Path,
     process::{ExitStatus, Stdio},
     time::{Duration, Instant},
 };
@@ -58,8 +57,12 @@ pub struct TrackedPathAccesses {
     pub path_writes: FxHashSet<RelativePathBuf>,
 }
 
+#[expect(
+    clippy::disallowed_types,
+    reason = "fspy strip_path_prefix exposes std::path::Path; convert to RelativePathBuf immediately"
+)]
 fn normalize_tracked_workspace_path(
-    stripped_path: &Path,
+    stripped_path: &std::path::Path,
     resolved_negatives: &[wax::Glob<'static>],
 ) -> Option<RelativePathBuf> {
     // On Windows, paths are possible to be still absolute after stripping the workspace root.
@@ -317,7 +320,8 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn malformed_windows_drive_path_after_workspace_strip_is_ignored() {
-        let relative_path = normalize_tracked_workspace_path(Path::new(r"foo\C:\bar"), &[]);
+        let relative_path =
+            normalize_tracked_workspace_path(std::path::Path::new(r"foo\C:\bar"), &[]);
         assert!(relative_path.is_none());
     }
 }

--- a/crates/vite_task/src/session/execute/spawn.rs
+++ b/crates/vite_task/src/session/execute/spawn.rs
@@ -70,7 +70,7 @@ fn normalize_tracked_workspace_path(
     // Clean `..` components — fspy may report paths like
     // `packages/sub-pkg/../shared/dist/output.js`. Normalize them for
     // consistent behavior across platforms and clean user-facing messages.
-    let relative = relative.clean();
+    let relative = relative.clean().ok()?;
 
     // Skip .git directory accesses (workaround for tools like oxlint)
     if relative.as_path().strip_prefix(".git").is_ok() {

--- a/crates/vite_task/src/session/execute/spawn.rs
+++ b/crates/vite_task/src/session/execute/spawn.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::hash_map::Entry,
     io::Write,
+    path::Path,
     process::{ExitStatus, Stdio},
     time::{Duration, Instant},
 };
@@ -55,6 +56,34 @@ pub struct TrackedPathAccesses {
 
     /// Tracked path writes
     pub path_writes: FxHashSet<RelativePathBuf>,
+}
+
+fn normalize_tracked_workspace_path(
+    stripped_path: &Path,
+    resolved_negatives: &[wax::Glob<'static>],
+) -> Option<RelativePathBuf> {
+    // On Windows, paths are possible to be still absolute after stripping the workspace root.
+    // For example: c:\workspace\subdir\c:\workspace\subdir
+    // Just ignore those accesses.
+    let relative = RelativePathBuf::new(stripped_path).ok()?;
+
+    // Clean `..` components — fspy may report paths like
+    // `packages/sub-pkg/../shared/dist/output.js`. Normalize them for
+    // consistent behavior across platforms and clean user-facing messages.
+    let relative = relative.clean();
+
+    // Skip .git directory accesses (workaround for tools like oxlint)
+    if relative.as_path().strip_prefix(".git").is_ok() {
+        return None;
+    }
+
+    if !resolved_negatives.is_empty()
+        && resolved_negatives.iter().any(|neg| neg.is_match(relative.as_str()))
+    {
+        return None;
+    }
+
+    Some(relative)
 }
 
 /// How the child process is awaited after stdout/stderr are drained.
@@ -231,28 +260,7 @@ pub async fn spawn_with_tracking(
                     let Ok(stripped_path) = strip_result else {
                         return None;
                     };
-                    // On Windows, paths are possible to be still absolute after stripping the workspace root.
-                    // For example: c:\workspace\subdir\c:\workspace\subdir
-                    // Just ignore those accesses.
-                    let relative = RelativePathBuf::new(stripped_path).ok()?;
-
-                    // Clean `..` components — fspy may report paths like
-                    // `packages/sub-pkg/../shared/dist/output.js`. Normalize them for
-                    // consistent behavior across platforms and clean user-facing messages.
-                    let relative = relative.clean();
-
-                    // Skip .git directory accesses (workaround for tools like oxlint)
-                    if relative.as_path().strip_prefix(".git").is_ok() {
-                        return None;
-                    }
-
-                    if !resolved_negatives.is_empty()
-                        && resolved_negatives.iter().any(|neg| neg.is_match(relative.as_str()))
-                    {
-                        return None;
-                    }
-
-                    Some(relative)
+                    normalize_tracked_workspace_path(stripped_path, resolved_negatives)
                 });
 
                 let Some(relative_path) = relative_path else {
@@ -298,5 +306,18 @@ pub async fn spawn_with_tracking(
             };
             Ok(SpawnResult { exit_status, duration: start.elapsed() })
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(windows)]
+    use super::*;
+
+    #[cfg(windows)]
+    #[test]
+    fn malformed_windows_drive_path_after_workspace_strip_is_ignored() {
+        let relative_path = normalize_tracked_workspace_path(Path::new(r"foo\C:\bar"), &[]);
+        assert!(relative_path.is_none());
     }
 }

--- a/crates/vite_task/src/session/execute/spawn.rs
+++ b/crates/vite_task/src/session/execute/spawn.rs
@@ -320,6 +320,10 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn malformed_windows_drive_path_after_workspace_strip_is_ignored() {
+        #[expect(
+            clippy::disallowed_types,
+            reason = "normalize_tracked_workspace_path requires std::path::Path for fspy strip_path_prefix output"
+        )]
         let relative_path =
             normalize_tracked_workspace_path(std::path::Path::new(r"foo\C:\bar"), &[]);
         assert!(relative_path.is_none());

--- a/crates/vite_task/src/session/mod.rs
+++ b/crates/vite_task/src/session/mod.rs
@@ -345,21 +345,18 @@ impl<'a> Session<'a> {
                 // created with CREATE_NEW_PROCESS_GROUP, which sets a per-process
                 // flag that silently drops CTRL_C_EVENT before it reaches
                 // registered handlers. Clear it so our handler fires.
+                //
+                // SAFETY: Passing (None, FALSE) clears the inherited
+                // CTRL_C ignore flag.
                 #[cfg(windows)]
-                {
-                    // SAFETY: Passing (None, FALSE) clears the inherited
-                    // CTRL_C ignore flag.
+                unsafe {
                     unsafe extern "system" {
                         fn SetConsoleCtrlHandler(
                             handler: Option<unsafe extern "system" fn(u32) -> i32>,
                             add: i32,
                         ) -> i32;
                     }
-                    // SAFETY: Passing (None, FALSE) clears the inherited
-                    // CTRL_C ignore flag.
-                    unsafe {
-                        SetConsoleCtrlHandler(None, 0);
-                    }
+                    SetConsoleCtrlHandler(None, 0);
                 }
                 let interrupt_token = tokio_util::sync::CancellationToken::new();
                 let ct = interrupt_token.clone();

--- a/crates/vite_task/src/session/mod.rs
+++ b/crates/vite_task/src/session/mod.rs
@@ -355,6 +355,8 @@ impl<'a> Session<'a> {
                             add: i32,
                         ) -> i32;
                     }
+                    // SAFETY: Passing (None, FALSE) clears the inherited
+                    // CTRL_C ignore flag.
                     unsafe {
                         SetConsoleCtrlHandler(None, 0);
                     }

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/malformed-fspy-path/package.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/malformed-fspy-path/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "malformed-fspy-path",
+  "private": true
+}

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/malformed-fspy-path/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/malformed-fspy-path/snapshots.toml
@@ -1,0 +1,7 @@
+# Windows-only repro for issue 325: a malformed observed path must not panic
+# when fspy input inference normalizes workspace-relative accesses.
+
+[[e2e]]
+name = "malformed observed path does not panic"
+platform = "windows"
+steps = [{ argv = ["vt", "run", "read-malformed-path"], envs = [["TEMP", "."], ["TMP", "."]] }]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/malformed-fspy-path/snapshots/malformed observed path does not panic.snap
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/malformed-fspy-path/snapshots/malformed observed path does not panic.snap
@@ -1,0 +1,7 @@
+---
+source: crates/vite_task_bin/tests/e2e_snapshots/main.rs
+expression: e2e_outputs
+---
+> TEMP=. TMP=. vt run read-malformed-path
+$ vtt print-file foo/C:/bar
+foo/C:/bar: not found

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/malformed-fspy-path/vite-task.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/malformed-fspy-path/vite-task.json
@@ -1,0 +1,13 @@
+{
+  "tasks": {
+    "read-malformed-path": {
+      "command": "vtt print-file foo/C:/bar",
+      "cache": true,
+      "input": [
+        {
+          "auto": true
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #325.

Windows file access tracking could panic when fspy observed a malformed path such as `foo/C:/bar`. The path is initially accepted as relative, but lexical cleanup can turn it into a drive-prefixed path that no longer satisfies `RelativePath` invariants.

- Make `RelativePath::clean()` fallible instead of panicking when cleanup produces a non-relative path
- Ignore fspy-observed paths that cannot be represented as valid workspace-relative inputs after cleanup
- Add a unit repro for the malformed Windows drive-path case
- Add a Windows-only E2E snapshot repro through the fspy input-inference path
- Add a changelog entry

## Test plan

- [x] `cargo test -p vite_path clean_malformed_drive_path`
- [x] `cargo test -p vite_task malformed_windows_drive_path_after_workspace_strip_is_ignored`
- [x] `cargo test -p vite_task_bin --test e2e_snapshots -- malformed-fspy-path`
- [x] `cargo check -p vite_path -p vite_task`