### PR TITLE
Consolidate workspace dependencies and add cargo-autoinherit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,11 +210,12 @@ jobs:
         with:
           save-cache: ${{ github.ref_name == 'main' }}
           cache-key: fmt
-          tools: cargo-shear@1.11.1
+          tools: cargo-shear@1.11.1,cargo-autoinherit
           components: clippy rust-docs rustfmt
 
       - uses: oxc-project/setup-node@fdbf0dfd334c4e6d56ceeb77d91c76339c2a0885 # v1.0.4
       - run: pnpm oxfmt --check
+      - run: cargo autoinherit && git diff --exit-code
       - run: cargo shear --deny-warnings
       - run: cargo fmt --check
       - run: RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --document-private-items

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
         with:
           save-cache: ${{ github.ref_name == 'main' }}
           cache-key: fmt
-          tools: cargo-shear@1.11.1,cargo-autoinherit
+          tools: cargo-shear@1.11.1,cargo-autoinherit@0.1.6
           components: clippy rust-docs rustfmt
 
       - uses: oxc-project/setup-node@fdbf0dfd334c4e6d56ceeb77d91c76339c2a0885 # v1.0.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,8 @@ widestring = "1.2.0"
 winapi = "0.3.9"
 winsafe = { version = "0.0.24", features = ["kernel"] }
 xxhash-rust = { version = "0.8.15", features = ["const_xxh3"] }
+ntest = "0.9.5"
+terminal_size = "0.4"
 
 [workspace.metadata.cargo-shear]
 ignored = [

--- a/crates/pty_terminal/Cargo.toml
+++ b/crates/pty_terminal/Cargo.toml
@@ -15,9 +15,9 @@ vt100 = { workspace = true }
 [dev-dependencies]
 ctor = { workspace = true }
 ctrlc = { workspace = true }
-ntest = "0.9.5"
+ntest = { workspace = true }
 subprocess_test = { workspace = true, features = ["portable-pty"] }
-terminal_size = "0.4"
+terminal_size = { workspace = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 nix = { workspace = true }

--- a/crates/pty_terminal_test/Cargo.toml
+++ b/crates/pty_terminal_test/Cargo.toml
@@ -16,7 +16,7 @@ pty_terminal_test_client = { workspace = true }
 [dev-dependencies]
 crossterm = { workspace = true }
 ctor = { workspace = true }
-ntest = "0.9.5"
+ntest = { workspace = true }
 pty_terminal_test_client = { workspace = true, features = ["testing"] }
 subprocess_test = { workspace = true, features = ["portable-pty"] }
 

--- a/crates/vite_select/Cargo.toml
+++ b/crates/vite_select/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 anyhow = { workspace = true }
 crossterm = { workspace = true }
 nucleo-matcher = { workspace = true }
-vite_str = { path = "../vite_str" }
+vite_str = { workspace = true }
 
 [dev-dependencies]
 assert2 = { workspace = true }

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ _default:
 alias r := ready
 
 init:
-  cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear@1.11.1 taplo-cli -y
+  cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear@1.11.1 cargo-autoinherit taplo-cli -y
 
 ready:
   git diff --exit-code --quiet
@@ -24,6 +24,7 @@ watch *args='':
   watchexec --no-vcs-ignore {{args}}
 
 fmt:
+  cargo autoinherit
   cargo shear --fix
   cargo fmt --all
   pnpm oxfmt


### PR DESCRIPTION
## Summary
This PR consolidates dependency management by moving dev-dependencies to the workspace root and ensuring all crates reference them consistently. It also introduces `cargo-autoinherit` to the development toolchain for automated workspace dependency inheritance.

## Key Changes
- **Workspace dependency consolidation**: Moved `ntest` and `terminal_size` from individual crate `Cargo.toml` files to the workspace root, allowing all crates to reference them via `{ workspace = true }`
- **Updated crate dependencies**: 
  - `crates/pty_terminal/Cargo.toml`: Changed `ntest` and `terminal_size` to use workspace inheritance
  - `crates/pty_terminal_test/Cargo.toml`: Changed `ntest` to use workspace inheritance
  - `crates/vite_select/Cargo.toml`: Changed `vite_str` to use workspace inheritance
- **Added cargo-autoinherit tooling**: 
  - Integrated `cargo-autoinherit@0.1.6` into CI pipeline
  - Added to development initialization script (`justfile`)
  - Added automated check in CI to ensure workspace dependencies are properly inherited
  - Integrated into the `fmt` recipe for automatic dependency inheritance during formatting

## Notable Details
The `cargo-autoinherit` tool is now part of the development workflow and CI checks, ensuring that workspace dependencies are consistently applied across all crates and preventing manual inconsistencies in dependency declarations.

https://claude.ai/code/session_01PCwRbvAEXdAD7ieDyKe7pb