### PR TITLE
chore(deps): switch seccompiler to upstream rust-vmm/seccompiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3005,7 +3005,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "seccompiler"
 version = "0.5.0"
-source = "git+https://github.com/branchseer/seccompiler?branch=seccomp-action-raw#dbccf624efc19685e8b85beb7b0a9fdda0678da2"
+source = "git+https://github.com/rust-vmm/seccompiler?rev=08587106340b8e3cb361c7561411510039436857#08587106340b8e3cb361c7561411510039436857"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ ref-cast = "1.0.24"
 regex = "1.11.3"
 rusqlite = "0.37.0"
 rustc-hash = "2.1.1"
+# SeccompAction::UserNotif (SECCOMP_RET_USER_NOTIF) was added after the latest published release (v0.5.0)
 seccompiler = { git = "https://github.com/rust-vmm/seccompiler", rev = "08587106340b8e3cb361c7561411510039436857" }
 serde = "1.0.219"
 serde_json = "1.0.140"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ ref-cast = "1.0.24"
 regex = "1.11.3"
 rusqlite = "0.37.0"
 rustc-hash = "2.1.1"
-seccompiler = { git = "https://github.com/branchseer/seccompiler", branch = "seccomp-action-raw" }
+seccompiler = { git = "https://github.com/rust-vmm/seccompiler", rev = "08587106340b8e3cb361c7561411510039436857" }
 serde = "1.0.219"
 serde_json = "1.0.140"
 serde_yml = "0.0.12"

--- a/crates/fspy_seccomp_unotify/src/supervisor/mod.rs
+++ b/crates/fspy_seccomp_unotify/src/supervisor/mod.rs
@@ -71,7 +71,7 @@ pub fn supervise<H: SeccompNotifyHandler + Default + Send + 'static>() -> io::Re
     let seccomp_filter = SeccompFilter::new(
         H::syscalls().iter().map(|sysno| (sysno.id().into(), vec![])).collect(),
         SeccompAction::Allow,
-        SeccompAction::Raw(libc::SECCOMP_RET_USER_NOTIF),
+        SeccompAction::UserNotif,
         std::env::consts::ARCH.try_into().unwrap(),
     )
     .unwrap();


### PR DESCRIPTION
## Summary
- Replace the personal fork (`branchseer/seccompiler`, branch `seccomp-action-raw`) with the upstream `rust-vmm/seccompiler` repo
- Use `SeccompAction::UserNotif` (added upstream in commit 0858710) instead of the fork's `SeccompAction::Raw(libc::SECCOMP_RET_USER_NOTIF)`
- Add comment in Cargo.toml explaining why we pin to a git rev (feature not yet in a published release)

## Test plan
- [x] `cargo check -p fspy_seccomp_unotify --features supervisor,target` passes
- [ ] CI passes

https://claude.ai/code/session_01GhffM3Grv8vjp7oDZDtv7C