### PR TITLE
refactor: migrate from bincode to wincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,26 +189,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,6 +745,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
@@ -778,6 +768,20 @@ name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
  "fnv",
  "ident_case",
@@ -807,6 +811,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.114",
 ]
@@ -1158,7 +1173,6 @@ version = "0.1.0"
 dependencies = [
  "allocator-api2",
  "anyhow",
- "bincode",
  "bstr",
  "bumpalo",
  "const_format",
@@ -1188,6 +1202,7 @@ dependencies = [
  "tokio-util",
  "which",
  "winapi",
+ "wincode",
  "winsafe 0.0.24",
  "xxhash-rust",
 ]
@@ -1219,20 +1234,19 @@ name = "fspy_preload_unix"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "bincode",
  "bstr",
  "ctor",
  "fspy_shared",
  "fspy_shared_unix",
  "libc",
  "nix 0.30.1",
+ "wincode",
 ]
 
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
 dependencies = [
- "bincode",
  "constcat",
  "fspy_detours_sys",
  "fspy_shared",
@@ -1241,6 +1255,7 @@ dependencies = [
  "tempfile",
  "widestring",
  "winapi",
+ "wincode",
  "winsafe 0.0.24",
 ]
 
@@ -1249,7 +1264,6 @@ name = "fspy_seccomp_unotify"
 version = "0.1.0"
 dependencies = [
  "assertables",
- "bincode",
  "futures-util",
  "libc",
  "nix 0.30.1",
@@ -1260,6 +1274,7 @@ dependencies = [
  "test-log",
  "tokio",
  "tracing",
+ "wincode",
 ]
 
 [[package]]
@@ -1268,7 +1283,6 @@ version = "0.0.0"
 dependencies = [
  "allocator-api2",
  "assert2",
- "bincode",
  "bitflags 2.10.0",
  "bstr",
  "bytemuck",
@@ -1281,6 +1295,7 @@ dependencies = [
  "tracing",
  "uuid",
  "winapi",
+ "wincode",
 ]
 
 [[package]]
@@ -1289,7 +1304,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "base64",
- "bincode",
  "bstr",
  "elf",
  "fspy_seccomp_unotify",
@@ -1298,6 +1312,7 @@ dependencies = [
  "nix 0.30.1",
  "phf",
  "stackalloc",
+ "wincode",
 ]
 
 [[package]]
@@ -3276,11 +3291,11 @@ name = "subprocess_test"
 version = "0.0.0"
 dependencies = [
  "base64",
- "bincode",
  "ctor",
  "fspy",
  "portable-pty",
  "rustc-hash",
+ "wincode",
 ]
 
 [[package]]
@@ -3799,12 +3814,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "utf8-chars"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3860,12 +3869,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
-
-[[package]]
 name = "vite_glob"
 version = "0.0.0"
 dependencies = [
@@ -3889,7 +3892,6 @@ name = "vite_path"
 version = "0.1.0"
 dependencies = [
  "assert2",
- "bincode",
  "diff-struct",
  "path-clean",
  "ref-cast",
@@ -3897,6 +3899,7 @@ dependencies = [
  "thiserror 2.0.18",
  "ts-rs",
  "vite_str",
+ "wincode",
 ]
 
 [[package]]
@@ -3914,23 +3917,23 @@ dependencies = [
 name = "vite_shell"
 version = "0.0.0"
 dependencies = [
- "bincode",
  "brush-parser",
  "diff-struct",
  "serde",
  "shell-escape",
  "vite_str",
+ "wincode",
 ]
 
 [[package]]
 name = "vite_str"
 version = "0.1.0"
 dependencies = [
- "bincode",
  "compact_str",
  "diff-struct",
  "serde",
  "ts-rs",
+ "wincode",
 ]
 
 [[package]]
@@ -3939,7 +3942,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bincode",
  "bstr",
  "clap",
  "ctrlc",
@@ -3970,6 +3972,7 @@ dependencies = [
  "vite_workspace",
  "wax",
  "winapi",
+ "wincode",
 ]
 
 [[package]]
@@ -4010,7 +4013,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bincode",
  "monostate",
  "petgraph",
  "pretty_assertions",
@@ -4025,6 +4027,7 @@ dependencies = [
  "vite_str",
  "vite_workspace",
  "wax",
+ "wincode",
 ]
 
 [[package]]
@@ -4033,7 +4036,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bincode",
  "clap",
  "copy_dir",
  "cow-utils",
@@ -4061,6 +4063,7 @@ dependencies = [
  "vite_task_graph",
  "vite_workspace",
  "which",
+ "wincode",
 ]
 
 [[package]]
@@ -4399,6 +4402,30 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wincode"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5cec722a3274e47d1524cbe2cea762f2c19d615bd9d73ada21db9066349d57e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "thiserror 2.0.18",
+ "wincode-derive",
+]
+
+[[package]]
+name = "wincode-derive"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8961eb04054a1b2e026b5628e24da7e001350249a787e1a85aa961f33dc5f286"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "windows"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -149,7 +149,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -205,7 +205,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -278,7 +278,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -331,7 +331,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -364,7 +364,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -461,7 +461,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -774,7 +774,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -788,7 +788,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -801,7 +801,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -812,7 +812,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -823,7 +823,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -834,7 +834,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -871,7 +871,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.114",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -1378,7 +1378,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1625,7 +1625,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1956,7 +1956,7 @@ checksum = "23f5b99488110875b5904839d396c2cdfaf241ff6622638acb879cc7effad5de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2167,7 +2167,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2300,7 +2300,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2345,6 +2345,12 @@ dependencies = [
  "libc",
  "tokio",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "path-clean"
@@ -2409,7 +2415,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2475,7 +2481,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2573,7 +2579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2602,7 +2608,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "version_check",
  "yansi",
 ]
@@ -2643,9 +2649,9 @@ version = "0.0.0"
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2866,7 +2872,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3052,7 +3058,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3283,7 +3289,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3330,9 +3336,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3470,7 +3476,7 @@ checksum = "be35209fd0781c5401458ab66e4f98accf63553e8fae7425503e92fdd319783b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3499,7 +3505,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3510,7 +3516,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3568,7 +3574,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3665,7 +3671,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3736,7 +3742,7 @@ checksum = "ee6ff59666c9cbaec3533964505d39154dc4e0a56151fdea30a09ed0301f62e2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "termcolor",
 ]
 
@@ -4201,7 +4207,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -4405,10 +4411,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.2.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5cec722a3274e47d1524cbe2cea762f2c19d615bd9d73ada21db9066349d57e"
+checksum = "b2f42dd20febad683d07044c5f543e57f822512ebebaf2c827705c99a0ad4575"
 dependencies = [
+ "pastey",
  "proc-macro2",
  "quote",
  "thiserror 2.0.18",
@@ -4417,14 +4424,14 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.2.3"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8961eb04054a1b2e026b5628e24da7e001350249a787e1a85aa961f33dc5f286"
+checksum = "fca057fc9a13dd19cdb64ef558635d43c42667c0afa1ae7915ea1fa66993fd1a"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4692,7 +4699,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4708,7 +4715,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4789,7 +4796,7 @@ checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/*"]
 authors = ["Vite+ Authors"]
 edition = "2024"
 license = "MIT"
-rust-version = "1.88.0"
+rust-version = "1.89.0"
 
 [workspace.lints.rust]
 absolute_paths_not_starting_with_crate = "warn"
@@ -44,7 +44,7 @@ assert2 = "0.3.16"
 assertables = "9.8.1"
 async-trait = "0.1.89"
 base64 = "0.22.1"
-wincode = "0.2.5"
+wincode = "0.5.2"
 bindgen = "0.72.1"
 bitflags = "2.10.0"
 # The newest released version (0.3.0) of brush-parser has a bug that reports incorrect locations for some ast nodes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ assert2 = "0.3.16"
 assertables = "9.8.1"
 async-trait = "0.1.89"
 base64 = "0.22.1"
-bincode = "2.0.1"
+wincode = { version = "0.2.5", features = ["derive"] }
 bindgen = "0.72.1"
 bitflags = "2.10.0"
 # The newest released version (0.3.0) of brush-parser has a bug that reports incorrect locations for some ast nodes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ assert2 = "0.3.16"
 assertables = "9.8.1"
 async-trait = "0.1.89"
 base64 = "0.22.1"
-wincode = { version = "0.2.5", features = ["derive"] }
+wincode = "0.2.5"
 bindgen = "0.72.1"
 bitflags = "2.10.0"
 # The newest released version (0.3.0) of brush-parser has a bug that reports incorrect locations for some ast nodes.

--- a/crates/fspy/Cargo.toml
+++ b/crates/fspy/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 allocator-api2 = { workspace = true, features = ["alloc"] }
-bincode = { workspace = true }
+wincode = { workspace = true }
 bstr = { workspace = true, default-features = false }
 bumpalo = { workspace = true }
 const_format = { workspace = true, features = ["fmt"] }

--- a/crates/fspy/src/ipc.rs
+++ b/crates/fspy/src/ipc.rs
@@ -32,7 +32,10 @@ impl OwnedReceiverLockGuard {
 
     pub fn iter_path_accesses(&self) -> impl Iterator<Item = PathAccess<'_>> {
         self.borrow_lock_guard().iter_frames().map(|frame| {
-            let path_access: PathAccess<'_> = wincode::deserialize(frame).unwrap();
+            let mut reader: &[u8] = frame;
+            let path_access =
+                <PathAccess<'_> as wincode::SchemaRead<'_>>::get(&mut reader).unwrap();
+            assert_eq!(reader.len(), 0, "trailing bytes after PathAccess frame");
             path_access
         })
     }

--- a/crates/fspy/src/ipc.rs
+++ b/crates/fspy/src/ipc.rs
@@ -31,12 +31,8 @@ impl OwnedReceiverLockGuard {
     }
 
     pub fn iter_path_accesses(&self) -> impl Iterator<Item = PathAccess<'_>> {
-        self.borrow_lock_guard().iter_frames().map(|frame| {
-            let mut reader: &[u8] = frame;
-            let path_access =
-                <PathAccess<'_> as wincode::SchemaRead<'_>>::get(&mut reader).unwrap();
-            assert_eq!(reader.len(), 0, "trailing bytes after PathAccess frame");
-            path_access
-        })
+        self.borrow_lock_guard()
+            .iter_frames()
+            .map(|frame| wincode::deserialize_exact(frame).unwrap())
     }
 }

--- a/crates/fspy/src/ipc.rs
+++ b/crates/fspy/src/ipc.rs
@@ -1,8 +1,7 @@
 use std::io;
 
-use bincode::borrow_decode_from_slice;
 use fspy_shared::ipc::{
-    BINCODE_CONFIG, PathAccess,
+    PathAccess,
     channel::{Receiver, ReceiverLockGuard},
 };
 use tokio::task::spawn_blocking;
@@ -33,9 +32,7 @@ impl OwnedReceiverLockGuard {
 
     pub fn iter_path_accesses(&self) -> impl Iterator<Item = PathAccess<'_>> {
         self.borrow_lock_guard().iter_frames().map(|frame| {
-            let (path_access, decoded_size) =
-                borrow_decode_from_slice::<PathAccess<'_>, _>(frame, BINCODE_CONFIG).unwrap();
-            assert_eq!(decoded_size, frame.len());
+            let path_access: PathAccess<'_> = wincode::deserialize(frame).unwrap();
             path_access
         })
     }

--- a/crates/fspy/src/windows/mod.rs
+++ b/crates/fspy/src/windows/mod.rs
@@ -9,7 +9,7 @@ use std::{
 use const_format::formatcp;
 use fspy_detours_sys::{DetourCopyPayloadToProcess, DetourUpdateProcessWithDll};
 use fspy_shared::{
-    ipc::{BINCODE_CONFIG, PathAccess, channel::channel},
+    ipc::{PathAccess, channel::channel},
     windows::{PAYLOAD_ID, Payload},
 };
 use futures_util::FutureExt;
@@ -109,7 +109,7 @@ impl SpyImpl {
                     channel_conf: channel_conf.clone(),
                     ansi_dll_path_with_nul: ansi_dll_path_with_nul.to_bytes(),
                 };
-                let payload_bytes = bincode::encode_to_vec(payload, BINCODE_CONFIG).unwrap();
+                let payload_bytes = wincode::serialize(&payload).unwrap();
                 // SAFETY: process_handle is valid, PAYLOAD_ID is a static GUID,
                 // payload_bytes is a valid buffer with correct length
                 let success = unsafe {

--- a/crates/fspy_preload_unix/Cargo.toml
+++ b/crates/fspy_preload_unix/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [target.'cfg(unix)'.dependencies]
 anyhow = { workspace = true }
-bincode = { workspace = true }
+wincode = { workspace = true }
 bstr = { workspace = true, default-features = false }
 ctor = { workspace = true }
 fspy_shared = { workspace = true }

--- a/crates/fspy_preload_unix/src/client/mod.rs
+++ b/crates/fspy_preload_unix/src/client/mod.rs
@@ -6,15 +6,15 @@ use std::{
     sync::OnceLock,
 };
 
-use bincode::{enc::write::SizeWriter, encode_into_slice, encode_into_writer};
 use convert::{ToAbsolutePath, ToAccessMode};
-use fspy_shared::ipc::{BINCODE_CONFIG, PathAccess, channel::Sender};
+use fspy_shared::ipc::{PathAccess, channel::Sender};
 use fspy_shared_unix::{
     exec::ExecResolveConfig,
     payload::EncodedPayload,
     spawn::{PreExec, handle_exec},
 };
 use raw_exec::RawExec;
+use wincode::Serialize as _;
 
 pub struct Client {
     encoded_payload: EncodedPayload,
@@ -72,17 +72,18 @@ impl Client {
             return Ok(());
         }
         let path_access = PathAccess { mode, path: path.into() };
-        let mut size_writer = SizeWriter::default();
-        encode_into_writer(path_access, &mut size_writer, BINCODE_CONFIG)?;
+        let serialized_size = usize::try_from(PathAccess::serialized_size(&path_access)?)
+            .expect("serialized size exceeds usize");
 
-        let frame_size = NonZeroUsize::new(size_writer.bytes_written)
+        let frame_size = NonZeroUsize::new(serialized_size)
             .expect("fspy: encoded PathAccess should never be empty");
 
         let mut frame = ipc_sender
             .claim_frame(frame_size)
             .expect("fspy: failed to claim frame in shared memory");
-        let written_size = encode_into_slice(path_access, &mut frame, BINCODE_CONFIG)?;
-        assert_eq!(written_size, size_writer.bytes_written);
+        let mut writer: &mut [u8] = &mut frame;
+        PathAccess::serialize_into(&mut writer, &path_access)?;
+        assert_eq!(writer.len(), 0);
 
         Ok(())
     }

--- a/crates/fspy_preload_windows/Cargo.toml
+++ b/crates/fspy_preload_windows/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 crate-type = ["cdylib"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
-bincode = { workspace = true }
+wincode = { workspace = true }
 constcat = { workspace = true }
 fspy_detours_sys = { workspace = true }
 fspy_shared = { workspace = true }

--- a/crates/fspy_preload_windows/src/windows/client.rs
+++ b/crates/fspy_preload_windows/src/windows/client.rs
@@ -1,9 +1,8 @@
 use std::{cell::SyncUnsafeCell, ffi::CStr, mem::MaybeUninit};
 
-use bincode::{borrow_decode_from_slice, encode_to_vec};
 use fspy_detours_sys::DetourCopyPayloadToProcess;
 use fspy_shared::{
-    ipc::{BINCODE_CONFIG, PathAccess, channel::Sender},
+    ipc::{PathAccess, channel::Sender},
     windows::{PAYLOAD_ID, Payload},
 };
 use winapi::{shared::minwindef::BOOL, um::winnt::HANDLE};
@@ -15,9 +14,7 @@ pub struct Client<'a> {
 
 impl<'a> Client<'a> {
     pub fn from_payload_bytes(payload_bytes: &'a [u8]) -> Self {
-        let (payload, decoded_len) =
-            borrow_decode_from_slice::<'a, Payload, _>(payload_bytes, BINCODE_CONFIG).unwrap();
-        assert_eq!(decoded_len, payload_bytes.len());
+        let payload: Payload<'a> = wincode::deserialize(payload_bytes).unwrap();
 
         let ipc_sender = match payload.channel_conf.sender() {
             Ok(sender) => Some(sender),
@@ -43,11 +40,11 @@ impl<'a> Client<'a> {
         let Some(sender) = &self.ipc_sender else {
             return;
         };
-        sender.write_encoded(&access, BINCODE_CONFIG).expect("failed to send path access");
+        sender.write_encoded(&access).expect("failed to send path access");
     }
 
     pub unsafe fn prepare_child_process(&self, child_handle: HANDLE) -> BOOL {
-        let payload_bytes = encode_to_vec(&self.payload, BINCODE_CONFIG).unwrap();
+        let payload_bytes = wincode::serialize(&self.payload).unwrap();
         // SAFETY: FFI call to DetourCopyPayloadToProcess with valid handle and payload buffer
         unsafe {
             DetourCopyPayloadToProcess(

--- a/crates/fspy_preload_windows/src/windows/client.rs
+++ b/crates/fspy_preload_windows/src/windows/client.rs
@@ -14,9 +14,7 @@ pub struct Client<'a> {
 
 impl<'a> Client<'a> {
     pub fn from_payload_bytes(payload_bytes: &'a [u8]) -> Self {
-        let mut reader: &'a [u8] = payload_bytes;
-        let payload = <Payload<'a> as wincode::SchemaRead<'a>>::get(&mut reader).unwrap();
-        assert_eq!(reader.len(), 0, "trailing bytes after Payload");
+        let payload: Payload<'a> = wincode::deserialize_exact(payload_bytes).unwrap();
 
         let ipc_sender = match payload.channel_conf.sender() {
             Ok(sender) => Some(sender),

--- a/crates/fspy_preload_windows/src/windows/client.rs
+++ b/crates/fspy_preload_windows/src/windows/client.rs
@@ -14,7 +14,9 @@ pub struct Client<'a> {
 
 impl<'a> Client<'a> {
     pub fn from_payload_bytes(payload_bytes: &'a [u8]) -> Self {
-        let payload: Payload<'a> = wincode::deserialize(payload_bytes).unwrap();
+        let mut reader: &'a [u8] = payload_bytes;
+        let payload = <Payload<'a> as wincode::SchemaRead<'a>>::get(&mut reader).unwrap();
+        assert_eq!(reader.len(), 0, "trailing bytes after Payload");
 
         let ipc_sender = match payload.channel_conf.sender() {
             Ok(sender) => Some(sender),

--- a/crates/fspy_seccomp_unotify/Cargo.toml
+++ b/crates/fspy_seccomp_unotify/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [target.'cfg(target_os = "linux")'.dependencies]
-bincode = { workspace = true }
+wincode = { workspace = true }
 libc = { workspace = true }
 nix = { workspace = true, features = ["process", "fs", "poll", "socket", "uio"] }
 passfd = { workspace = true, default-features = false, optional = true }

--- a/crates/fspy_seccomp_unotify/Cargo.toml
+++ b/crates/fspy_seccomp_unotify/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [target.'cfg(target_os = "linux")'.dependencies]
-wincode = { workspace = true }
+wincode = { workspace = true, features = ["derive"] }
 libc = { workspace = true }
 nix = { workspace = true, features = ["process", "fs", "poll", "socket", "uio"] }
 passfd = { workspace = true, default-features = false, optional = true }

--- a/crates/fspy_seccomp_unotify/src/payload/filter.rs
+++ b/crates/fspy_seccomp_unotify/src/payload/filter.rs
@@ -1,6 +1,6 @@
-use bincode::{Decode, Encode};
+use wincode::{SchemaRead, SchemaWrite};
 
-#[derive(Debug, Encode, Decode, Clone, Copy)]
+#[derive(Debug, SchemaWrite, SchemaRead, Clone, Copy)]
 pub struct CodableSockFilter {
     code: u16,
     jt: u8,
@@ -24,5 +24,5 @@ impl From<CodableSockFilter> for libc::sock_filter {
     }
 }
 
-#[derive(Encode, Decode, Debug, Clone)]
+#[derive(SchemaWrite, SchemaRead, Debug, Clone)]
 pub struct Filter(pub(crate) Vec<CodableSockFilter>);

--- a/crates/fspy_seccomp_unotify/src/payload/mod.rs
+++ b/crates/fspy_seccomp_unotify/src/payload/mod.rs
@@ -1,8 +1,8 @@
 mod filter;
-use bincode::{Decode, Encode};
 pub use filter::Filter;
+use wincode::{SchemaRead, SchemaWrite};
 
-#[derive(Debug, Encode, Decode, Clone)]
+#[derive(Debug, SchemaWrite, SchemaRead, Clone)]
 pub struct SeccompPayload {
     pub(crate) ipc_path: Vec<u8>,
     pub(crate) filter: Filter,

--- a/crates/fspy_shared/Cargo.toml
+++ b/crates/fspy_shared/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 allocator-api2 = { workspace = true }
-bincode = { workspace = true }
+wincode = { workspace = true }
 bitflags = { workspace = true }
 bstr = { workspace = true }
 bytemuck = { workspace = true, features = ["must_cast", "derive"] }

--- a/crates/fspy_shared/Cargo.toml
+++ b/crates/fspy_shared/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 allocator-api2 = { workspace = true }
-wincode = { workspace = true }
+wincode = { workspace = true, features = ["derive"] }
 bitflags = { workspace = true }
 bstr = { workspace = true }
 bytemuck = { workspace = true, features = ["must_cast", "derive"] }

--- a/crates/fspy_shared/src/ipc/channel/mod.rs
+++ b/crates/fspy_shared/src/ipc/channel/mod.rs
@@ -2,23 +2,81 @@
 
 mod shm_io;
 
-use std::{env::temp_dir, fs::File, io, ops::Deref, path::PathBuf, sync::Arc};
+use std::{env::temp_dir, fs::File, io, mem::MaybeUninit, ops::Deref, path::PathBuf, sync::Arc};
 
-use bincode::{Decode, Encode};
 use shared_memory::{Shmem, ShmemConf};
 pub use shm_io::FrameMut;
 use shm_io::{ShmReader, ShmWriter};
 use tracing::debug;
 use uuid::Uuid;
+use wincode::{
+    SchemaRead, SchemaWrite,
+    error::{ReadResult, WriteResult},
+    io::{Reader, Writer},
+};
 
 use super::NativeStr;
 
+/// wincode schema adapter for `Arc<str>`, which is a foreign type with unsized inner.
+struct ArcStrSchema;
+
+impl SchemaWrite for ArcStrSchema {
+    type Src = Arc<str>;
+
+    fn size_of(src: &Self::Src) -> WriteResult<usize> {
+        <str as SchemaWrite>::size_of(src)
+    }
+
+    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+        <str as SchemaWrite>::write(writer, src)
+    }
+}
+
+impl<'de> SchemaRead<'de> for ArcStrSchema {
+    type Dst = Arc<str>;
+
+    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let s: String = String::get(reader)?;
+        dst.write(Arc::from(s.as_str()));
+        Ok(())
+    }
+}
+
 /// Serializable configuration to create channel senders.
-#[derive(Encode, Decode, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct ChannelConf {
     lock_file_path: Box<NativeStr>,
     shm_id: Arc<str>,
     shm_size: usize,
+}
+
+impl SchemaWrite for ChannelConf {
+    type Src = Self;
+
+    fn size_of(src: &Self::Src) -> WriteResult<usize> {
+        Ok(<Box<NativeStr>>::size_of(&src.lock_file_path)?
+            + ArcStrSchema::size_of(&src.shm_id)?
+            + usize::size_of(&src.shm_size)?)
+    }
+
+    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+        <Box<NativeStr>>::write(writer, &src.lock_file_path)?;
+        ArcStrSchema::write(writer, &src.shm_id)?;
+        usize::write(writer, &src.shm_size)?;
+        Ok(())
+    }
+}
+
+impl<'de> SchemaRead<'de> for ChannelConf {
+    type Dst = Self;
+
+    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let lock_file_path = <Box<NativeStr>>::get(reader)?;
+        let shm_id = ArcStrSchema::get(reader)?;
+        let shm_size = usize::get(reader)?;
+        dst.write(Self { lock_file_path, shm_id, shm_size });
+        Ok(())
+    }
 }
 
 /// Creates a mpsc IPC channel with one receiver and a `ChannelConf` that can be passed around processes and used to create multiple senders

--- a/crates/fspy_shared/src/ipc/channel/mod.rs
+++ b/crates/fspy_shared/src/ipc/channel/mod.rs
@@ -18,7 +18,7 @@ use wincode::{
 use super::NativeStr;
 
 /// wincode schema adapter for `Arc<str>`, which is a foreign type with unsized inner.
-struct ArcStrSchema;
+pub(crate) struct ArcStrSchema;
 
 impl SchemaWrite for ArcStrSchema {
     type Src = Arc<str>;
@@ -36,47 +36,19 @@ impl<'de> SchemaRead<'de> for ArcStrSchema {
     type Dst = Arc<str>;
 
     fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let s: String = String::get(reader)?;
-        dst.write(Arc::from(s.as_str()));
+        let s: &str = <&str>::get(reader)?;
+        dst.write(Arc::from(s));
         Ok(())
     }
 }
 
 /// Serializable configuration to create channel senders.
-#[derive(Clone, Debug)]
+#[derive(SchemaWrite, SchemaRead, Clone, Debug)]
 pub struct ChannelConf {
     lock_file_path: Box<NativeStr>,
+    #[wincode(with = "ArcStrSchema")]
     shm_id: Arc<str>,
     shm_size: usize,
-}
-
-impl SchemaWrite for ChannelConf {
-    type Src = Self;
-
-    fn size_of(src: &Self::Src) -> WriteResult<usize> {
-        Ok(<Box<NativeStr>>::size_of(&src.lock_file_path)?
-            + ArcStrSchema::size_of(&src.shm_id)?
-            + usize::size_of(&src.shm_size)?)
-    }
-
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
-        <Box<NativeStr>>::write(writer, &src.lock_file_path)?;
-        ArcStrSchema::write(writer, &src.shm_id)?;
-        usize::write(writer, &src.shm_size)?;
-        Ok(())
-    }
-}
-
-impl<'de> SchemaRead<'de> for ChannelConf {
-    type Dst = Self;
-
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let lock_file_path = <Box<NativeStr>>::get(reader)?;
-        let shm_id = ArcStrSchema::get(reader)?;
-        let shm_size = usize::get(reader)?;
-        dst.write(Self { lock_file_path, shm_id, shm_size });
-        Ok(())
-    }
 }
 
 /// Creates a mpsc IPC channel with one receiver and a `ChannelConf` that can be passed around processes and used to create multiple senders

--- a/crates/fspy_shared/src/ipc/channel/mod.rs
+++ b/crates/fspy_shared/src/ipc/channel/mod.rs
@@ -11,6 +11,7 @@ use tracing::debug;
 use uuid::Uuid;
 use wincode::{
     SchemaRead, SchemaWrite,
+    config::Config,
     error::{ReadResult, WriteResult},
     io::{Reader, Writer},
 };
@@ -20,23 +21,25 @@ use super::NativeStr;
 /// wincode schema adapter for `Arc<str>`, which is a foreign type with unsized inner.
 pub(crate) struct ArcStrSchema;
 
-impl SchemaWrite for ArcStrSchema {
+// SAFETY: Delegates to `str`'s SchemaWrite impl, preserving its size/write invariants.
+unsafe impl<C: Config> SchemaWrite<C> for ArcStrSchema {
     type Src = Arc<str>;
 
     fn size_of(src: &Self::Src) -> WriteResult<usize> {
-        <str as SchemaWrite>::size_of(src)
+        <str as SchemaWrite<C>>::size_of(src)
     }
 
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
-        <str as SchemaWrite>::write(writer, src)
+    fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+        <str as SchemaWrite<C>>::write(writer, src)
     }
 }
 
-impl<'de> SchemaRead<'de> for ArcStrSchema {
+// SAFETY: Delegates to `&str`'s SchemaRead impl; dst is initialized on Ok.
+unsafe impl<'de, C: Config> SchemaRead<'de, C> for ArcStrSchema {
     type Dst = Arc<str>;
 
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let s: &str = <&str>::get(reader)?;
+    fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let s: &str = <&str as SchemaRead<'de, C>>::get(&mut reader)?;
         dst.write(Arc::from(s));
         Ok(())
     }

--- a/crates/fspy_shared/src/ipc/channel/shm_io.rs
+++ b/crates/fspy_shared/src/ipc/channel/shm_io.rs
@@ -10,7 +10,7 @@ use std::{
 
 use bytemuck::must_cast;
 use shared_memory::Shmem;
-use wincode::{SchemaWrite, Serialize as _};
+use wincode::{SchemaWrite, Serialize as _, config::DefaultConfig};
 
 // `ShmWriter` writes headers using atomic operations to prevent partial writes due to crashes,
 // while `ShmReader` reads headers by simple pointer dereferences.
@@ -224,7 +224,7 @@ impl<M: AsRawSlice> ShmWriter<M> {
     }
 
     /// Append an encoded value into the shared memory.
-    pub fn write_encoded<T: SchemaWrite<Src = T>>(
+    pub fn write_encoded<T: SchemaWrite<DefaultConfig, Src = T>>(
         &self,
         value: &T,
     ) -> Result<(), WriteEncodedError> {

--- a/crates/fspy_shared/src/ipc/channel/shm_io.rs
+++ b/crates/fspy_shared/src/ipc/channel/shm_io.rs
@@ -8,11 +8,9 @@ use std::{
     sync::atomic::{AtomicI32, AtomicUsize, Ordering, fence},
 };
 
-use bincode::{
-    Encode, config::Config, enc::write::SizeWriter, encode_into_slice, encode_into_writer,
-};
 use bytemuck::must_cast;
 use shared_memory::Shmem;
+use wincode::{SchemaWrite, Serialize as _};
 
 // `ShmWriter` writes headers using atomic operations to prevent partial writes due to crashes,
 // while `ShmReader` reads headers by simple pointer dereferences.
@@ -109,7 +107,7 @@ impl Drop for FrameMut<'_> {
 #[derive(thiserror::Error, Debug)]
 pub enum WriteEncodedError {
     #[error("Failed to encode value into shared memory")]
-    EncodeError(#[from] bincode::error::EncodeError),
+    EncodeError(#[from] wincode::error::WriteError),
     #[error("Tried to write a frame of zero size into shared memory")]
     ZeroSizedFrame,
     #[error("Not enough space in shared memory to write the encoded frame")]
@@ -226,23 +224,23 @@ impl<M: AsRawSlice> ShmWriter<M> {
     }
 
     /// Append an encoded value into the shared memory.
-    pub fn write_encoded<T: Encode, C: Config>(
+    pub fn write_encoded<T: SchemaWrite<Src = T>>(
         &self,
         value: &T,
-        config: C,
     ) -> Result<(), WriteEncodedError> {
-        let mut size_writer = SizeWriter::default();
-        encode_into_writer(value, &mut size_writer, config)?;
+        let serialized_size =
+            usize::try_from(T::serialized_size(value)?).expect("serialized size exceeds usize");
 
-        let Some(frame_size) = NonZeroUsize::new(size_writer.bytes_written) else {
+        let Some(frame_size) = NonZeroUsize::new(serialized_size) else {
             return Err(WriteEncodedError::ZeroSizedFrame);
         };
         let Some(mut frame) = self.claim_frame(frame_size) else {
             return Err(WriteEncodedError::InsufficientSpace);
         };
 
-        let written_size = encode_into_slice(value, &mut frame, config)?;
-        assert_eq!(written_size, size_writer.bytes_written);
+        let mut writer: &mut [u8] = &mut frame;
+        T::serialize_into(&mut writer, value)?;
+        assert_eq!(writer.len(), 0);
 
         Ok(())
     }

--- a/crates/fspy_shared/src/ipc/mod.rs
+++ b/crates/fspy_shared/src/ipc/mod.rs
@@ -5,14 +5,12 @@ pub(crate) mod native_str;
 
 use std::fmt::Debug;
 
-use bincode::{BorrowDecode, Encode, config::Configuration};
 use bitflags::bitflags;
 pub use native_path::NativePath;
 pub use native_str::NativeStr;
+use wincode::{SchemaRead, SchemaWrite};
 
-pub const BINCODE_CONFIG: Configuration = bincode::config::standard();
-
-#[derive(Encode, BorrowDecode, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+#[derive(SchemaWrite, SchemaRead, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 pub struct AccessMode(u8);
 
 bitflags! {
@@ -35,7 +33,7 @@ impl Debug for AccessMode {
     }
 }
 
-#[derive(Encode, BorrowDecode, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(SchemaWrite, SchemaRead, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PathAccess<'a> {
     pub mode: AccessMode,
     pub path: &'a NativePath,

--- a/crates/fspy_shared/src/ipc/native_path.rs
+++ b/crates/fspy_shared/src/ipc/native_path.rs
@@ -29,6 +29,7 @@ pub struct NativePath {
     inner: NativeStr,
 }
 
+// Manual impl: wincode derive requires Sized, but NativePath wraps unsized NativeStr.
 impl SchemaWrite for NativePath {
     type Src = Self;
 

--- a/crates/fspy_shared/src/ipc/native_path.rs
+++ b/crates/fspy_shared/src/ipc/native_path.rs
@@ -3,12 +3,17 @@ use std::os::unix::ffi::OsStrExt as _;
 use std::{
     ffi::OsStr,
     fmt::Debug,
+    mem::MaybeUninit,
     path::{Path, StripPrefixError},
 };
 
 use allocator_api2::alloc::Allocator;
-use bincode::{BorrowDecode, Encode, de::BorrowDecoder, error::DecodeError};
 use bytemuck::TransparentWrapper;
+use wincode::{
+    SchemaRead, SchemaWrite,
+    error::{ReadResult, WriteResult},
+    io::{Reader, Writer},
+};
 
 use super::native_str::NativeStr;
 
@@ -18,10 +23,32 @@ use super::native_str::NativeStr;
 /// whose raw data is not meaningful for direct consumption. The only way
 /// to use the path is through [`strip_path_prefix`](NativePath::strip_path_prefix),
 /// which normalizes platform differences and extracts a workspace-relative path.
-#[derive(TransparentWrapper, Encode, PartialEq, Eq)]
+#[derive(TransparentWrapper, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct NativePath {
     inner: NativeStr,
+}
+
+impl SchemaWrite for NativePath {
+    type Src = Self;
+
+    fn size_of(src: &Self::Src) -> WriteResult<usize> {
+        NativeStr::size_of(&src.inner)
+    }
+
+    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+        NativeStr::write(writer, &src.inner)
+    }
+}
+
+impl<'de> SchemaRead<'de> for &'de NativePath {
+    type Dst = &'de NativePath;
+
+    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let inner: &'de NativeStr = <&NativeStr>::get(reader)?;
+        dst.write(NativePath::wrap_ref(inner));
+        Ok(())
+    }
 }
 
 impl NativePath {
@@ -84,15 +111,6 @@ impl NativePath {
 impl Debug for NativePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         <NativeStr as Debug>::fmt(&self.inner, f)
-    }
-}
-
-impl<'a, C> BorrowDecode<'a, C> for &'a NativePath {
-    fn borrow_decode<D: BorrowDecoder<'a, Context = C>>(
-        decoder: &mut D,
-    ) -> Result<Self, DecodeError> {
-        let inner: &'a NativeStr = BorrowDecode::borrow_decode(decoder)?;
-        Ok(NativePath::wrap_ref(inner))
     }
 }
 

--- a/crates/fspy_shared/src/ipc/native_path.rs
+++ b/crates/fspy_shared/src/ipc/native_path.rs
@@ -11,6 +11,7 @@ use allocator_api2::alloc::Allocator;
 use bytemuck::TransparentWrapper;
 use wincode::{
     SchemaRead, SchemaWrite,
+    config::Config,
     error::{ReadResult, WriteResult},
     io::{Reader, Writer},
 };
@@ -30,23 +31,25 @@ pub struct NativePath {
 }
 
 // Manual impl: wincode derive requires Sized, but NativePath wraps unsized NativeStr.
-impl SchemaWrite for NativePath {
+// SAFETY: Delegates to `NativeStr`'s SchemaWrite impl, preserving its invariants.
+unsafe impl<C: Config> SchemaWrite<C> for NativePath {
     type Src = Self;
 
     fn size_of(src: &Self::Src) -> WriteResult<usize> {
-        NativeStr::size_of(&src.inner)
+        <NativeStr as SchemaWrite<C>>::size_of(&src.inner)
     }
 
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
-        NativeStr::write(writer, &src.inner)
+    fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+        <NativeStr as SchemaWrite<C>>::write(writer, &src.inner)
     }
 }
 
-impl<'de> SchemaRead<'de> for &'de NativePath {
+// SAFETY: Delegates to `&NativeStr`'s SchemaRead impl; dst is initialized on Ok.
+unsafe impl<'de, C: Config> SchemaRead<'de, C> for &'de NativePath {
     type Dst = &'de NativePath;
 
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let inner: &'de NativeStr = <&NativeStr>::get(reader)?;
+    fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let inner: &'de NativeStr = <&NativeStr as SchemaRead<'de, C>>::get(&mut reader)?;
         dst.write(NativePath::wrap_ref(inner));
         Ok(())
     }

--- a/crates/fspy_shared/src/ipc/native_str.rs
+++ b/crates/fspy_shared/src/ipc/native_str.rs
@@ -74,13 +74,7 @@ impl NativeStr {
     }
 }
 
-impl Debug for NativeStr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        <OsStr as Debug>::fmt(self.to_cow_os_str().as_ref(), f)
-    }
-}
-
-// SchemaWrite for &NativeStr: encode as byte slice
+// Manual impl: wincode derive requires Sized, but NativeStr wraps unsized [u8].
 impl SchemaWrite for NativeStr {
     type Src = Self;
 
@@ -90,6 +84,12 @@ impl SchemaWrite for NativeStr {
 
     fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
         <[u8] as SchemaWrite>::write(writer, &src.data)
+    }
+}
+
+impl Debug for NativeStr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        <OsStr as Debug>::fmt(self.to_cow_os_str().as_ref(), f)
     }
 }
 
@@ -121,8 +121,8 @@ impl<'de> SchemaRead<'de> for Box<NativeStr> {
     type Dst = Self;
 
     fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let data: Vec<u8> = <Vec<u8>>::get(reader)?;
-        dst.write(NativeStr::wrap_box(data.into_boxed_slice()));
+        let data: &[u8] = <&[u8]>::get(reader)?;
+        dst.write(NativeStr::wrap_box(data.into()));
         Ok(())
     }
 }

--- a/crates/fspy_shared/src/ipc/native_str.rs
+++ b/crates/fspy_shared/src/ipc/native_str.rs
@@ -6,29 +6,28 @@ use std::os::unix::ffi::OsStrExt as _;
 use std::os::windows::ffi::OsStrExt as _;
 #[cfg(windows)]
 use std::os::windows::ffi::OsStringExt as _;
-use std::{borrow::Cow, ffi::OsStr, fmt::Debug};
+use std::{borrow::Cow, ffi::OsStr, fmt::Debug, mem::MaybeUninit};
 
 use allocator_api2::alloc::Allocator;
-use bincode::{
-    BorrowDecode, Decode, Encode,
-    de::{BorrowDecoder, Decoder},
-    error::DecodeError,
-    impl_borrow_decode,
-};
 #[cfg(windows)]
 use bytemuck::must_cast_slice;
 use bytemuck::{TransparentWrapper, TransparentWrapperAlloc};
+use wincode::{
+    SchemaRead, SchemaWrite,
+    error::{ReadResult, WriteResult},
+    io::{Reader, Writer},
+};
 
 /// Similar to `OsStr`, but
-/// - Can be infallibly and losslessly encoded/decoded using bincode.
-///   (`Encode`/`Decoded` implementations for `OsStr` requires it to be valid UTF-8. This does not.)
+/// - Can be infallibly and losslessly encoded/decoded using wincode.
+///   (`SchemaWrite`/`SchemaRead` implementations for `OsStr` requires it to be valid UTF-8. This does not.)
 /// - Can be constructed from wide characters on Windows with zero copy.
-/// - Supports zero-copy `BorrowDecode`.
-#[derive(TransparentWrapper, Encode, PartialEq, Eq)]
+/// - Supports zero-copy `SchemaRead`.
+#[derive(TransparentWrapper, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct NativeStr {
     // On unix, this is the raw bytes of the OsStr.
-    // On windows, this is safely transmuted from `&[u16]` in `NativeStr::from_wide`. We don't declare it as `&[u16]` to allow `BorrowDecode`.
+    // On windows, this is safely transmuted from `&[u16]` in `NativeStr::from_wide`. We don't declare it as `&[u16]` to allow zero-copy read.
     // Transmuting back to `&[u16]` would be unsafe because of different alignments between `u8` and `u16` (See `to_os_string`).
     data: [u8],
 }
@@ -81,12 +80,50 @@ impl Debug for NativeStr {
     }
 }
 
-impl<'a, C> BorrowDecode<'a, C> for &'a NativeStr {
-    fn borrow_decode<D: BorrowDecoder<'a, Context = C>>(
-        decoder: &mut D,
-    ) -> Result<Self, DecodeError> {
-        let data: &'a [u8] = BorrowDecode::borrow_decode(decoder)?;
-        Ok(NativeStr::wrap_ref(data))
+// SchemaWrite for &NativeStr: encode as byte slice
+impl SchemaWrite for NativeStr {
+    type Src = Self;
+
+    fn size_of(src: &Self::Src) -> WriteResult<usize> {
+        <[u8] as SchemaWrite>::size_of(&src.data)
+    }
+
+    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+        <[u8] as SchemaWrite>::write(writer, &src.data)
+    }
+}
+
+// SchemaRead for &NativeStr: zero-copy borrow from input bytes
+impl<'de> SchemaRead<'de> for &'de NativeStr {
+    type Dst = &'de NativeStr;
+
+    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let data: &'de [u8] = <&[u8]>::get(reader)?;
+        dst.write(NativeStr::wrap_ref(data));
+        Ok(())
+    }
+}
+
+impl SchemaWrite for Box<NativeStr> {
+    type Src = Self;
+
+    fn size_of(src: &Self::Src) -> WriteResult<usize> {
+        NativeStr::size_of(src)
+    }
+
+    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+        NativeStr::write(writer, src)
+    }
+}
+
+// SchemaRead for Box<NativeStr>: owned decode
+impl<'de> SchemaRead<'de> for Box<NativeStr> {
+    type Dst = Self;
+
+    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let data: Vec<u8> = <Vec<u8>>::get(reader)?;
+        dst.write(NativeStr::wrap_box(data.into_boxed_slice()));
+        Ok(())
     }
 }
 
@@ -96,14 +133,6 @@ impl<'a, S: AsRef<OsStr> + ?Sized> From<&'a S> for &'a NativeStr {
         NativeStr::from_bytes(value.as_ref().as_bytes())
     }
 }
-
-impl<C> Decode<C> for Box<NativeStr> {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
-        let data: Box<[u8]> = Decode::decode(decoder)?;
-        Ok(NativeStr::wrap_box(data))
-    }
-}
-impl_borrow_decode!(Box<NativeStr>);
 
 impl Clone for Box<NativeStr> {
     fn clone(&self) -> Self {
@@ -148,15 +177,12 @@ mod tests {
     fn test_from_wide() {
         use std::os::windows::ffi::OsStrExt;
 
-        use bincode::{borrow_decode_from_slice, config, encode_to_vec};
-
         let wide_str: &[u16] = &[528, 491];
         let native_str = NativeStr::from_wide(wide_str);
 
-        let mut encoded = encode_to_vec(native_str, config::standard()).unwrap();
+        let mut encoded = wincode::serialize(native_str).unwrap();
 
-        let (decoded, _) =
-            borrow_decode_from_slice::<'_, &NativeStr, _>(&encoded, config::standard()).unwrap();
+        let decoded: &NativeStr = wincode::deserialize(&encoded).unwrap();
         let decoded_wide = decoded.to_os_string().encode_wide().collect::<Vec<u16>>();
         assert_eq!(decoded_wide, wide_str);
 
@@ -164,9 +190,7 @@ mod tests {
         encoded.push(0);
         encoded.copy_within(..encoded_len, 1);
 
-        let (decoded, _) =
-            borrow_decode_from_slice::<'_, &NativeStr, _>(&encoded[1..], config::standard())
-                .unwrap();
+        let decoded: &NativeStr = wincode::deserialize(&encoded[1..]).unwrap();
         let decoded_wide = decoded.to_os_string().encode_wide().collect::<Vec<u16>>();
         assert_eq!(decoded_wide, wide_str);
     }

--- a/crates/fspy_shared/src/ipc/native_str.rs
+++ b/crates/fspy_shared/src/ipc/native_str.rs
@@ -14,6 +14,7 @@ use bytemuck::must_cast_slice;
 use bytemuck::{TransparentWrapper, TransparentWrapperAlloc};
 use wincode::{
     SchemaRead, SchemaWrite,
+    config::Config,
     error::{ReadResult, WriteResult},
     io::{Reader, Writer},
 };
@@ -75,15 +76,16 @@ impl NativeStr {
 }
 
 // Manual impl: wincode derive requires Sized, but NativeStr wraps unsized [u8].
-impl SchemaWrite for NativeStr {
+// SAFETY: Delegates to `[u8]`'s SchemaWrite impl, preserving its size/write invariants.
+unsafe impl<C: Config> SchemaWrite<C> for NativeStr {
     type Src = Self;
 
     fn size_of(src: &Self::Src) -> WriteResult<usize> {
-        <[u8] as SchemaWrite>::size_of(&src.data)
+        <[u8] as SchemaWrite<C>>::size_of(&src.data)
     }
 
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
-        <[u8] as SchemaWrite>::write(writer, &src.data)
+    fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+        <[u8] as SchemaWrite<C>>::write(writer, &src.data)
     }
 }
 
@@ -94,34 +96,37 @@ impl Debug for NativeStr {
 }
 
 // SchemaRead for &NativeStr: zero-copy borrow from input bytes
-impl<'de> SchemaRead<'de> for &'de NativeStr {
+// SAFETY: Delegates to `&[u8]`'s SchemaRead impl; dst is initialized on Ok.
+unsafe impl<'de, C: Config> SchemaRead<'de, C> for &'de NativeStr {
     type Dst = &'de NativeStr;
 
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let data: &'de [u8] = <&[u8]>::get(reader)?;
+    fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let data: &'de [u8] = <&[u8] as SchemaRead<'de, C>>::get(&mut reader)?;
         dst.write(NativeStr::wrap_ref(data));
         Ok(())
     }
 }
 
-impl SchemaWrite for Box<NativeStr> {
+// SAFETY: Delegates to `NativeStr`'s SchemaWrite impl, preserving its invariants.
+unsafe impl<C: Config> SchemaWrite<C> for Box<NativeStr> {
     type Src = Self;
 
     fn size_of(src: &Self::Src) -> WriteResult<usize> {
-        NativeStr::size_of(src)
+        <NativeStr as SchemaWrite<C>>::size_of(src)
     }
 
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
-        NativeStr::write(writer, src)
+    fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+        <NativeStr as SchemaWrite<C>>::write(writer, src)
     }
 }
 
 // SchemaRead for Box<NativeStr>: owned decode
-impl<'de> SchemaRead<'de> for Box<NativeStr> {
+// SAFETY: Delegates to `&[u8]`'s SchemaRead impl; dst is initialized on Ok.
+unsafe impl<'de, C: Config> SchemaRead<'de, C> for Box<NativeStr> {
     type Dst = Self;
 
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let data: &[u8] = <&[u8]>::get(reader)?;
+    fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let data: &[u8] = <&[u8] as SchemaRead<'de, C>>::get(&mut reader)?;
         dst.write(NativeStr::wrap_box(data.into()));
         Ok(())
     }

--- a/crates/fspy_shared/src/windows/mod.rs
+++ b/crates/fspy_shared/src/windows/mod.rs
@@ -1,5 +1,5 @@
-use bincode::{BorrowDecode, Encode};
 use winapi::DEFINE_GUID;
+use wincode::{SchemaRead, SchemaWrite};
 
 use crate::ipc::channel::ChannelConf;
 
@@ -20,7 +20,7 @@ DEFINE_GUID!(
     0x33
 );
 
-#[derive(Encode, BorrowDecode, Debug, Clone)]
+#[derive(SchemaWrite, SchemaRead, Debug, Clone)]
 pub struct Payload<'a> {
     pub channel_conf: ChannelConf,
     pub ansi_dll_path_with_nul: &'a [u8],

--- a/crates/fspy_shared_unix/Cargo.toml
+++ b/crates/fspy_shared_unix/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(unix)'.dependencies]
 anyhow = { workspace = true }
 base64 = { workspace = true }
-bincode = { workspace = true }
+wincode = { workspace = true }
 bstr = { workspace = true }
 fspy_shared = { workspace = true }
 nix = { workspace = true, features = ["fs"] }

--- a/crates/fspy_shared_unix/Cargo.toml
+++ b/crates/fspy_shared_unix/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [target.'cfg(unix)'.dependencies]
 anyhow = { workspace = true }
 base64 = { workspace = true }
-wincode = { workspace = true }
+wincode = { workspace = true, features = ["derive"] }
 bstr = { workspace = true }
 fspy_shared = { workspace = true }
 nix = { workspace = true, features = ["fs"] }

--- a/crates/fspy_shared_unix/src/payload.rs
+++ b/crates/fspy_shared_unix/src/payload.rs
@@ -70,8 +70,6 @@ pub fn decode_payload_from_env() -> anyhow::Result<EncodedPayload> {
 
 fn decode_payload(encoded_string: BString) -> anyhow::Result<EncodedPayload> {
     let bytes = BASE64_STANDARD_NO_PAD.decode(&encoded_string)?;
-    let mut reader: &[u8] = &bytes;
-    let payload = <Payload as wincode::SchemaRead<'_>>::get(&mut reader)?;
-    assert_eq!(reader.len(), 0, "trailing bytes after Payload");
+    let payload: Payload = wincode::deserialize_exact(&bytes)?;
     Ok(EncodedPayload { payload, encoded_string })
 }

--- a/crates/fspy_shared_unix/src/payload.rs
+++ b/crates/fspy_shared_unix/src/payload.rs
@@ -1,14 +1,14 @@
 use std::os::unix::ffi::OsStringExt;
 
 use base64::{Engine as _, prelude::BASE64_STANDARD_NO_PAD};
-use bincode::{Decode, Encode, config::standard};
 use bstr::BString;
 #[cfg(not(target_env = "musl"))]
 use fspy_shared::ipc::NativeStr;
 #[cfg(not(target_env = "musl"))]
 use fspy_shared::ipc::channel::ChannelConf;
+use wincode::{SchemaRead, SchemaWrite};
 
-#[derive(Debug, Encode, Decode)]
+#[derive(Debug, SchemaWrite, SchemaRead)]
 pub struct Payload {
     #[cfg(not(target_env = "musl"))]
     pub ipc_channel_conf: ChannelConf,
@@ -28,7 +28,7 @@ pub struct Payload {
 }
 
 #[cfg(target_os = "macos")]
-#[derive(Debug, Encode, Decode, Clone)]
+#[derive(Debug, SchemaWrite, SchemaRead, Clone)]
 pub struct Artifacts {
     pub bash_path: Box<NativeStr>,
     pub coreutils_path: Box<NativeStr>,
@@ -45,11 +45,11 @@ pub struct EncodedPayload {
 ///
 /// # Panics
 ///
-/// Panics if bincode serialization fails, which should never happen for valid `Payload` structs.
+/// Panics if serialization fails, which should never happen for valid `Payload` structs.
 #[must_use]
 pub fn encode_payload(payload: Payload) -> EncodedPayload {
-    let bincode_bytes = bincode::encode_to_vec(&payload, standard()).unwrap();
-    let encoded_string = BASE64_STANDARD_NO_PAD.encode(&bincode_bytes);
+    let bytes = wincode::serialize(&payload).unwrap();
+    let encoded_string = BASE64_STANDARD_NO_PAD.encode(&bytes);
     EncodedPayload { payload, encoded_string: encoded_string.into() }
 }
 
@@ -60,7 +60,7 @@ pub fn encode_payload(payload: Payload) -> EncodedPayload {
 /// Returns an error if:
 /// - The environment variable is not found
 /// - The base64 decoding fails
-/// - The bincode deserialization fails
+/// - The deserialization fails
 pub fn decode_payload_from_env() -> anyhow::Result<EncodedPayload> {
     let Some(encoded_string) = std::env::var_os(PAYLOAD_ENV_NAME) else {
         anyhow::bail!("Environment variable '{PAYLOAD_ENV_NAME}' not found");
@@ -69,8 +69,7 @@ pub fn decode_payload_from_env() -> anyhow::Result<EncodedPayload> {
 }
 
 fn decode_payload(encoded_string: BString) -> anyhow::Result<EncodedPayload> {
-    let bincode_bytes = BASE64_STANDARD_NO_PAD.decode(&encoded_string)?;
-    let (payload, n) = bincode::decode_from_slice::<Payload, _>(&bincode_bytes, standard())?;
-    assert_eq!(bincode_bytes.len(), n);
+    let bytes = BASE64_STANDARD_NO_PAD.decode(&encoded_string)?;
+    let payload: Payload = wincode::deserialize(&bytes)?;
     Ok(EncodedPayload { payload, encoded_string })
 }

--- a/crates/fspy_shared_unix/src/payload.rs
+++ b/crates/fspy_shared_unix/src/payload.rs
@@ -70,6 +70,8 @@ pub fn decode_payload_from_env() -> anyhow::Result<EncodedPayload> {
 
 fn decode_payload(encoded_string: BString) -> anyhow::Result<EncodedPayload> {
     let bytes = BASE64_STANDARD_NO_PAD.decode(&encoded_string)?;
-    let payload: Payload = wincode::deserialize(&bytes)?;
+    let mut reader: &[u8] = &bytes;
+    let payload = <Payload as wincode::SchemaRead<'_>>::get(&mut reader)?;
+    assert_eq!(reader.len(), 0, "trailing bytes after Payload");
     Ok(EncodedPayload { payload, encoded_string })
 }

--- a/crates/subprocess_test/Cargo.toml
+++ b/crates/subprocess_test/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 base64 = { workspace = true }
-bincode = { workspace = true }
+wincode = { workspace = true }
 ctor = { workspace = true }
 fspy = { workspace = true, optional = true }
 portable-pty = { workspace = true, optional = true }

--- a/crates/subprocess_test/src/lib.rs
+++ b/crates/subprocess_test/src/lib.rs
@@ -2,7 +2,7 @@ use std::{env::current_exe, ffi::OsString, path::PathBuf, process::Command as St
 
 use base64::{Engine, prelude::BASE64_STANDARD_NO_PAD};
 use rustc_hash::FxHashMap;
-use wincode::{SchemaReadOwned, SchemaWrite};
+use wincode::{SchemaReadOwned, SchemaWrite, config::DefaultConfig};
 
 /// A command configuration that can be converted to `std::process::Command`
 /// or `fspy::Command` for execution.
@@ -119,7 +119,7 @@ fn read_proc_cmdline() -> Option<Vec<String>> {
 }
 
 #[doc(hidden)]
-pub fn init_impl<A: SchemaReadOwned<Dst = A>>(expected_id: &str, f: impl FnOnce(A)) {
+pub fn init_impl<A: SchemaReadOwned<DefaultConfig, Dst = A>>(expected_id: &str, f: impl FnOnce(A)) {
     let args = get_args();
     // <test_binary> <expected_id> <arg_base64>
     let (Some(current_id), Some(arg_base64)) = (args.get(1), args.get(2)) else {
@@ -135,7 +135,7 @@ pub fn init_impl<A: SchemaReadOwned<Dst = A>>(expected_id: &str, f: impl FnOnce(
 }
 
 #[doc(hidden)]
-pub fn create_command<T: SchemaWrite<Src = T>>(id: &str, arg: T) -> Command {
+pub fn create_command<T: SchemaWrite<DefaultConfig, Src = T>>(id: &str, arg: T) -> Command {
     let program = current_exe().unwrap().into_os_string();
     let arg_bytes = wincode::serialize(&arg).expect("Failed to encode arg");
     let arg_base64 = BASE64_STANDARD_NO_PAD.encode(&arg_bytes);

--- a/crates/subprocess_test/src/lib.rs
+++ b/crates/subprocess_test/src/lib.rs
@@ -1,8 +1,8 @@
 use std::{env::current_exe, ffi::OsString, path::PathBuf, process::Command as StdCommand};
 
 use base64::{Engine, prelude::BASE64_STANDARD_NO_PAD};
-use bincode::{Decode, Encode, config};
 use rustc_hash::FxHashMap;
+use wincode::{SchemaReadOwned, SchemaWrite};
 
 /// A command configuration that can be converted to `std::process::Command`
 /// or `fspy::Command` for execution.
@@ -50,7 +50,7 @@ impl From<Command> for portable_pty::CommandBuilder {
 
 /// Creates a `subprocess_test::Command` that only executes the provided function.
 ///
-/// - $arg: The argument to pass to the function, must implement `Encode` and `Decode`.
+/// - $arg: The argument to pass to the function, must implement `SchemaWrite` and `SchemaReadOwned`.
 /// - $f: The function to run in the separate process, takes one argument of the type of $arg.
 #[macro_export]
 macro_rules! command_for_fn {
@@ -119,7 +119,7 @@ fn read_proc_cmdline() -> Option<Vec<String>> {
 }
 
 #[doc(hidden)]
-pub fn init_impl<A: Decode<()>>(expected_id: &str, f: impl FnOnce(A)) {
+pub fn init_impl<A: SchemaReadOwned<Dst = A>>(expected_id: &str, f: impl FnOnce(A)) {
     let args = get_args();
     // <test_binary> <expected_id> <arg_base64>
     let (Some(current_id), Some(arg_base64)) = (args.get(1), args.get(2)) else {
@@ -129,17 +129,15 @@ pub fn init_impl<A: Decode<()>>(expected_id: &str, f: impl FnOnce(A)) {
         return;
     }
     let arg_bytes = BASE64_STANDARD_NO_PAD.decode(arg_base64).expect("Failed to decode base64 arg");
-    let arg: A = bincode::decode_from_slice(&arg_bytes, config::standard())
-        .expect("Failed to decode bincode arg")
-        .0;
+    let arg: A = wincode::deserialize(&arg_bytes).expect("Failed to decode wincode arg");
     f(arg);
     std::process::exit(0);
 }
 
 #[doc(hidden)]
-pub fn create_command(id: &str, arg: impl Encode) -> Command {
+pub fn create_command<T: SchemaWrite<Src = T>>(id: &str, arg: T) -> Command {
     let program = current_exe().unwrap().into_os_string();
-    let arg_bytes = bincode::encode_to_vec(&arg, config::standard()).expect("Failed to encode arg");
+    let arg_bytes = wincode::serialize(&arg).expect("Failed to encode arg");
     let arg_base64 = BASE64_STANDARD_NO_PAD.encode(&arg_bytes);
 
     let args = vec![OsString::from(id), OsString::from(arg_base64)];

--- a/crates/vite_path/Cargo.toml
+++ b/crates/vite_path/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bincode = { workspace = true }
+wincode = { workspace = true }
 diff-struct = { workspace = true }
 path-clean = { workspace = true }
 ref-cast = { workspace = true }

--- a/crates/vite_path/Cargo.toml
+++ b/crates/vite_path/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-wincode = { workspace = true }
+wincode = { workspace = true, features = ["derive"] }
 diff-struct = { workspace = true }
 path-clean = { workspace = true }
 ref-cast = { workspace = true }

--- a/crates/vite_path/src/relative.rs
+++ b/crates/vite_path/src/relative.rs
@@ -6,15 +6,20 @@
 use std::{
     borrow::Borrow,
     fmt::Display,
+    mem::MaybeUninit,
     ops::Deref,
     path::{Component, Path},
 };
 
-use bincode::{Decode, Encode, de::Decoder, error::DecodeError};
 use diff::Diff;
 use ref_cast::{RefCastCustom, ref_cast_custom};
 use serde::{Deserialize, Serialize};
 use vite_str::Str;
+use wincode::{
+    SchemaRead, SchemaWrite,
+    error::{ReadResult, WriteResult},
+    io::{Reader, Writer},
+};
 
 /// A relative path with additional guarantees to make it portable:
 ///
@@ -100,14 +105,39 @@ impl RelativePath {
 }
 
 /// A owned relative path buf with the same guarantees as `RelativePath`
-#[derive(
-    Debug, Encode, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize, Default,
-)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize, Default)]
 #[expect(
     clippy::unsafe_derive_deserialize,
-    reason = "unsafe in Decode impl validates portability invariants"
+    reason = "unsafe in SchemaRead impl validates portability invariants"
 )]
 pub struct RelativePathBuf(Str);
+
+impl SchemaWrite for RelativePathBuf {
+    type Src = Self;
+
+    fn size_of(src: &Self::Src) -> WriteResult<usize> {
+        Str::size_of(&src.0)
+    }
+
+    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+        Str::write(writer, &src.0)
+    }
+}
+
+impl<'de> SchemaRead<'de> for RelativePathBuf {
+    type Dst = Self;
+
+    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let path_str = Str::get(reader)?;
+        Self::new(path_str.as_str()).map_or(
+            Err(wincode::error::ReadError::Custom("invalid relative path in encoded data")),
+            |path| {
+                dst.write(path);
+                Ok(())
+            },
+        )
+    }
+}
 
 impl AsRef<Path> for RelativePathBuf {
     fn as_ref(&self) -> &Path {
@@ -210,27 +240,11 @@ impl RelativePathBuf {
 
     #[must_use]
     pub fn as_relative_path(&self) -> &RelativePath {
-        // SAFETY: RelativePathBuf's constructors (new, Decode) validate portability
+        // SAFETY: RelativePathBuf's constructors (new, SchemaRead) validate portability
         // invariants, so the inner string is guaranteed to be a valid portable path.
         unsafe { RelativePath::assume_portable(&self.0) }
     }
 }
-
-impl<Context> Decode<Context> for RelativePathBuf {
-    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
-        let path_str = Str::decode(decoder)?;
-        Self::new(path_str.as_str()).map_err(|err| {
-            #[expect(
-                clippy::disallowed_macros,
-                reason = "bincode::error::DecodeError requires std format!"
-            )]
-            let msg = format!("{err}: {path_str}");
-            DecodeError::OtherString(msg)
-        })
-    }
-}
-
-bincode::impl_borrow_decode!(RelativePathBuf);
 
 impl TryFrom<&Path> for RelativePathBuf {
     type Error = FromPathError;
@@ -466,10 +480,8 @@ mod tests {
     #[test]
     fn encode_decode() {
         let rel_path = RelativePathBuf::new("foo/bar").unwrap();
-        let config = bincode::config::standard();
-        let encoded = bincode::encode_to_vec(&rel_path, config).unwrap();
-        let (decoded, _) =
-            bincode::decode_from_slice::<RelativePathBuf, _>(&encoded, config).unwrap();
+        let encoded = wincode::serialize(&rel_path).unwrap();
+        let decoded: RelativePathBuf = wincode::deserialize(&encoded).unwrap();
         assert_eq!(rel_path, decoded);
     }
 }

--- a/crates/vite_path/src/relative.rs
+++ b/crates/vite_path/src/relative.rs
@@ -15,7 +15,7 @@ use diff::Diff;
 use ref_cast::{RefCastCustom, ref_cast_custom};
 use serde::{Deserialize, Serialize};
 use vite_str::Str;
-use wincode::{SchemaRead, SchemaWrite, error::ReadResult, io::Reader};
+use wincode::{SchemaRead, SchemaWrite, config::Config, error::ReadResult, io::Reader};
 
 /// A relative path with additional guarantees to make it portable:
 ///
@@ -110,11 +110,12 @@ impl RelativePath {
 )]
 pub struct RelativePathBuf(Str);
 
-impl<'de> SchemaRead<'de> for RelativePathBuf {
+// SAFETY: Delegates to `Str`'s SchemaRead impl; dst is initialized only on Ok.
+unsafe impl<'de, C: Config> SchemaRead<'de, C> for RelativePathBuf {
     type Dst = Self;
 
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let path_str = Str::get(reader)?;
+    fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let path_str = <Str as SchemaRead<'de, C>>::get(&mut reader)?;
         Self::new(path_str.as_str()).map_or(
             Err(wincode::error::ReadError::Custom("invalid relative path in encoded data")),
             |path| {

--- a/crates/vite_path/src/relative.rs
+++ b/crates/vite_path/src/relative.rs
@@ -15,11 +15,7 @@ use diff::Diff;
 use ref_cast::{RefCastCustom, ref_cast_custom};
 use serde::{Deserialize, Serialize};
 use vite_str::Str;
-use wincode::{
-    SchemaRead, SchemaWrite,
-    error::{ReadResult, WriteResult},
-    io::{Reader, Writer},
-};
+use wincode::{SchemaRead, SchemaWrite, error::ReadResult, io::Reader};
 
 /// A relative path with additional guarantees to make it portable:
 ///
@@ -105,24 +101,14 @@ impl RelativePath {
 }
 
 /// A owned relative path buf with the same guarantees as `RelativePath`
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize, Default)]
+#[derive(
+    Debug, SchemaWrite, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize, Default,
+)]
 #[expect(
     clippy::unsafe_derive_deserialize,
     reason = "unsafe in SchemaRead impl validates portability invariants"
 )]
 pub struct RelativePathBuf(Str);
-
-impl SchemaWrite for RelativePathBuf {
-    type Src = Self;
-
-    fn size_of(src: &Self::Src) -> WriteResult<usize> {
-        Str::size_of(&src.0)
-    }
-
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
-        Str::write(writer, &src.0)
-    }
-}
 
 impl<'de> SchemaRead<'de> for RelativePathBuf {
     type Dst = Self;

--- a/crates/vite_shell/Cargo.toml
+++ b/crates/vite_shell/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 rust-version.workspace = true
 
 [dependencies]
-bincode = { workspace = true }
+wincode = { workspace = true }
 brush-parser = { workspace = true }
 diff-struct = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/vite_shell/Cargo.toml
+++ b/crates/vite_shell/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 rust-version.workspace = true
 
 [dependencies]
-wincode = { workspace = true }
+wincode = { workspace = true, features = ["derive"] }
 brush-parser = { workspace = true }
 diff-struct = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/vite_shell/src/lib.rs
+++ b/crates/vite_shell/src/lib.rs
@@ -1,6 +1,5 @@
 use std::{collections::BTreeMap, fmt::Display, ops::Range};
 
-use bincode::{Decode, Encode};
 use brush_parser::{
     Parser, ParserOptions,
     ast::{
@@ -13,9 +12,10 @@ use brush_parser::{
 use diff::Diff;
 use serde::{Deserialize, Serialize};
 use vite_str::Str;
+use wincode::{SchemaRead, SchemaWrite};
 
 /// "FOO=BAR program arg1 arg2"
-#[derive(Encode, Decode, Serialize, Deserialize, Debug, PartialEq, Eq, Diff, Clone)]
+#[derive(SchemaWrite, SchemaRead, Serialize, Deserialize, Debug, PartialEq, Eq, Diff, Clone)]
 #[diff(attr(#[derive(Debug)]))]
 pub struct TaskParsedCommand {
     pub envs: BTreeMap<Str, Str>,
@@ -298,8 +298,6 @@ mod tests {
 
     #[test]
     fn test_task_parsed_command_serialization_stability() {
-        use bincode::{decode_from_slice, encode_to_vec};
-
         // Create a command with multiple environment variables
         let cmd = TaskParsedCommand {
             envs: [
@@ -313,15 +311,14 @@ mod tests {
         };
 
         // Serialize multiple times
-        let config = bincode::config::standard();
-        let bytes1 = encode_to_vec(&cmd, config).unwrap();
-        let bytes2 = encode_to_vec(&cmd, config).unwrap();
+        let bytes1 = wincode::serialize(&cmd).unwrap();
+        let bytes2 = wincode::serialize(&cmd).unwrap();
 
         // Verify serialization is stable
         assert_eq!(bytes1, bytes2);
 
         // Verify deserialization works and maintains order
-        let (decoded, _): (TaskParsedCommand, _) = decode_from_slice(&bytes1, config).unwrap();
+        let decoded: TaskParsedCommand = wincode::deserialize(&bytes1).unwrap();
         assert_eq!(decoded, cmd);
 
         // Verify the decoded command still has stable string representation

--- a/crates/vite_str/Cargo.toml
+++ b/crates/vite_str/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bincode = { workspace = true }
+wincode = { workspace = true }
 compact_str = { workspace = true, features = ["serde"] }
 diff-struct = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/vite_str/src/lib.rs
+++ b/crates/vite_str/src/lib.rs
@@ -16,6 +16,7 @@ use diff::Diff;
 use serde::{Deserialize, Serialize};
 use wincode::{
     SchemaRead, SchemaWrite,
+    config::Config,
     error::{ReadResult, WriteResult},
     io::{Reader, Writer},
 };
@@ -114,23 +115,25 @@ impl Debug for Str {
     }
 }
 
-impl SchemaWrite for Str {
+// SAFETY: Delegates to `str`'s SchemaWrite impl, preserving its size/write invariants.
+unsafe impl<C: Config> SchemaWrite<C> for Str {
     type Src = Self;
 
     fn size_of(src: &Self::Src) -> WriteResult<usize> {
-        <str as SchemaWrite>::size_of(src.as_str())
+        <str as SchemaWrite<C>>::size_of(src.as_str())
     }
 
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
-        <str as SchemaWrite>::write(writer, src.as_str())
+    fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+        <str as SchemaWrite<C>>::write(writer, src.as_str())
     }
 }
 
-impl<'de> SchemaRead<'de> for Str {
+// SAFETY: Delegates to `&str`'s SchemaRead impl and wraps the result; dst is initialized on Ok.
+unsafe impl<'de, C: Config> SchemaRead<'de, C> for Str {
     type Dst = Self;
 
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let s: &str = <&str>::get(reader)?;
+    fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let s: &str = <&str as SchemaRead<'de, C>>::get(&mut reader)?;
         dst.write(Self(CompactString::from(s)));
         Ok(())
     }

--- a/crates/vite_str/src/lib.rs
+++ b/crates/vite_str/src/lib.rs
@@ -129,12 +129,8 @@ impl SchemaWrite for Str {
 impl<'de> SchemaRead<'de> for Str {
     type Dst = Self;
 
-    #[expect(
-        clippy::disallowed_types,
-        reason = "wincode String decode, converted to CompactString"
-    )]
     fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let s: String = String::get(reader)?;
+        let s: &str = <&str>::get(reader)?;
         dst.write(Self(CompactString::from(s)));
         Ok(())
     }

--- a/crates/vite_str/src/lib.rs
+++ b/crates/vite_str/src/lib.rs
@@ -3,24 +3,22 @@ use std::{
     borrow::Borrow,
     ffi::OsStr,
     fmt::{Debug, Display},
+    mem::MaybeUninit,
     ops::Deref,
     path::Path,
-    str::from_utf8,
     sync::Arc,
 };
 
-use bincode::{
-    Decode, Encode,
-    de::{Decoder, read::Reader},
-    enc::Encoder,
-    error::{DecodeError, EncodeError},
-    impl_borrow_decode,
-};
 use compact_str::CompactString;
 #[doc(hidden)] // for `format` macro only
 pub use compact_str::format_compact;
 use diff::Diff;
 use serde::{Deserialize, Serialize};
+use wincode::{
+    SchemaRead, SchemaWrite,
+    error::{ReadResult, WriteResult},
+    io::{Reader, Writer},
+};
 
 #[macro_export]
 macro_rules! format {
@@ -116,34 +114,31 @@ impl Debug for Str {
     }
 }
 
-impl Encode for Str {
-    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        self.0.encode(encoder)
+impl SchemaWrite for Str {
+    type Src = Self;
+
+    fn size_of(src: &Self::Src) -> WriteResult<usize> {
+        <str as SchemaWrite>::size_of(src.as_str())
+    }
+
+    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+        <str as SchemaWrite>::write(writer, src.as_str())
     }
 }
 
-// https://github.com/bincode-org/bincode/blob/48ac8d4e8057387696a7ed3af2dda198ead23246/src/de/mod.rs#L331
-fn decode_slice_len<D: Decoder>(decoder: &mut D) -> Result<usize, DecodeError> {
-    let v = u64::decode(decoder)?;
-    v.try_into().map_err(|_| DecodeError::OutsideUsizeRange(v))
-}
-impl<Context> Decode<Context> for Str {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
-        let len = decode_slice_len(decoder)?;
-        decoder.claim_container_read::<u8>(len)?;
+impl<'de> SchemaRead<'de> for Str {
+    type Dst = Self;
 
-        let mut compact_str = CompactString::with_capacity(len);
-        // SAFETY: we write exactly `len` bytes into the spare capacity, validate UTF-8, then set length
-        unsafe {
-            let buf = &mut compact_str.as_mut_bytes()[..len];
-            decoder.reader().read(buf)?;
-            from_utf8(buf).map_err(|utf8_error| DecodeError::Utf8 { inner: utf8_error })?;
-            compact_str.set_len(len);
-        }
-        Ok(Self(compact_str))
+    #[expect(
+        clippy::disallowed_types,
+        reason = "wincode String decode, converted to CompactString"
+    )]
+    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let s: String = String::get(reader)?;
+        dst.write(Self(CompactString::from(s)));
+        Ok(())
     }
 }
-impl_borrow_decode!(Str);
 
 impl From<&str> for Str {
     fn from(value: &str) -> Self {
@@ -188,7 +183,7 @@ mod ts_impl {
 
     use super::Str;
 
-    #[expect(clippy::disallowed_types, reason = "ts-rs trait requires returning String")]
+    #[expect(clippy::disallowed_types, reason = "ts_rs::TS trait requires returning String")]
     impl TS for Str {
         type OptionInnerType = Self;
         type WithoutGenerics = Self;
@@ -217,17 +212,13 @@ mod ts_impl {
 
 #[cfg(test)]
 mod tests {
-    use bincode::{config::standard, decode_from_slice, encode_to_vec};
-
     use super::*;
 
     #[test]
     fn test_str_encode_decode() {
-        let config = standard();
         let original = Str::from("Hello, World!");
-        let encoded = encode_to_vec(&original, config).unwrap();
-
-        let decoded: Str = decode_from_slice(&encoded, config).unwrap().0;
+        let encoded = wincode::serialize(&original).unwrap();
+        let decoded: Str = wincode::deserialize(&encoded).unwrap();
         assert_eq!(original, decoded);
     }
 }

--- a/crates/vite_task/Cargo.toml
+++ b/crates/vite_task/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-bincode = { workspace = true, features = ["derive"] }
+wincode = { workspace = true }
 bstr = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 ctrlc = { workspace = true }

--- a/crates/vite_task/Cargo.toml
+++ b/crates/vite_task/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-wincode = { workspace = true }
+wincode = { workspace = true, features = ["derive"] }
 bstr = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 ctrlc = { workspace = true }

--- a/crates/vite_task/src/collections.rs
+++ b/crates/vite_task/src/collections.rs
@@ -1,2 +1,2 @@
-#[expect(clippy::disallowed_types, reason = "std HashMap needed for bincode/serde compatibility")]
+#[expect(clippy::disallowed_types, reason = "std HashMap needed for wincode/serde compatibility")]
 pub type HashMap<K, V> = std::collections::HashMap<K, V>;

--- a/crates/vite_task/src/maybe_str.rs
+++ b/crates/vite_task/src/maybe_str.rs
@@ -3,14 +3,14 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use bincode::{Decode, Encode};
 use bstr::BStr;
 use serde::Serialize;
+use wincode::{SchemaRead, SchemaWrite};
 
-/// Similar to `bstr::BString`, but also implements `bincode::{Encode`, Decode},
+/// Similar to `bstr::BString`, but also implements `wincode::{SchemaWrite, SchemaRead}`,
 /// and serializes losslessly to utf8 for outputting debug json
 
-#[derive(Encode, Decode)]
+#[derive(SchemaWrite, SchemaRead)]
 #[expect(dead_code, reason = "struct fields accessed via Deref<Target = Vec<u8>>")]
 pub struct MaybeString(Vec<u8>);
 

--- a/crates/vite_task/src/session/cache/mod.rs
+++ b/crates/vite_task/src/session/cache/mod.rs
@@ -18,6 +18,7 @@ use vite_task_graph::config::ResolvedInputConfig;
 use vite_task_plan::cache_metadata::{CacheMetadata, ExecutionCacheKey, SpawnFingerprint};
 use wincode::{
     SchemaRead, SchemaReadOwned, SchemaWrite,
+    config::{ConfigCore, DefaultConfig},
     error::{ReadResult, WriteResult},
     io::{Reader, Writer},
 };
@@ -57,29 +58,31 @@ impl CacheEntryKey {
 /// wincode schema adapter for `Duration`.
 struct DurationSchema;
 
-impl SchemaWrite for DurationSchema {
+// SAFETY: Writes exactly `size_of::<u64>() + size_of::<u32>()` bytes matching size_of.
+unsafe impl<C: ConfigCore> SchemaWrite<C> for DurationSchema {
     type Src = Duration;
 
     fn size_of(_src: &Self::Src) -> WriteResult<usize> {
         Ok(size_of::<u64>() + size_of::<u32>())
     }
 
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
-        u64::write(writer, &src.as_secs())?;
-        u32::write(writer, &src.subsec_nanos())?;
+    fn write(mut writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+        <u64 as SchemaWrite<C>>::write(writer.by_ref(), &src.as_secs())?;
+        <u32 as SchemaWrite<C>>::write(writer.by_ref(), &src.subsec_nanos())?;
         Ok(())
     }
 }
 
-impl<'de> SchemaRead<'de> for DurationSchema {
+// SAFETY: Reads u64 + u32, matching the write format; dst is initialized on Ok.
+unsafe impl<'de, C: ConfigCore> SchemaRead<'de, C> for DurationSchema {
     type Dst = Duration;
 
     fn read(
-        reader: &mut impl Reader<'de>,
+        mut reader: impl Reader<'de>,
         dst: &mut std::mem::MaybeUninit<Self::Dst>,
     ) -> ReadResult<()> {
-        let secs = u64::get(reader)?;
-        let nanos = u32::get(reader)?;
+        let secs = <u64 as SchemaRead<'de, C>>::get(&mut reader)?;
+        let nanos = <u32 as SchemaRead<'de, C>>::get(&mut reader)?;
         dst.write(Duration::new(secs, nanos));
         Ok(())
     }
@@ -180,10 +183,6 @@ impl ExecutionCache {
         // Use file lock to prevent race conditions when multiple processes initialize the database
         let lock_path = path.join("db_open.lock");
         let lock_file = File::create(lock_path.as_path())?;
-        #[expect(
-            clippy::incompatible_msrv,
-            reason = "File::lock is stable since 1.84.0, our MSRV 1.88.0 is higher; clippy false positive"
-        )]
         lock_file.lock()?;
 
         let db_path = path.join("cache.db");
@@ -361,7 +360,10 @@ impl ExecutionCache {
         clippy::significant_drop_tightening,
         reason = "lock guard cannot be dropped earlier because prepared statement borrows connection"
     )]
-    async fn get_key_by_value<K: SchemaWrite<Src = K>, V: SchemaReadOwned<Dst = V>>(
+    async fn get_key_by_value<
+        K: SchemaWrite<DefaultConfig, Src = K>,
+        V: SchemaReadOwned<DefaultConfig, Dst = V>,
+    >(
         &self,
         table: &str,
         key: &K,
@@ -404,7 +406,10 @@ impl ExecutionCache {
         clippy::significant_drop_tightening,
         reason = "lock guard must be held while executing the prepared statement"
     )]
-    async fn upsert<K: SchemaWrite<Src = K>, V: SchemaWrite<Src = V>>(
+    async fn upsert<
+        K: SchemaWrite<DefaultConfig, Src = K>,
+        V: SchemaWrite<DefaultConfig, Src = V>,
+    >(
         &self,
         table: &str,
         key: &K,
@@ -442,8 +447,8 @@ impl ExecutionCache {
         reason = "lock guard must be held while iterating over query rows"
     )]
     async fn list_table<
-        K: SchemaReadOwned<Dst = K> + Serialize,
-        V: SchemaReadOwned<Dst = V> + Serialize,
+        K: SchemaReadOwned<DefaultConfig, Dst = K> + Serialize,
+        V: SchemaReadOwned<DefaultConfig, Dst = V> + Serialize,
     >(
         &self,
         table: &str,

--- a/crates/vite_task/src/session/cache/mod.rs
+++ b/crates/vite_task/src/session/cache/mod.rs
@@ -89,51 +89,17 @@ impl<'de> SchemaRead<'de> for DurationSchema {
 ///
 /// Contains the post-run fingerprint (from fspy), captured outputs,
 /// execution duration, and explicit input file hashes.
-#[derive(Debug, Serialize)]
+#[derive(Debug, SchemaWrite, SchemaRead, Serialize)]
 pub struct CacheEntryValue {
     pub post_run_fingerprint: PostRunFingerprint,
     pub std_outputs: Arc<[StdOutput]>,
+    #[wincode(with = "DurationSchema")]
     pub duration: Duration,
     /// Hashes of explicit input files computed from positive globs.
     /// Files matching negative globs are already filtered out.
     /// Path is relative to workspace root, value is `xxHash3_64` of file content.
     /// Stored in the value (not the key) so changes can be detected and reported.
     pub globbed_inputs: BTreeMap<RelativePathBuf, u64>,
-}
-
-impl SchemaWrite for CacheEntryValue {
-    type Src = Self;
-
-    fn size_of(src: &Self::Src) -> WriteResult<usize> {
-        Ok(PostRunFingerprint::size_of(&src.post_run_fingerprint)?
-            + <Arc<[StdOutput]>>::size_of(&src.std_outputs)?
-            + DurationSchema::size_of(&src.duration)?
-            + <BTreeMap<RelativePathBuf, u64>>::size_of(&src.globbed_inputs)?)
-    }
-
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
-        PostRunFingerprint::write(writer, &src.post_run_fingerprint)?;
-        <Arc<[StdOutput]>>::write(writer, &src.std_outputs)?;
-        DurationSchema::write(writer, &src.duration)?;
-        <BTreeMap<RelativePathBuf, u64>>::write(writer, &src.globbed_inputs)?;
-        Ok(())
-    }
-}
-
-impl<'de> SchemaRead<'de> for CacheEntryValue {
-    type Dst = Self;
-
-    fn read(
-        reader: &mut impl Reader<'de>,
-        dst: &mut std::mem::MaybeUninit<Self::Dst>,
-    ) -> ReadResult<()> {
-        let post_run_fingerprint = <PostRunFingerprint as SchemaRead<'_>>::get(reader)?;
-        let std_outputs = <Arc<[StdOutput]> as SchemaRead<'_>>::get(reader)?;
-        let duration = <DurationSchema as SchemaRead<'_>>::get(reader)?;
-        let globbed_inputs = <BTreeMap<RelativePathBuf, u64> as SchemaRead<'_>>::get(reader)?;
-        dst.write(Self { post_run_fingerprint, std_outputs, duration, globbed_inputs });
-        Ok(())
-    }
 }
 
 #[derive(Debug)]

--- a/crates/vite_task/src/session/cache/mod.rs
+++ b/crates/vite_task/src/session/cache/mod.rs
@@ -4,7 +4,6 @@ pub mod display;
 
 use std::{collections::BTreeMap, fmt::Display, fs::File, io::Write, sync::Arc, time::Duration};
 
-use bincode::{Decode, Encode, decode_from_slice, encode_to_vec};
 // Re-export display functions for convenience
 pub use display::format_cache_status_inline;
 pub use display::{
@@ -17,6 +16,11 @@ use tokio::sync::Mutex;
 use vite_path::{AbsolutePath, RelativePathBuf};
 use vite_task_graph::config::ResolvedInputConfig;
 use vite_task_plan::cache_metadata::{CacheMetadata, ExecutionCacheKey, SpawnFingerprint};
+use wincode::{
+    SchemaRead, SchemaReadOwned, SchemaWrite,
+    error::{ReadResult, WriteResult},
+    io::{Reader, Writer},
+};
 
 use super::execute::{fingerprint::PostRunFingerprint, spawn::StdOutput};
 
@@ -32,7 +36,7 @@ use super::execute::{fingerprint::PostRunFingerprint, spawn::StdOutput};
 /// overwrite the existing entry (e.g., input file hashes — there's no
 /// reason to keep the old hash around, and storing them in the value
 /// lets us report exactly *which file* changed).
-#[derive(Debug, Encode, Decode, Serialize, PartialEq, Eq, Clone)]
+#[derive(Debug, SchemaWrite, SchemaRead, Serialize, PartialEq, Eq, Clone)]
 pub struct CacheEntryKey {
     /// The spawn fingerprint (command, args, cwd, envs)
     pub spawn_fingerprint: SpawnFingerprint,
@@ -50,11 +54,42 @@ impl CacheEntryKey {
     }
 }
 
+/// wincode schema adapter for `Duration`.
+struct DurationSchema;
+
+impl SchemaWrite for DurationSchema {
+    type Src = Duration;
+
+    fn size_of(_src: &Self::Src) -> WriteResult<usize> {
+        Ok(size_of::<u64>() + size_of::<u32>())
+    }
+
+    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+        u64::write(writer, &src.as_secs())?;
+        u32::write(writer, &src.subsec_nanos())?;
+        Ok(())
+    }
+}
+
+impl<'de> SchemaRead<'de> for DurationSchema {
+    type Dst = Duration;
+
+    fn read(
+        reader: &mut impl Reader<'de>,
+        dst: &mut std::mem::MaybeUninit<Self::Dst>,
+    ) -> ReadResult<()> {
+        let secs = u64::get(reader)?;
+        let nanos = u32::get(reader)?;
+        dst.write(Duration::new(secs, nanos));
+        Ok(())
+    }
+}
+
 /// Cached execution result for a task.
 ///
 /// Contains the post-run fingerprint (from fspy), captured outputs,
 /// execution duration, and explicit input file hashes.
-#[derive(Debug, Encode, Decode, Serialize)]
+#[derive(Debug, Serialize)]
 pub struct CacheEntryValue {
     pub post_run_fingerprint: PostRunFingerprint,
     pub std_outputs: Arc<[StdOutput]>,
@@ -66,12 +101,45 @@ pub struct CacheEntryValue {
     pub globbed_inputs: BTreeMap<RelativePathBuf, u64>,
 }
 
+impl SchemaWrite for CacheEntryValue {
+    type Src = Self;
+
+    fn size_of(src: &Self::Src) -> WriteResult<usize> {
+        Ok(PostRunFingerprint::size_of(&src.post_run_fingerprint)?
+            + <Arc<[StdOutput]>>::size_of(&src.std_outputs)?
+            + DurationSchema::size_of(&src.duration)?
+            + <BTreeMap<RelativePathBuf, u64>>::size_of(&src.globbed_inputs)?)
+    }
+
+    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+        PostRunFingerprint::write(writer, &src.post_run_fingerprint)?;
+        <Arc<[StdOutput]>>::write(writer, &src.std_outputs)?;
+        DurationSchema::write(writer, &src.duration)?;
+        <BTreeMap<RelativePathBuf, u64>>::write(writer, &src.globbed_inputs)?;
+        Ok(())
+    }
+}
+
+impl<'de> SchemaRead<'de> for CacheEntryValue {
+    type Dst = Self;
+
+    fn read(
+        reader: &mut impl Reader<'de>,
+        dst: &mut std::mem::MaybeUninit<Self::Dst>,
+    ) -> ReadResult<()> {
+        let post_run_fingerprint = <PostRunFingerprint as SchemaRead<'_>>::get(reader)?;
+        let std_outputs = <Arc<[StdOutput]> as SchemaRead<'_>>::get(reader)?;
+        let duration = <DurationSchema as SchemaRead<'_>>::get(reader)?;
+        let globbed_inputs = <BTreeMap<RelativePathBuf, u64> as SchemaRead<'_>>::get(reader)?;
+        dst.write(Self { post_run_fingerprint, std_outputs, duration, globbed_inputs });
+        Ok(())
+    }
+}
+
 #[derive(Debug)]
 pub struct ExecutionCache {
     conn: Mutex<Connection>,
 }
-
-const BINCODE_CONFIG: bincode::config::Configuration = bincode::config::standard();
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[expect(
@@ -168,16 +236,16 @@ impl ExecutionCache {
                         "CREATE TABLE task_fingerprints (key BLOB PRIMARY KEY, value BLOB);",
                         (),
                     )?;
-                    conn.execute("PRAGMA user_version = 10", ())?;
+                    conn.execute("PRAGMA user_version = 11", ())?;
                 }
-                1..=9 => {
+                1..=10 => {
                     // old internal db version. reset
                     conn.set_db_config(DbConfig::SQLITE_DBCONFIG_RESET_DATABASE, true)?;
                     conn.execute("VACUUM", ())?;
                     conn.set_db_config(DbConfig::SQLITE_DBCONFIG_RESET_DATABASE, false)?;
                 }
-                10 => break, // current version
-                11.. => {
+                11 => break, // current version
+                12.. => {
                     return Err(anyhow::anyhow!("Unrecognized database version: {user_version}"));
                 }
             }
@@ -327,12 +395,12 @@ impl ExecutionCache {
         clippy::significant_drop_tightening,
         reason = "lock guard cannot be dropped earlier because prepared statement borrows connection"
     )]
-    async fn get_key_by_value<K: Encode, V: Decode<()>>(
+    async fn get_key_by_value<K: SchemaWrite<Src = K>, V: SchemaReadOwned<Dst = V>>(
         &self,
         table: &str,
         key: &K,
     ) -> anyhow::Result<Option<V>> {
-        let key_blob = encode_to_vec(key, BINCODE_CONFIG)?;
+        let key_blob = wincode::serialize(key)?;
         let value_blob = {
             let conn = self.conn.lock().await;
             #[expect(
@@ -348,7 +416,7 @@ impl ExecutionCache {
         let Some(value_blob) = value_blob else {
             return Ok(None);
         };
-        let (value, _) = decode_from_slice::<V, _>(&value_blob, BINCODE_CONFIG)?;
+        let value: V = wincode::deserialize(&value_blob)?;
         Ok(Some(value))
     }
 
@@ -370,14 +438,14 @@ impl ExecutionCache {
         clippy::significant_drop_tightening,
         reason = "lock guard must be held while executing the prepared statement"
     )]
-    async fn upsert<K: Encode, V: Encode>(
+    async fn upsert<K: SchemaWrite<Src = K>, V: SchemaWrite<Src = V>>(
         &self,
         table: &str,
         key: &K,
         value: &V,
     ) -> anyhow::Result<()> {
-        let key_blob = encode_to_vec(key, BINCODE_CONFIG)?;
-        let value_blob = encode_to_vec(value, BINCODE_CONFIG)?;
+        let key_blob = wincode::serialize(key)?;
+        let value_blob = wincode::serialize(value)?;
         let conn = self.conn.lock().await;
         #[expect(clippy::disallowed_macros, reason = "SQL query string for rusqlite requires String")]
         let mut update_stmt = conn.prepare_cached(&format!(
@@ -407,7 +475,10 @@ impl ExecutionCache {
         clippy::significant_drop_tightening,
         reason = "lock guard must be held while iterating over query rows"
     )]
-    async fn list_table<K: Decode<()> + Serialize, V: Decode<()> + Serialize>(
+    async fn list_table<
+        K: SchemaReadOwned<Dst = K> + Serialize,
+        V: SchemaReadOwned<Dst = V> + Serialize,
+    >(
         &self,
         table: &str,
         out: &mut impl Write,
@@ -422,8 +493,8 @@ impl ExecutionCache {
         while let Some(row) = rows.next()? {
             let key_blob: Vec<u8> = row.get(0)?;
             let value_blob: Vec<u8> = row.get(1)?;
-            let (key, _) = decode_from_slice::<K, _>(&key_blob, BINCODE_CONFIG)?;
-            let (value, _) = decode_from_slice::<V, _>(&value_blob, BINCODE_CONFIG)?;
+            let key: K = wincode::deserialize(&key_blob)?;
+            let value: V = wincode::deserialize(&value_blob)?;
             writeln!(
                 out,
                 "{} => {}",

--- a/crates/vite_task/src/session/execute/fingerprint.rs
+++ b/crates/vite_task/src/session/execute/fingerprint.rs
@@ -10,18 +10,18 @@ use std::{
     sync::Arc,
 };
 
-use bincode::{Decode, Encode};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 use vite_path::{AbsolutePath, RelativePathBuf};
 use vite_str::Str;
+use wincode::{SchemaRead, SchemaWrite};
 
 use super::spawn::PathRead;
 use crate::{collections::HashMap, session::cache::InputChangeKind};
 
 /// Post-run fingerprint capturing file state after execution.
 /// Used to validate whether cached outputs are still valid.
-#[derive(Encode, Decode, Debug, Serialize)]
+#[derive(SchemaWrite, SchemaRead, Debug, Serialize)]
 pub struct PostRunFingerprint {
     /// Paths inferred from fspy during execution with their content fingerprints.
     /// Only populated when `input_config.includes_auto` is true.
@@ -29,7 +29,7 @@ pub struct PostRunFingerprint {
 }
 
 /// Fingerprint for a single path (file or directory)
-#[derive(Encode, Decode, PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+#[derive(SchemaWrite, SchemaRead, PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
 pub enum PathFingerprint {
     /// Path was not found when fingerprinting
     NotFound,
@@ -43,7 +43,7 @@ pub enum PathFingerprint {
 }
 
 /// Kind of directory entry
-#[derive(Encode, Decode, PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+#[derive(SchemaWrite, SchemaRead, PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
 pub enum DirEntryKind {
     File,
     Dir,

--- a/crates/vite_task/src/session/execute/spawn.rs
+++ b/crates/vite_task/src/session/execute/spawn.rs
@@ -7,7 +7,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use bincode::{Decode, Encode};
 use fspy::AccessMode;
 use rustc_hash::FxHashSet;
 use serde::Serialize;
@@ -16,6 +15,7 @@ use tokio_util::sync::CancellationToken;
 use vite_path::{AbsolutePath, RelativePathBuf};
 use vite_task_plan::SpawnCommand;
 use wax::Program as _;
+use wincode::{SchemaRead, SchemaWrite};
 
 use crate::collections::HashMap;
 
@@ -26,14 +26,14 @@ pub struct PathRead {
 }
 
 /// Output kind for stdout/stderr
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, SchemaWrite, SchemaRead, Serialize)]
 pub enum OutputKind {
     StdOut,
     StdErr,
 }
 
 /// Output chunk with stream kind
-#[derive(Debug, Encode, Decode, Serialize, Clone)]
+#[derive(Debug, SchemaWrite, SchemaRead, Serialize, Clone)]
 pub struct StdOutput {
     pub kind: OutputKind,
     pub content: Vec<u8>,

--- a/crates/vite_task_graph/Cargo.toml
+++ b/crates/vite_task_graph/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-bincode = { workspace = true }
+wincode = { workspace = true }
 monostate = { workspace = true }
 petgraph = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/vite_task_graph/Cargo.toml
+++ b/crates/vite_task_graph/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-wincode = { workspace = true }
+wincode = { workspace = true, features = ["derive"] }
 monostate = { workspace = true }
 petgraph = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/vite_task_graph/src/config/mod.rs
+++ b/crates/vite_task_graph/src/config/mod.rs
@@ -2,7 +2,6 @@ pub mod user;
 
 use std::{collections::BTreeSet, sync::Arc};
 
-use bincode::{Decode, Encode};
 use monostate::MustBe;
 use rustc_hash::FxHashSet;
 use serde::Serialize;
@@ -13,6 +12,7 @@ pub use user::{
 };
 use vite_path::AbsolutePath;
 use vite_str::Str;
+use wincode::{SchemaRead, SchemaWrite};
 
 use crate::config::user::UserTaskOptions;
 
@@ -103,7 +103,7 @@ pub struct CacheConfig {
 /// - `includes_auto`: Whether automatic file tracking is enabled
 /// - `positive_globs`: Glob patterns for files to include (without `!` prefix)
 /// - `negative_globs`: Glob patterns for files to exclude (without `!` prefix)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, SchemaWrite, SchemaRead)]
 pub struct ResolvedInputConfig {
     /// Whether automatic file tracking is enabled
     pub includes_auto: bool,

--- a/crates/vite_task_plan/Cargo.toml
+++ b/crates/vite_task_plan/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-bincode = { workspace = true }
+wincode = { workspace = true }
 futures-util = { workspace = true }
 petgraph = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/vite_task_plan/Cargo.toml
+++ b/crates/vite_task_plan/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-wincode = { workspace = true }
+wincode = { workspace = true, features = ["derive"] }
 futures-util = { workspace = true }
 petgraph = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/vite_task_plan/src/cache_metadata.rs
+++ b/crates/vite_task_plan/src/cache_metadata.rs
@@ -1,15 +1,15 @@
 use std::sync::Arc;
 
-use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use vite_path::RelativePathBuf;
 use vite_str::{self, Str};
 use vite_task_graph::config::ResolvedInputConfig;
+use wincode::{SchemaRead, SchemaWrite};
 
 use crate::envs::EnvFingerprints;
 
 /// Key to identify an execution across sessions.
-#[derive(Debug, Encode, Decode, Serialize)]
+#[derive(Debug, SchemaWrite, SchemaRead, Serialize)]
 pub enum ExecutionCacheKey {
     /// This execution is from a script of a user-defined task.
     UserTask {
@@ -67,7 +67,7 @@ pub struct CacheMetadata {
 /// - The resolver provides envs which become part of the fingerprint
 /// - If resolver provides different envs between runs, cache breaks
 /// - Each built-in task type must have unique task name to avoid cache collision
-#[derive(Encode, Decode, Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(SchemaWrite, SchemaRead, Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct SpawnFingerprint {
     pub(crate) cwd: RelativePathBuf,
     pub(crate) program_fingerprint: ProgramFingerprint,
@@ -102,7 +102,7 @@ impl SpawnFingerprint {
 }
 
 /// The program fingerprint used in `SpawnFingerprint`
-#[derive(Encode, Decode, Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(SchemaWrite, SchemaRead, Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub(crate) enum ProgramFingerprint {
     /// If the program is outside the workspace, fingerprint by its name only (like `node`, `npm`, etc)
     OutsideWorkspace { program_name: Str },

--- a/crates/vite_task_plan/src/envs.rs
+++ b/crates/vite_task_plan/src/envs.rs
@@ -28,13 +28,12 @@ impl SchemaWrite for ArcStrSchema {
     }
 }
 
-#[expect(clippy::disallowed_types, reason = "wincode decode: String → Arc<str>")]
 impl<'de> SchemaRead<'de> for ArcStrSchema {
     type Dst = Arc<str>;
 
     fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let s: String = String::get(reader)?;
-        dst.write(Arc::from(s.as_str()));
+        let s: &str = <&str>::get(reader)?;
+        dst.write(Arc::from(s));
         Ok(())
     }
 }
@@ -43,46 +42,18 @@ impl<'de> SchemaRead<'de> for ArcStrSchema {
 ///
 /// Contents of this struct are only for fingerprinting and cache key computation (some of envs may be hashed for security).
 /// The actual environment variables to be passed to the execution are in `LeafExecutionItem.all_envs`.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, SchemaWrite, SchemaRead, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct EnvFingerprints {
     /// Environment variables that should be fingerprinted for this execution.
     ///
     /// Use `BTreeMap` to ensure stable order.
+    #[wincode(with = "BTreeMap<Str, ArcStrSchema>")]
     pub fingerprinted_envs: BTreeMap<Str, Arc<str>>,
 
     /// Environment variable names that should be passed through without values being fingerprinted.
     ///
     /// Names are still included in the fingerprint so that changes to these names can invalidate the cache.
     pub untracked_env_config: Arc<[Str]>,
-}
-
-impl SchemaWrite for EnvFingerprints {
-    type Src = Self;
-
-    fn size_of(src: &Self::Src) -> WriteResult<usize> {
-        Ok(<BTreeMap<Str, ArcStrSchema>>::size_of(&src.fingerprinted_envs)?
-            + <Arc<[Str]>>::size_of(&src.untracked_env_config)?)
-    }
-
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
-        <BTreeMap<Str, ArcStrSchema>>::write(writer, &src.fingerprinted_envs)?;
-        <Arc<[Str]>>::write(writer, &src.untracked_env_config)?;
-        Ok(())
-    }
-}
-
-impl<'de> SchemaRead<'de> for EnvFingerprints {
-    type Dst = Self;
-
-    fn read(
-        reader: &mut impl Reader<'de>,
-        dst: &mut std::mem::MaybeUninit<Self::Dst>,
-    ) -> ReadResult<()> {
-        let fingerprinted_envs = <BTreeMap<Str, ArcStrSchema> as SchemaRead<'_>>::get(reader)?;
-        let untracked_env_config = <Arc<[Str]> as SchemaRead<'_>>::get(reader)?;
-        dst.write(Self { fingerprinted_envs, untracked_env_config });
-        Ok(())
-    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/vite_task_plan/src/envs.rs
+++ b/crates/vite_task_plan/src/envs.rs
@@ -1,6 +1,5 @@
-use std::{collections::BTreeMap, ffi::OsStr, sync::Arc};
+use std::{collections::BTreeMap, ffi::OsStr, mem::MaybeUninit, sync::Arc};
 
-use bincode::{Decode, Encode};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
@@ -8,12 +7,43 @@ use supports_color::{Stream, on};
 use vite_glob::GlobPatternSet;
 use vite_str::Str;
 use vite_task_graph::config::EnvConfig;
+use wincode::{
+    SchemaRead, SchemaWrite,
+    error::{ReadResult, WriteResult},
+    io::{Reader, Writer},
+};
+
+/// wincode schema adapter for `Arc<str>`, which is a foreign type with unsized inner.
+struct ArcStrSchema;
+
+impl SchemaWrite for ArcStrSchema {
+    type Src = Arc<str>;
+
+    fn size_of(src: &Self::Src) -> WriteResult<usize> {
+        <str as SchemaWrite>::size_of(src)
+    }
+
+    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+        <str as SchemaWrite>::write(writer, src)
+    }
+}
+
+#[expect(clippy::disallowed_types, reason = "wincode decode: String → Arc<str>")]
+impl<'de> SchemaRead<'de> for ArcStrSchema {
+    type Dst = Arc<str>;
+
+    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let s: String = String::get(reader)?;
+        dst.write(Arc::from(s.as_str()));
+        Ok(())
+    }
+}
 
 /// Environment variable fingerprints for a task execution.
 ///
 /// Contents of this struct are only for fingerprinting and cache key computation (some of envs may be hashed for security).
 /// The actual environment variables to be passed to the execution are in `LeafExecutionItem.all_envs`.
-#[derive(Debug, Encode, Decode, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct EnvFingerprints {
     /// Environment variables that should be fingerprinted for this execution.
     ///
@@ -24,6 +54,35 @@ pub struct EnvFingerprints {
     ///
     /// Names are still included in the fingerprint so that changes to these names can invalidate the cache.
     pub untracked_env_config: Arc<[Str]>,
+}
+
+impl SchemaWrite for EnvFingerprints {
+    type Src = Self;
+
+    fn size_of(src: &Self::Src) -> WriteResult<usize> {
+        Ok(<BTreeMap<Str, ArcStrSchema>>::size_of(&src.fingerprinted_envs)?
+            + <Arc<[Str]>>::size_of(&src.untracked_env_config)?)
+    }
+
+    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
+        <BTreeMap<Str, ArcStrSchema>>::write(writer, &src.fingerprinted_envs)?;
+        <Arc<[Str]>>::write(writer, &src.untracked_env_config)?;
+        Ok(())
+    }
+}
+
+impl<'de> SchemaRead<'de> for EnvFingerprints {
+    type Dst = Self;
+
+    fn read(
+        reader: &mut impl Reader<'de>,
+        dst: &mut std::mem::MaybeUninit<Self::Dst>,
+    ) -> ReadResult<()> {
+        let fingerprinted_envs = <BTreeMap<Str, ArcStrSchema> as SchemaRead<'_>>::get(reader)?;
+        let untracked_env_config = <Arc<[Str]> as SchemaRead<'_>>::get(reader)?;
+        dst.write(Self { fingerprinted_envs, untracked_env_config });
+        Ok(())
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/vite_task_plan/src/envs.rs
+++ b/crates/vite_task_plan/src/envs.rs
@@ -9,6 +9,7 @@ use vite_str::Str;
 use vite_task_graph::config::EnvConfig;
 use wincode::{
     SchemaRead, SchemaWrite,
+    config::Config,
     error::{ReadResult, WriteResult},
     io::{Reader, Writer},
 };
@@ -16,23 +17,25 @@ use wincode::{
 /// wincode schema adapter for `Arc<str>`, which is a foreign type with unsized inner.
 struct ArcStrSchema;
 
-impl SchemaWrite for ArcStrSchema {
+// SAFETY: Delegates to `str`'s SchemaWrite impl, preserving its size/write invariants.
+unsafe impl<C: Config> SchemaWrite<C> for ArcStrSchema {
     type Src = Arc<str>;
 
     fn size_of(src: &Self::Src) -> WriteResult<usize> {
-        <str as SchemaWrite>::size_of(src)
+        <str as SchemaWrite<C>>::size_of(src)
     }
 
-    fn write(writer: &mut impl Writer, src: &Self::Src) -> WriteResult<()> {
-        <str as SchemaWrite>::write(writer, src)
+    fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+        <str as SchemaWrite<C>>::write(writer, src)
     }
 }
 
-impl<'de> SchemaRead<'de> for ArcStrSchema {
+// SAFETY: Delegates to `&str`'s SchemaRead impl; dst is initialized on Ok.
+unsafe impl<'de, C: Config> SchemaRead<'de, C> for ArcStrSchema {
     type Dst = Arc<str>;
 
-    fn read(reader: &mut impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let s: &str = <&str>::get(reader)?;
+    fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let s: &str = <&str as SchemaRead<'de, C>>::get(&mut reader)?;
         dst.write(Arc::from(s));
         Ok(())
     }


### PR DESCRIPTION
## Why

bincode is unmaintained. The author ceased development and published a [final 3.0.0 release](https://docs.rs/crate/bincode/3.0.0) containing only a compiler error to inform users. wincode is the recommended bincode-compatible drop-in replacement.

## Summary
- Replace bincode 2.x with wincode across all 14 crates for in-place initialization and direct memory writes without intermediate staging buffers
- Use wincode's foreign type adoption for `Arc<str>` and `Duration` (manual `SchemaWrite`/`SchemaRead` impls)
- Borrowed zero-copy deserialization preserved for `&NativeStr`, `&NativePath`, `PathAccess<'a>`, `Payload<'a>`
- Bump cache version from 10 → 11

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` passes (no warnings)
- [x] All 23 workspace test suites pass (excluding 3 pre-existing fspy oxlint failures unrelated to this change)
- [x] E2E snapshot tests pass
- [x] Plan snapshot tests pass
- [x] `fspy_shared` IPC channel tests pass (encoding/decoding round-trips correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)