### PR TITLE
docs(test): move snapshots.toml comment to per-[[e2e]] level

### DIFF
--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/associate_existing_cache/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/associate_existing_cache/snapshots.toml
@@ -1,9 +1,8 @@
+[[e2e]]
+name = "associate_existing_cache"
 comment = """
 Tests that tasks with identical commands share cache
 """
-
-[[e2e]]
-name = "associate_existing_cache"
 steps = [
   { argv = [
     "vt",

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/builtin_different_cwd/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/builtin_different_cwd/snapshots.toml
@@ -1,9 +1,8 @@
+[[e2e]]
+name = "builtin_different_cwd"
 comment = """
 Tests that synthetic tasks have separate cache per cwd
 """
-
-[[e2e]]
-name = "builtin_different_cwd"
 steps = [
   { argv = [
     "vt",

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_disabled/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_disabled/snapshots.toml
@@ -1,7 +1,7 @@
 [[e2e]]
 name = "task_with_cache_disabled"
 comment = """
-Tests that cache: false in task config disables caching
+A task configured with `cache: false` should re-run on every invocation instead of being cached.
 """
 steps = [
   { argv = [
@@ -19,7 +19,7 @@ steps = [
 [[e2e]]
 name = "task_with_cache_enabled"
 comment = """
-Tests that cache: false in task config disables caching
+A task with caching enabled should produce a cache hit on the second run.
 """
 steps = [
   { argv = [

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_disabled/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_disabled/snapshots.toml
@@ -1,9 +1,8 @@
+[[e2e]]
+name = "task_with_cache_disabled"
 comment = """
 Tests that cache: false in task config disables caching
 """
-
-[[e2e]]
-name = "task_with_cache_disabled"
 steps = [
   { argv = [
     "vt",
@@ -19,6 +18,9 @@ steps = [
 
 [[e2e]]
 name = "task_with_cache_enabled"
+comment = """
+Tests that cache: false in task config disables caching
+"""
 steps = [
   { argv = [
     "vt",

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_disabled/snapshots/task_with_cache_disabled.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_disabled/snapshots/task_with_cache_disabled.md
@@ -1,6 +1,6 @@
 # task_with_cache_disabled
 
-Tests that cache: false in task config disables caching
+A task configured with `cache: false` should re-run on every invocation instead of being cached.
 
 ## `vt run no-cache-task`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_disabled/snapshots/task_with_cache_enabled.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_disabled/snapshots/task_with_cache_enabled.md
@@ -1,6 +1,6 @@
 # task_with_cache_enabled
 
-Tests that cache: false in task config disables caching
+A task with caching enabled should produce a cache hit on the second run.
 
 ## `vt run cached-task`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_command_change/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_command_change/snapshots.toml
@@ -1,9 +1,8 @@
+[[e2e]]
+name = "cache_miss_command_change"
 comment = """
 Tests cache behavior when command changes partially
 """
-
-[[e2e]]
-name = "cache_miss_command_change"
 steps = [
   { argv = [
     "vt",

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots.toml
@@ -1,9 +1,8 @@
+[[e2e]]
+name = "env_value_changed"
 comment = """
 Test all cache miss reason variants
 """
-
-[[e2e]]
-name = "env_value_changed"
 steps = [
   { argv = [
     "vt",
@@ -29,6 +28,9 @@ steps = [
 
 [[e2e]]
 name = "env_added"
+comment = """
+Test all cache miss reason variants
+"""
 steps = [
   { argv = [
     "vt",
@@ -49,6 +51,9 @@ steps = [
 
 [[e2e]]
 name = "env_removed"
+comment = """
+Test all cache miss reason variants
+"""
 steps = [
   { argv = [
     "vt",
@@ -69,6 +74,9 @@ steps = [
 
 [[e2e]]
 name = "untracked_env_added"
+comment = """
+Test all cache miss reason variants
+"""
 steps = [
   { argv = [
     "vt",
@@ -91,6 +99,9 @@ steps = [
 
 [[e2e]]
 name = "untracked_env_removed"
+comment = """
+Test all cache miss reason variants
+"""
 steps = [
   { argv = [
     "vtt",
@@ -120,6 +131,9 @@ steps = [
 
 [[e2e]]
 name = "cwd_changed"
+comment = """
+Test all cache miss reason variants
+"""
 steps = [
   { argv = [
     "vt",
@@ -154,6 +168,9 @@ steps = [
 
 [[e2e]]
 name = "inferred_input_changes"
+comment = """
+Test all cache miss reason variants
+"""
 steps = [
   { argv = [
     "vt",
@@ -197,6 +214,9 @@ steps = [
 
 [[e2e]]
 name = "input_config_changed"
+comment = """
+Test all cache miss reason variants
+"""
 steps = [
   { argv = [
     "vt",
@@ -219,6 +239,9 @@ steps = [
 
 [[e2e]]
 name = "glob_input_changes"
+comment = """
+Test all cache miss reason variants
+"""
 steps = [
   { argv = [
     "vt",

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots.toml
@@ -1,7 +1,7 @@
 [[e2e]]
 name = "env_value_changed"
 comment = """
-Test all cache miss reason variants
+Changing the value of a tracked env var between runs should invalidate the cache.
 """
 steps = [
   { argv = [
@@ -29,7 +29,7 @@ steps = [
 [[e2e]]
 name = "env_added"
 comment = """
-Test all cache miss reason variants
+Setting a tracked env var that was previously unset should invalidate the cache.
 """
 steps = [
   { argv = [
@@ -52,7 +52,7 @@ steps = [
 [[e2e]]
 name = "env_removed"
 comment = """
-Test all cache miss reason variants
+Unsetting a tracked env var that was previously set should invalidate the cache.
 """
 steps = [
   { argv = [
@@ -75,7 +75,7 @@ steps = [
 [[e2e]]
 name = "untracked_env_added"
 comment = """
-Test all cache miss reason variants
+Adding an `untrackedEnv` entry to the task config should invalidate the cache.
 """
 steps = [
   { argv = [
@@ -100,7 +100,7 @@ steps = [
 [[e2e]]
 name = "untracked_env_removed"
 comment = """
-Test all cache miss reason variants
+Removing an existing `untrackedEnv` entry from the task config should invalidate the cache.
 """
 steps = [
   { argv = [
@@ -132,7 +132,7 @@ steps = [
 [[e2e]]
 name = "cwd_changed"
 comment = """
-Test all cache miss reason variants
+Changing the task's `cwd` should invalidate the cache, even if the input file exists at the new location.
 """
 steps = [
   { argv = [
@@ -169,7 +169,7 @@ steps = [
 [[e2e]]
 name = "inferred_input_changes"
 comment = """
-Test all cache miss reason variants
+Modifying, removing, and re-adding an input file (tracked via fspy inference) should each invalidate the cache.
 """
 steps = [
   { argv = [
@@ -215,7 +215,7 @@ steps = [
 [[e2e]]
 name = "input_config_changed"
 comment = """
-Test all cache miss reason variants
+Changing the task's `input` configuration should invalidate the cache even when the underlying files are unchanged.
 """
 steps = [
   { argv = [
@@ -240,7 +240,7 @@ steps = [
 [[e2e]]
 name = "glob_input_changes"
 comment = """
-Test all cache miss reason variants
+Modifying, adding, or removing files matched by a glob `input` pattern should each invalidate the cache.
 """
 steps = [
   { argv = [

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/cwd_changed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/cwd_changed.md
@@ -1,6 +1,6 @@
 # cwd_changed
 
-Test all cache miss reason variants
+Changing the task's `cwd` should invalidate the cache, even if the input file exists at the new location.
 
 ## `vt run test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/env_added.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/env_added.md
@@ -1,6 +1,6 @@
 # env_added
 
-Test all cache miss reason variants
+Setting a tracked env var that was previously unset should invalidate the cache.
 
 ## `vt run test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/env_removed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/env_removed.md
@@ -1,6 +1,6 @@
 # env_removed
 
-Test all cache miss reason variants
+Unsetting a tracked env var that was previously set should invalidate the cache.
 
 ## `MY_ENV=1 vt run test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/env_value_changed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/env_value_changed.md
@@ -1,6 +1,6 @@
 # env_value_changed
 
-Test all cache miss reason variants
+Changing the value of a tracked env var between runs should invalidate the cache.
 
 ## `MY_ENV=1 vt run test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/glob_input_changes.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/glob_input_changes.md
@@ -1,6 +1,6 @@
 # glob_input_changes
 
-Test all cache miss reason variants
+Modifying, adding, or removing files matched by a glob `input` pattern should each invalidate the cache.
 
 ## `vt run glob-test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/inferred_input_changes.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/inferred_input_changes.md
@@ -1,6 +1,6 @@
 # inferred_input_changes
 
-Test all cache miss reason variants
+Modifying, removing, and re-adding an input file (tracked via fspy inference) should each invalidate the cache.
 
 ## `vt run test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/input_config_changed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/input_config_changed.md
@@ -1,6 +1,6 @@
 # input_config_changed
 
-Test all cache miss reason variants
+Changing the task's `input` configuration should invalidate the cache even when the underlying files are unchanged.
 
 ## `vt run test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/untracked_env_added.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/untracked_env_added.md
@@ -1,6 +1,6 @@
 # untracked_env_added
 
-Test all cache miss reason variants
+Adding an `untrackedEnv` entry to the task config should invalidate the cache.
 
 ## `vt run test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/untracked_env_removed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/untracked_env_removed.md
@@ -1,6 +1,6 @@
 # untracked_env_removed
 
-Test all cache miss reason variants
+Removing an existing `untrackedEnv` entry from the task config should invalidate the cache.
 
 ## `vtt replace-file-content vite-task.json '"cache": true' '"cache": true, "untrackedEnv": ["MY_UNTRACKED"]'`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/colon_in_name/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/colon_in_name/snapshots.toml
@@ -1,9 +1,8 @@
+[[e2e]]
+name = "read_file_with_colon_in_name"
 comment = """
 Tests that a task name with colon works correctly with caching
 """
-
-[[e2e]]
-name = "read_file_with_colon_in_name"
 steps = [
   { argv = [
     "vt",

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots.toml
@@ -1,12 +1,11 @@
+[[e2e]]
+name = "independent_tasks_run_concurrently"
 comment = """
 Tests that independent tasks execute concurrently.
 Packages a and b have no dependency relationship.
 Both use a barrier that requires 2 participants — if run sequentially,
 the first would wait forever and the test would timeout.
 """
-
-[[e2e]]
-name = "independent_tasks_run_concurrently"
 steps = [["vt", "run", "-r", "build"]]
 
 # Both tasks use a single-command barrier (no && splitting). Task a exits with
@@ -15,12 +14,24 @@ steps = [["vt", "run", "-r", "build"]]
 # The test completing without timeout proves cancellation kills b.
 [[e2e]]
 name = "failure_kills_concurrent_tasks"
+comment = """
+Tests that independent tasks execute concurrently.
+Packages a and b have no dependency relationship.
+Both use a barrier that requires 2 participants — if run sequentially,
+the first would wait forever and the test would timeout.
+"""
 steps = [["vt", "run", "-r", "test"]]
 
 # Same as above but with --cache to exercise the piped stdio / fspy path
 # (spawn_with_tracking) instead of the inherited stdio path (spawn_inherited).
 [[e2e]]
 name = "failure_kills_concurrent_cached_tasks"
+comment = """
+Tests that independent tasks execute concurrently.
+Packages a and b have no dependency relationship.
+Both use a barrier that requires 2 participants — if run sequentially,
+the first would wait forever and the test would timeout.
+"""
 steps = [["vt", "run", "-r", "--cache", "test"]]
 
 # Task b closes stdout/stderr after the barrier but stays alive (daemonizes).
@@ -28,4 +39,10 @@ steps = [["vt", "run", "-r", "--cache", "test"]]
 # able to kill it via the cancellation token + Job Object.
 [[e2e]]
 name = "failure_kills_daemonized_concurrent_tasks"
+comment = """
+Tests that independent tasks execute concurrently.
+Packages a and b have no dependency relationship.
+Both use a barrier that requires 2 participants — if run sequentially,
+the first would wait forever and the test would timeout.
+"""
 steps = [["vt", "run", "-r", "--cache", "daemon"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots.toml
@@ -1,48 +1,35 @@
 [[e2e]]
 name = "independent_tasks_run_concurrently"
 comment = """
-Tests that independent tasks execute concurrently.
-Packages a and b have no dependency relationship.
-Both use a barrier that requires 2 participants — if run sequentially,
-the first would wait forever and the test would timeout.
+Two packages with no dependency relationship should run concurrently. Both tasks
+participate in a 2-way barrier, so sequential execution would hang forever and
+time out.
 """
 steps = [["vt", "run", "-r", "build"]]
 
-# Both tasks use a single-command barrier (no && splitting). Task a exits with
-# code 1 after the barrier, task b hangs after the barrier. Since both
-# participate in the same barrier, b is guaranteed to be running when a fails.
-# The test completing without timeout proves cancellation kills b.
 [[e2e]]
 name = "failure_kills_concurrent_tasks"
 comment = """
-Tests that independent tasks execute concurrently.
-Packages a and b have no dependency relationship.
-Both use a barrier that requires 2 participants — if run sequentially,
-the first would wait forever and the test would timeout.
+When one concurrent task fails, the sibling running under inherited stdio must
+be cancelled. Task a exits 1 after the shared barrier, task b hangs after it —
+completing without timeout proves cancellation killed b.
 """
 steps = [["vt", "run", "-r", "test"]]
 
-# Same as above but with --cache to exercise the piped stdio / fspy path
-# (spawn_with_tracking) instead of the inherited stdio path (spawn_inherited).
 [[e2e]]
 name = "failure_kills_concurrent_cached_tasks"
 comment = """
-Tests that independent tasks execute concurrently.
-Packages a and b have no dependency relationship.
-Both use a barrier that requires 2 participants — if run sequentially,
-the first would wait forever and the test would timeout.
+Same failure-cancellation scenario, but with `--cache` so execution goes through
+the piped stdio / fspy path (spawn_with_tracking) instead of the inherited-stdio
+path.
 """
 steps = [["vt", "run", "-r", "--cache", "test"]]
 
-# Task b closes stdout/stderr after the barrier but stays alive (daemonizes).
-# The pipe reads EOF but the process doesn't exit. The runner must still be
-# able to kill it via the cancellation token + Job Object.
 [[e2e]]
 name = "failure_kills_daemonized_concurrent_tasks"
 comment = """
-Tests that independent tasks execute concurrently.
-Packages a and b have no dependency relationship.
-Both use a barrier that requires 2 participants — if run sequentially,
-the first would wait forever and the test would timeout.
+Cancellation must also kill a sibling that has daemonized — closing stdout/stderr
+(EOF on the pipe) while the process itself stays alive. The runner must reach
+the process via the cancellation token + Job Object, not by pipe closure.
 """
 steps = [["vt", "run", "-r", "--cache", "daemon"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots/failure_kills_concurrent_cached_tasks.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots/failure_kills_concurrent_cached_tasks.md
@@ -1,9 +1,8 @@
 # failure_kills_concurrent_cached_tasks
 
-Tests that independent tasks execute concurrently.
-Packages a and b have no dependency relationship.
-Both use a barrier that requires 2 participants — if run sequentially,
-the first would wait forever and the test would timeout.
+Same failure-cancellation scenario, but with `--cache` so execution goes through
+the piped stdio / fspy path (spawn_with_tracking) instead of the inherited-stdio
+path.
 
 ## `vt run -r --cache test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots/failure_kills_concurrent_tasks.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots/failure_kills_concurrent_tasks.md
@@ -1,9 +1,8 @@
 # failure_kills_concurrent_tasks
 
-Tests that independent tasks execute concurrently.
-Packages a and b have no dependency relationship.
-Both use a barrier that requires 2 participants — if run sequentially,
-the first would wait forever and the test would timeout.
+When one concurrent task fails, the sibling running under inherited stdio must
+be cancelled. Task a exits 1 after the shared barrier, task b hangs after it —
+completing without timeout proves cancellation killed b.
 
 ## `vt run -r test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots/failure_kills_daemonized_concurrent_tasks.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots/failure_kills_daemonized_concurrent_tasks.md
@@ -1,9 +1,8 @@
 # failure_kills_daemonized_concurrent_tasks
 
-Tests that independent tasks execute concurrently.
-Packages a and b have no dependency relationship.
-Both use a barrier that requires 2 participants — if run sequentially,
-the first would wait forever and the test would timeout.
+Cancellation must also kill a sibling that has daemonized — closing stdout/stderr
+(EOF on the pipe) while the process itself stays alive. The runner must reach
+the process via the cancellation token + Job Object, not by pipe closure.
 
 ## `vt run -r --cache daemon`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots/independent_tasks_run_concurrently.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots/independent_tasks_run_concurrently.md
@@ -1,9 +1,8 @@
 # independent_tasks_run_concurrently
 
-Tests that independent tasks execute concurrently.
-Packages a and b have no dependency relationship.
-Both use a barrier that requires 2 participants — if run sequentially,
-the first would wait forever and the test would timeout.
+Two packages with no dependency relationship should run concurrently. Both tasks
+participate in a 2-way barrier, so sequential execution would hang forever and
+time out.
 
 ## `vt run -r build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ctrl_c/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ctrl_c/snapshots.toml
@@ -1,9 +1,8 @@
+[[e2e]]
+name = "ctrl_c_terminates_running_tasks"
 comment = """
 Tests that Ctrl+C (SIGINT) propagates to and terminates a running task.
 """
-
-[[e2e]]
-name = "ctrl_c_terminates_running_tasks"
 steps = [
   { argv = [
     "vt",
@@ -18,6 +17,9 @@ steps = [
 
 [[e2e]]
 name = "ctrl_c_terminates_running_tasks__cached_"
+comment = """
+Tests that Ctrl+C (SIGINT) propagates to and terminates a running task.
+"""
 steps = [
   { argv = [
     "vt",
@@ -33,6 +35,9 @@ steps = [
 # After Ctrl-C terminates a, b should not be scheduled.
 [[e2e]]
 name = "ctrl_c_prevents_future_tasks"
+comment = """
+Tests that Ctrl+C (SIGINT) propagates to and terminates a running task.
+"""
 steps = [
   { argv = [
     "vt",
@@ -50,6 +55,9 @@ steps = [
 # The second run should be a cache miss, not a hit.
 [[e2e]]
 name = "ctrl_c_prevents_caching"
+comment = """
+Tests that Ctrl+C (SIGINT) propagates to and terminates a running task.
+"""
 steps = [
   { argv = [
     "vt",

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ctrl_c/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ctrl_c/snapshots.toml
@@ -1,7 +1,7 @@
 [[e2e]]
 name = "ctrl_c_terminates_running_tasks"
 comment = """
-Tests that Ctrl+C (SIGINT) propagates to and terminates a running task.
+Ctrl+C (SIGINT) on an uncached run should propagate to the running task and terminate it.
 """
 steps = [
   { argv = [
@@ -18,7 +18,7 @@ steps = [
 [[e2e]]
 name = "ctrl_c_terminates_running_tasks__cached_"
 comment = """
-Tests that Ctrl+C (SIGINT) propagates to and terminates a running task.
+Same as above, but under the cached execution path (piped stdio + fspy tracking).
 """
 steps = [
   { argv = [
@@ -31,12 +31,11 @@ steps = [
   ] },
 ]
 
-# Package b depends on a, so without --parallel they run sequentially.
-# After Ctrl-C terminates a, b should not be scheduled.
 [[e2e]]
 name = "ctrl_c_prevents_future_tasks"
 comment = """
-Tests that Ctrl+C (SIGINT) propagates to and terminates a running task.
+Ctrl+C while running sequentially (b depends on a) should terminate a and
+prevent b from being scheduled.
 """
 steps = [
   { argv = [
@@ -51,12 +50,11 @@ steps = [
   ] },
 ]
 
-# dev exits 0 after Ctrl-C but the result should not be cached.
-# The second run should be a cache miss, not a hit.
 [[e2e]]
 name = "ctrl_c_prevents_caching"
 comment = """
-Tests that Ctrl+C (SIGINT) propagates to and terminates a running task.
+A task interrupted by Ctrl+C must not populate the cache, even if it happens to
+exit 0 — the following run should be a cache miss, not a hit.
 """
 steps = [
   { argv = [

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ctrl_c/snapshots/ctrl_c_prevents_caching.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ctrl_c/snapshots/ctrl_c_prevents_caching.md
@@ -1,6 +1,7 @@
 # ctrl_c_prevents_caching
 
-Tests that Ctrl+C (SIGINT) propagates to and terminates a running task.
+A task interrupted by Ctrl+C must not populate the cache, even if it happens to
+exit 0 — the following run should be a cache miss, not a hit.
 
 ## `vt run @ctrl-c/a#dev`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ctrl_c/snapshots/ctrl_c_prevents_future_tasks.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ctrl_c/snapshots/ctrl_c_prevents_future_tasks.md
@@ -1,6 +1,7 @@
 # ctrl_c_prevents_future_tasks
 
-Tests that Ctrl+C (SIGINT) propagates to and terminates a running task.
+Ctrl+C while running sequentially (b depends on a) should terminate a and
+prevent b from being scheduled.
 
 ## `vt run -r --no-cache dev`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ctrl_c/snapshots/ctrl_c_terminates_running_tasks.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ctrl_c/snapshots/ctrl_c_terminates_running_tasks.md
@@ -1,6 +1,6 @@
 # ctrl_c_terminates_running_tasks
 
-Tests that Ctrl+C (SIGINT) propagates to and terminates a running task.
+Ctrl+C (SIGINT) on an uncached run should propagate to the running task and terminate it.
 
 ## `vt run --no-cache @ctrl-c/a#dev`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ctrl_c/snapshots/ctrl_c_terminates_running_tasks__cached_.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ctrl_c/snapshots/ctrl_c_terminates_running_tasks__cached_.md
@@ -1,6 +1,6 @@
 # ctrl_c_terminates_running_tasks__cached_
 
-Tests that Ctrl+C (SIGINT) propagates to and terminates a running task.
+Same as above, but under the cached execution path (piped stdio + fspy tracking).
 
 ## `vt run @ctrl-c/a#dev`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/error_cycle_dependency/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/error_cycle_dependency/snapshots.toml
@@ -1,7 +1,6 @@
+[[e2e]]
+name = "cycle_dependency_error"
 comment = """
 Tests error message for cyclic task dependencies
 """
-
-[[e2e]]
-name = "cycle_dependency_error"
 steps = [{ argv = ["vt", "run", "task-a"], comment = "task-a -> task-b -> task-a cycle" }]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit_codes/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit_codes/snapshots.toml
@@ -1,21 +1,22 @@
 [[e2e]]
 name = "single_task_failure_returns_task_exit_code"
 comment = """
-Tests exit code behavior for task failures
+`vp run` should exit with the underlying task's exit code when a single task fails.
 """
 steps = [{ argv = ["vt", "run", "pkg-a#fail"], comment = "exits with code 42" }]
 
 [[e2e]]
 name = "task_failure_fast_fails_remaining_tasks"
 comment = """
-Tests exit code behavior for task failures
+A failing task under `-r` should fast-fail the run and skip any remaining packages.
 """
 steps = [{ argv = ["vt", "run", "-r", "fail"], comment = "pkg-a fails, pkg-b is skipped" }]
 
 [[e2e]]
 name = "dependency_failure_fast_fails_dependents"
 comment = """
-Tests exit code behavior for task failures
+When a dependency fails under `-t`, dependents should be skipped rather than
+run anyway.
 """
 cwd = "packages/pkg-b"
 steps = [{ argv = ["vt", "run", "-t", "check"], comment = "pkg-a fails, pkg-b is skipped" }]
@@ -23,7 +24,8 @@ steps = [{ argv = ["vt", "run", "-t", "check"], comment = "pkg-a fails, pkg-b is
 [[e2e]]
 name = "chained_command_with____stops_at_first_failure"
 comment = """
-Tests exit code behavior for task failures
+In a `&&`-chained command, a non-zero exit from the first sub-command should
+short-circuit and skip the rest.
 """
 steps = [
   { argv = [

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit_codes/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit_codes/snapshots.toml
@@ -1,22 +1,30 @@
+[[e2e]]
+name = "single_task_failure_returns_task_exit_code"
 comment = """
 Tests exit code behavior for task failures
 """
-
-[[e2e]]
-name = "single_task_failure_returns_task_exit_code"
 steps = [{ argv = ["vt", "run", "pkg-a#fail"], comment = "exits with code 42" }]
 
 [[e2e]]
 name = "task_failure_fast_fails_remaining_tasks"
+comment = """
+Tests exit code behavior for task failures
+"""
 steps = [{ argv = ["vt", "run", "-r", "fail"], comment = "pkg-a fails, pkg-b is skipped" }]
 
 [[e2e]]
 name = "dependency_failure_fast_fails_dependents"
+comment = """
+Tests exit code behavior for task failures
+"""
 cwd = "packages/pkg-b"
 steps = [{ argv = ["vt", "run", "-t", "check"], comment = "pkg-a fails, pkg-b is skipped" }]
 
 [[e2e]]
 name = "chained_command_with____stops_at_first_failure"
+comment = """
+Tests exit code behavior for task failures
+"""
 steps = [
   { argv = [
     "vt",

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit_codes/snapshots/chained_command_with____stops_at_first_failure.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit_codes/snapshots/chained_command_with____stops_at_first_failure.md
@@ -1,6 +1,7 @@
 # chained_command_with____stops_at_first_failure
 
-Tests exit code behavior for task failures
+In a `&&`-chained command, a non-zero exit from the first sub-command should
+short-circuit and skip the rest.
 
 ## `vt run pkg-a#chained`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit_codes/snapshots/dependency_failure_fast_fails_dependents.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit_codes/snapshots/dependency_failure_fast_fails_dependents.md
@@ -1,6 +1,7 @@
 # dependency_failure_fast_fails_dependents
 
-Tests exit code behavior for task failures
+When a dependency fails under `-t`, dependents should be skipped rather than
+run anyway.
 
 ## `vt run -t check`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit_codes/snapshots/single_task_failure_returns_task_exit_code.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit_codes/snapshots/single_task_failure_returns_task_exit_code.md
@@ -1,6 +1,6 @@
 # single_task_failure_returns_task_exit_code
 
-Tests exit code behavior for task failures
+`vp run` should exit with the underlying task's exit code when a single task fails.
 
 ## `vt run pkg-a#fail`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit_codes/snapshots/task_failure_fast_fails_remaining_tasks.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit_codes/snapshots/task_failure_fast_fails_remaining_tasks.md
@@ -1,6 +1,6 @@
 # task_failure_fast_fails_remaining_tasks
 
-Tests exit code behavior for task failures
+A failing task under `-r` should fast-fail the run and skip any remaining packages.
 
 ## `vt run -r fail`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots.toml
@@ -1,47 +1,47 @@
-# One filter matches, one doesn't → warning for the unmatched one, task still runs
 [[e2e]]
 name = "partial_match_warns_for_unmatched_filter"
 comment = """
-Tests for unmatched --filter warnings on stderr
+When some `--filter` flags match and one does not, the run should proceed and
+warn only for the unmatched filter.
 """
 steps = [["vt", "run", "--filter", "@test/app", "--filter", "nonexistent", "build"]]
 
-# Multiple unmatched alongside a match → one warning per unmatched filter
 [[e2e]]
 name = "multiple_unmatched_filters_warn_individually"
 comment = """
-Tests for unmatched --filter warnings on stderr
+Each unmatched `--filter` should produce its own warning — warnings must not
+be collapsed into a single message.
 """
 steps = [["vt", "run", "--filter", "@test/app", "--filter", "nope1", "--filter", "nope2", "build"]]
 
-# Whitespace-split filter with one unmatched token
 [[e2e]]
 name = "whitespace_split_filter_warns_for_unmatched_token"
 comment = """
-Tests for unmatched --filter warnings on stderr
+A whitespace-split `--filter` argument should warn about each of its individual
+unmatched tokens.
 """
 steps = [["vt", "run", "--filter", "@test/app nope", "build"]]
 
-# Exclusion filter that matches nothing does NOT warn (only inclusions warn)
 [[e2e]]
 name = "unmatched_exclusion_filter_does_not_warn"
 comment = """
-Tests for unmatched --filter warnings on stderr
+An exclusion filter (`!...`) that matches nothing should be silent; only
+unmatched inclusion filters warn.
 """
 steps = [["vt", "run", "--filter", "@test/app", "--filter", "!nonexistent", "build"]]
 
-# Glob filter that matches nothing alongside a match
 [[e2e]]
 name = "unmatched_glob_filter_warns"
 comment = """
-Tests for unmatched --filter warnings on stderr
+A glob `--filter` that matches no packages should warn like any other
+unmatched inclusion filter.
 """
 steps = [["vt", "run", "--filter", "@test/app", "--filter", "@nope/*", "build"]]
 
-# Directory filter that matches nothing
 [[e2e]]
 name = "unmatched_directory_filter_warns"
 comment = """
-Tests for unmatched --filter warnings on stderr
+A directory-style `--filter` (`./packages/...`) that points nowhere should
+warn just like an unmatched name filter.
 """
 steps = [["vt", "run", "--filter", "@test/app", "--filter", "./packages/nope", "build"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots.toml
@@ -1,33 +1,47 @@
-comment = """
-Tests for unmatched --filter warnings on stderr
-"""
-
 # One filter matches, one doesn't → warning for the unmatched one, task still runs
 [[e2e]]
 name = "partial_match_warns_for_unmatched_filter"
+comment = """
+Tests for unmatched --filter warnings on stderr
+"""
 steps = [["vt", "run", "--filter", "@test/app", "--filter", "nonexistent", "build"]]
 
 # Multiple unmatched alongside a match → one warning per unmatched filter
 [[e2e]]
 name = "multiple_unmatched_filters_warn_individually"
+comment = """
+Tests for unmatched --filter warnings on stderr
+"""
 steps = [["vt", "run", "--filter", "@test/app", "--filter", "nope1", "--filter", "nope2", "build"]]
 
 # Whitespace-split filter with one unmatched token
 [[e2e]]
 name = "whitespace_split_filter_warns_for_unmatched_token"
+comment = """
+Tests for unmatched --filter warnings on stderr
+"""
 steps = [["vt", "run", "--filter", "@test/app nope", "build"]]
 
 # Exclusion filter that matches nothing does NOT warn (only inclusions warn)
 [[e2e]]
 name = "unmatched_exclusion_filter_does_not_warn"
+comment = """
+Tests for unmatched --filter warnings on stderr
+"""
 steps = [["vt", "run", "--filter", "@test/app", "--filter", "!nonexistent", "build"]]
 
 # Glob filter that matches nothing alongside a match
 [[e2e]]
 name = "unmatched_glob_filter_warns"
+comment = """
+Tests for unmatched --filter warnings on stderr
+"""
 steps = [["vt", "run", "--filter", "@test/app", "--filter", "@nope/*", "build"]]
 
 # Directory filter that matches nothing
 [[e2e]]
 name = "unmatched_directory_filter_warns"
+comment = """
+Tests for unmatched --filter warnings on stderr
+"""
 steps = [["vt", "run", "--filter", "@test/app", "--filter", "./packages/nope", "build"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/multiple_unmatched_filters_warn_individually.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/multiple_unmatched_filters_warn_individually.md
@@ -1,6 +1,7 @@
 # multiple_unmatched_filters_warn_individually
 
-Tests for unmatched --filter warnings on stderr
+Each unmatched `--filter` should produce its own warning — warnings must not
+be collapsed into a single message.
 
 ## `vt run --filter @test/app --filter nope1 --filter nope2 build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/partial_match_warns_for_unmatched_filter.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/partial_match_warns_for_unmatched_filter.md
@@ -1,6 +1,7 @@
 # partial_match_warns_for_unmatched_filter
 
-Tests for unmatched --filter warnings on stderr
+When some `--filter` flags match and one does not, the run should proceed and
+warn only for the unmatched filter.
 
 ## `vt run --filter @test/app --filter nonexistent build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/unmatched_directory_filter_warns.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/unmatched_directory_filter_warns.md
@@ -1,6 +1,7 @@
 # unmatched_directory_filter_warns
 
-Tests for unmatched --filter warnings on stderr
+A directory-style `--filter` (`./packages/...`) that points nowhere should
+warn just like an unmatched name filter.
 
 ## `vt run --filter @test/app --filter ./packages/nope build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/unmatched_exclusion_filter_does_not_warn.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/unmatched_exclusion_filter_does_not_warn.md
@@ -1,6 +1,7 @@
 # unmatched_exclusion_filter_does_not_warn
 
-Tests for unmatched --filter warnings on stderr
+An exclusion filter (`!...`) that matches nothing should be silent; only
+unmatched inclusion filters warn.
 
 ## `vt run --filter @test/app --filter !nonexistent build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/unmatched_glob_filter_warns.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/unmatched_glob_filter_warns.md
@@ -1,6 +1,7 @@
 # unmatched_glob_filter_warns
 
-Tests for unmatched --filter warnings on stderr
+A glob `--filter` that matches no packages should warn like any other
+unmatched inclusion filter.
 
 ## `vt run --filter @test/app --filter @nope/* build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/whitespace_split_filter_warns_for_unmatched_token.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/whitespace_split_filter_warns_for_unmatched_token.md
@@ -1,6 +1,7 @@
 # whitespace_split_filter_warns_for_unmatched_token
 
-Tests for unmatched --filter warnings on stderr
+A whitespace-split `--filter` argument should warn about each of its individual
+unmatched tokens.
 
 ## `vt run --filter '@test/app nope' build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots.toml
@@ -1,12 +1,11 @@
+# 1. Root package - glob matches files in root's src/
+[[e2e]]
+name = "root_glob___matches_src_files"
 comment = """
 Test glob base directory behavior
 Globs are relative to PACKAGE directory, NOT task cwd
 No special cross-package filtering - just normal relative path matching
 """
-
-# 1. Root package - glob matches files in root's src/
-[[e2e]]
-name = "root_glob___matches_src_files"
 steps = [
   ["vt", "run", "root-glob-test"],
   # Modify matched file
@@ -17,6 +16,11 @@ steps = [
 
 [[e2e]]
 name = "root_glob___unmatched_directory"
+comment = """
+Test glob base directory behavior
+Globs are relative to PACKAGE directory, NOT task cwd
+No special cross-package filtering - just normal relative path matching
+"""
 steps = [
   ["vt", "run", "root-glob-test"],
   # Modify file outside glob pattern
@@ -27,6 +31,11 @@ steps = [
 
 [[e2e]]
 name = "root_glob___subpackage_path_unmatched_by_relative_glob"
+comment = """
+Test glob base directory behavior
+Globs are relative to PACKAGE directory, NOT task cwd
+No special cross-package filtering - just normal relative path matching
+"""
 steps = [
   ["vt", "run", "root-glob-test"],
   # Modify file in subpackage - relative glob src/** doesn't reach packages/sub-pkg/src/
@@ -38,6 +47,11 @@ steps = [
 # 2. Root package with custom cwd - glob still relative to package root
 [[e2e]]
 name = "root_glob_with_cwd___glob_relative_to_package_not_cwd"
+comment = """
+Test glob base directory behavior
+Globs are relative to PACKAGE directory, NOT task cwd
+No special cross-package filtering - just normal relative path matching
+"""
 steps = [
   ["vt", "run", "root-glob-with-cwd"],
   # Modify file - glob is src/** relative to package root
@@ -49,6 +63,11 @@ steps = [
 # 3. Subpackage - glob matches files in subpackage's src/
 [[e2e]]
 name = "subpackage_glob___matches_own_src_files"
+comment = """
+Test glob base directory behavior
+Globs are relative to PACKAGE directory, NOT task cwd
+No special cross-package filtering - just normal relative path matching
+"""
 steps = [
   ["vt", "run", "sub-pkg#sub-glob-test"],
   # Modify matched file in subpackage
@@ -59,6 +78,11 @@ steps = [
 
 [[e2e]]
 name = "subpackage_glob___unmatched_directory_in_subpackage"
+comment = """
+Test glob base directory behavior
+Globs are relative to PACKAGE directory, NOT task cwd
+No special cross-package filtering - just normal relative path matching
+"""
 steps = [
   ["vt", "run", "sub-pkg#sub-glob-test"],
   # Modify file outside glob pattern
@@ -69,6 +93,11 @@ steps = [
 
 [[e2e]]
 name = "subpackage_glob___root_path_unmatched_by_relative_glob"
+comment = """
+Test glob base directory behavior
+Globs are relative to PACKAGE directory, NOT task cwd
+No special cross-package filtering - just normal relative path matching
+"""
 steps = [
   ["vt", "run", "sub-pkg#sub-glob-test"],
   # Modify file in root - relative glob src/** is resolved from subpackage dir
@@ -80,6 +109,11 @@ steps = [
 # 4. Subpackage with custom cwd - glob still relative to subpackage root
 [[e2e]]
 name = "subpackage_glob_with_cwd___glob_relative_to_package_not_cwd"
+comment = """
+Test glob base directory behavior
+Globs are relative to PACKAGE directory, NOT task cwd
+No special cross-package filtering - just normal relative path matching
+"""
 steps = [
   ["vt", "run", "sub-pkg#sub-glob-with-cwd"],
   # Modify file - glob is src/** relative to subpackage root

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots.toml
@@ -1,10 +1,8 @@
-# 1. Root package - glob matches files in root's src/
 [[e2e]]
 name = "root_glob___matches_src_files"
 comment = """
-Test glob base directory behavior
-Globs are relative to PACKAGE directory, NOT task cwd
-No special cross-package filtering - just normal relative path matching
+A root-package glob should match files under the package's own `src/` —
+modifying such a file invalidates the cache.
 """
 steps = [
   ["vt", "run", "root-glob-test"],
@@ -17,9 +15,8 @@ steps = [
 [[e2e]]
 name = "root_glob___unmatched_directory"
 comment = """
-Test glob base directory behavior
-Globs are relative to PACKAGE directory, NOT task cwd
-No special cross-package filtering - just normal relative path matching
+Modifying a file outside the glob pattern (e.g. `other/`) should leave the
+cache hit intact.
 """
 steps = [
   ["vt", "run", "root-glob-test"],
@@ -32,9 +29,8 @@ steps = [
 [[e2e]]
 name = "root_glob___subpackage_path_unmatched_by_relative_glob"
 comment = """
-Test glob base directory behavior
-Globs are relative to PACKAGE directory, NOT task cwd
-No special cross-package filtering - just normal relative path matching
+A relative glob anchored at the root package should not reach into
+`packages/<sub>/src/` — a subpackage file change stays a cache hit.
 """
 steps = [
   ["vt", "run", "root-glob-test"],
@@ -44,13 +40,11 @@ steps = [
   ["vt", "run", "root-glob-test"],
 ]
 
-# 2. Root package with custom cwd - glob still relative to package root
 [[e2e]]
 name = "root_glob_with_cwd___glob_relative_to_package_not_cwd"
 comment = """
-Test glob base directory behavior
-Globs are relative to PACKAGE directory, NOT task cwd
-No special cross-package filtering - just normal relative path matching
+Even when the task declares a custom `cwd`, its glob stays anchored at the
+package root — `src/**` still matches `src/root.ts`.
 """
 steps = [
   ["vt", "run", "root-glob-with-cwd"],
@@ -60,13 +54,10 @@ steps = [
   ["vt", "run", "root-glob-with-cwd"],
 ]
 
-# 3. Subpackage - glob matches files in subpackage's src/
 [[e2e]]
 name = "subpackage_glob___matches_own_src_files"
 comment = """
-Test glob base directory behavior
-Globs are relative to PACKAGE directory, NOT task cwd
-No special cross-package filtering - just normal relative path matching
+A subpackage's glob should match files under its own `src/` directory.
 """
 steps = [
   ["vt", "run", "sub-pkg#sub-glob-test"],
@@ -79,9 +70,8 @@ steps = [
 [[e2e]]
 name = "subpackage_glob___unmatched_directory_in_subpackage"
 comment = """
-Test glob base directory behavior
-Globs are relative to PACKAGE directory, NOT task cwd
-No special cross-package filtering - just normal relative path matching
+Changes to a sibling directory within the subpackage that the glob does not
+cover (e.g. `other/`) should leave the cache hit intact.
 """
 steps = [
   ["vt", "run", "sub-pkg#sub-glob-test"],
@@ -94,9 +84,8 @@ steps = [
 [[e2e]]
 name = "subpackage_glob___root_path_unmatched_by_relative_glob"
 comment = """
-Test glob base directory behavior
-Globs are relative to PACKAGE directory, NOT task cwd
-No special cross-package filtering - just normal relative path matching
+A subpackage-anchored relative glob should not reach up into the root
+package's `src/` — a root-package file change stays a cache hit.
 """
 steps = [
   ["vt", "run", "sub-pkg#sub-glob-test"],
@@ -106,13 +95,11 @@ steps = [
   ["vt", "run", "sub-pkg#sub-glob-test"],
 ]
 
-# 4. Subpackage with custom cwd - glob still relative to subpackage root
 [[e2e]]
 name = "subpackage_glob_with_cwd___glob_relative_to_package_not_cwd"
 comment = """
-Test glob base directory behavior
-Globs are relative to PACKAGE directory, NOT task cwd
-No special cross-package filtering - just normal relative path matching
+A custom `cwd` on a subpackage task should not shift its glob base — `src/**`
+still resolves relative to the subpackage directory.
 """
 steps = [
   ["vt", "run", "sub-pkg#sub-glob-with-cwd"],

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/root_glob___matches_src_files.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/root_glob___matches_src_files.md
@@ -1,8 +1,7 @@
 # root_glob___matches_src_files
 
-Test glob base directory behavior
-Globs are relative to PACKAGE directory, NOT task cwd
-No special cross-package filtering - just normal relative path matching
+A root-package glob should match files under the package's own `src/` —
+modifying such a file invalidates the cache.
 
 ## `vt run root-glob-test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/root_glob___subpackage_path_unmatched_by_relative_glob.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/root_glob___subpackage_path_unmatched_by_relative_glob.md
@@ -1,8 +1,7 @@
 # root_glob___subpackage_path_unmatched_by_relative_glob
 
-Test glob base directory behavior
-Globs are relative to PACKAGE directory, NOT task cwd
-No special cross-package filtering - just normal relative path matching
+A relative glob anchored at the root package should not reach into
+`packages/<sub>/src/` — a subpackage file change stays a cache hit.
 
 ## `vt run root-glob-test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/root_glob___unmatched_directory.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/root_glob___unmatched_directory.md
@@ -1,8 +1,7 @@
 # root_glob___unmatched_directory
 
-Test glob base directory behavior
-Globs are relative to PACKAGE directory, NOT task cwd
-No special cross-package filtering - just normal relative path matching
+Modifying a file outside the glob pattern (e.g. `other/`) should leave the
+cache hit intact.
 
 ## `vt run root-glob-test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/root_glob_with_cwd___glob_relative_to_package_not_cwd.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/root_glob_with_cwd___glob_relative_to_package_not_cwd.md
@@ -1,8 +1,7 @@
 # root_glob_with_cwd___glob_relative_to_package_not_cwd
 
-Test glob base directory behavior
-Globs are relative to PACKAGE directory, NOT task cwd
-No special cross-package filtering - just normal relative path matching
+Even when the task declares a custom `cwd`, its glob stays anchored at the
+package root — `src/**` still matches `src/root.ts`.
 
 ## `vt run root-glob-with-cwd`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/subpackage_glob___matches_own_src_files.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/subpackage_glob___matches_own_src_files.md
@@ -1,8 +1,6 @@
 # subpackage_glob___matches_own_src_files
 
-Test glob base directory behavior
-Globs are relative to PACKAGE directory, NOT task cwd
-No special cross-package filtering - just normal relative path matching
+A subpackage's glob should match files under its own `src/` directory.
 
 ## `vt run sub-pkg#sub-glob-test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/subpackage_glob___root_path_unmatched_by_relative_glob.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/subpackage_glob___root_path_unmatched_by_relative_glob.md
@@ -1,8 +1,7 @@
 # subpackage_glob___root_path_unmatched_by_relative_glob
 
-Test glob base directory behavior
-Globs are relative to PACKAGE directory, NOT task cwd
-No special cross-package filtering - just normal relative path matching
+A subpackage-anchored relative glob should not reach up into the root
+package's `src/` — a root-package file change stays a cache hit.
 
 ## `vt run sub-pkg#sub-glob-test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/subpackage_glob___unmatched_directory_in_subpackage.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/subpackage_glob___unmatched_directory_in_subpackage.md
@@ -1,8 +1,7 @@
 # subpackage_glob___unmatched_directory_in_subpackage
 
-Test glob base directory behavior
-Globs are relative to PACKAGE directory, NOT task cwd
-No special cross-package filtering - just normal relative path matching
+Changes to a sibling directory within the subpackage that the glob does not
+cover (e.g. `other/`) should leave the cache hit intact.
 
 ## `vt run sub-pkg#sub-glob-test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/subpackage_glob_with_cwd___glob_relative_to_package_not_cwd.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/subpackage_glob_with_cwd___glob_relative_to_package_not_cwd.md
@@ -1,8 +1,7 @@
 # subpackage_glob_with_cwd___glob_relative_to_package_not_cwd
 
-Test glob base directory behavior
-Globs are relative to PACKAGE directory, NOT task cwd
-No special cross-package filtering - just normal relative path matching
+A custom `cwd` on a subpackage task should not shift its glob base — `src/**`
+still resolves relative to the subpackage directory.
 
 ## `vt run sub-pkg#sub-glob-with-cwd`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots.toml
@@ -1,3 +1,7 @@
+# ─── stdout/stderr: always piped (not-tty), output grouped ───
+
+[[e2e]]
+name = "single_task__cache_off__grouped_output"
 comment = """
 Tests stdio behavior in grouped mode (--log=grouped).
 
@@ -8,29 +12,64 @@ In grouped mode, stdio is always piped regardless of cache state:
 `check-tty` prints whether each stdio fd is a TTY.
 `read-stdin` reads one line from stdin and prints it.
 """
-
-# ─── stdout/stderr: always piped (not-tty), output grouped ───
-
-[[e2e]]
-name = "single_task__cache_off__grouped_output"
 steps = [["vt", "run", "--log=grouped", "check-tty"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_off__grouped_output"
+comment = """
+Tests stdio behavior in grouped mode (--log=grouped).
+
+In grouped mode, stdio is always piped regardless of cache state:
+- stdin is /dev/null
+- stdout/stderr are buffered per task and printed as a block on completion
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [["vt", "run", "--log=grouped", "-r", "check-tty"]]
 
 [[e2e]]
 name = "single_task__cache_miss__grouped_output"
+comment = """
+Tests stdio behavior in grouped mode (--log=grouped).
+
+In grouped mode, stdio is always piped regardless of cache state:
+- stdin is /dev/null
+- stdout/stderr are buffered per task and printed as a block on completion
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [["vt", "run", "--log=grouped", "check-tty-cached"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_miss__grouped_output"
+comment = """
+Tests stdio behavior in grouped mode (--log=grouped).
+
+In grouped mode, stdio is always piped regardless of cache state:
+- stdin is /dev/null
+- stdout/stderr are buffered per task and printed as a block on completion
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [["vt", "run", "--log=grouped", "-r", "check-tty-cached"]]
 
 # ─── cache hit → replayed in grouped blocks ───────────────────
 
 [[e2e]]
 name = "single_task__cache_hit__replayed"
+comment = """
+Tests stdio behavior in grouped mode (--log=grouped).
+
+In grouped mode, stdio is always piped regardless of cache state:
+- stdin is /dev/null
+- stdout/stderr are buffered per task and printed as a block on completion
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [
   [
     "vt",
@@ -48,6 +87,16 @@ steps = [
 
 [[e2e]]
 name = "multiple_tasks__cache_hit__replayed"
+comment = """
+Tests stdio behavior in grouped mode (--log=grouped).
+
+In grouped mode, stdio is always piped regardless of cache state:
+- stdin is /dev/null
+- stdout/stderr are buffered per task and printed as a block on completion
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [
   [
     "vt",
@@ -69,4 +118,14 @@ steps = [
 
 [[e2e]]
 name = "stdin_is_always_null"
+comment = """
+Tests stdio behavior in grouped mode (--log=grouped).
+
+In grouped mode, stdio is always piped regardless of cache state:
+- stdin is /dev/null
+- stdout/stderr are buffered per task and printed as a block on completion
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [["vtt", "pipe-stdin", "from-stdin", "--", "vt", "run", "--log=grouped", "read-stdin"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots.toml
@@ -1,74 +1,40 @@
-# ─── stdout/stderr: always piped (not-tty), output grouped ───
-
 [[e2e]]
 name = "single_task__cache_off__grouped_output"
 comment = """
-Tests stdio behavior in grouped mode (--log=grouped).
-
-In grouped mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are buffered per task and printed as a block on completion
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+Under `--log=grouped` with caching off, a single task's piped stdout/stderr
+should be printed as one grouped block; none of the fds should be TTYs.
 """
 steps = [["vt", "run", "--log=grouped", "check-tty"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_off__grouped_output"
 comment = """
-Tests stdio behavior in grouped mode (--log=grouped).
-
-In grouped mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are buffered per task and printed as a block on completion
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+Under `--log=grouped` with caching off, each task's output should be emitted
+as its own grouped block (one block per task, never interleaved).
 """
 steps = [["vt", "run", "--log=grouped", "-r", "check-tty"]]
 
 [[e2e]]
 name = "single_task__cache_miss__grouped_output"
 comment = """
-Tests stdio behavior in grouped mode (--log=grouped).
-
-In grouped mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are buffered per task and printed as a block on completion
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+On a cache miss, grouped mode should still pipe stdio and emit one block for
+the single task.
 """
 steps = [["vt", "run", "--log=grouped", "check-tty-cached"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_miss__grouped_output"
 comment = """
-Tests stdio behavior in grouped mode (--log=grouped).
-
-In grouped mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are buffered per task and printed as a block on completion
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+On a cache miss across multiple tasks, grouped mode should emit one block
+per task with piped, non-TTY stdio.
 """
 steps = [["vt", "run", "--log=grouped", "-r", "check-tty-cached"]]
-
-# ─── cache hit → replayed in grouped blocks ───────────────────
 
 [[e2e]]
 name = "single_task__cache_hit__replayed"
 comment = """
-Tests stdio behavior in grouped mode (--log=grouped).
-
-In grouped mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are buffered per task and printed as a block on completion
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+A cache-hit replay of a single task under grouped mode should reproduce the
+original grouped block from cached output.
 """
 steps = [
   [
@@ -88,14 +54,8 @@ steps = [
 [[e2e]]
 name = "multiple_tasks__cache_hit__replayed"
 comment = """
-Tests stdio behavior in grouped mode (--log=grouped).
-
-In grouped mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are buffered per task and printed as a block on completion
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+Cache-hit replays for multiple tasks under grouped mode should each produce
+their own block, matching the original (non-replayed) output.
 """
 steps = [
   [
@@ -114,18 +74,10 @@ steps = [
   ],
 ]
 
-# ─── stdin: always null ───────────────────────────────────────
-
 [[e2e]]
 name = "stdin_is_always_null"
 comment = """
-Tests stdio behavior in grouped mode (--log=grouped).
-
-In grouped mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are buffered per task and printed as a block on completion
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+In grouped mode, task stdin is always `/dev/null` regardless of the parent's
+stdin — piping data in from outside must not reach the task.
 """
 steps = [["vtt", "pipe-stdin", "from-stdin", "--", "vt", "run", "--log=grouped", "read-stdin"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/multiple_tasks__cache_hit__replayed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/multiple_tasks__cache_hit__replayed.md
@@ -1,13 +1,7 @@
 # multiple_tasks__cache_hit__replayed
 
-Tests stdio behavior in grouped mode (--log=grouped).
-
-In grouped mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are buffered per task and printed as a block on completion
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+Cache-hit replays for multiple tasks under grouped mode should each produce
+their own block, matching the original (non-replayed) output.
 
 ## `vt run --log=grouped -r check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/multiple_tasks__cache_miss__grouped_output.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/multiple_tasks__cache_miss__grouped_output.md
@@ -1,13 +1,7 @@
 # multiple_tasks__cache_miss__grouped_output
 
-Tests stdio behavior in grouped mode (--log=grouped).
-
-In grouped mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are buffered per task and printed as a block on completion
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+On a cache miss across multiple tasks, grouped mode should emit one block
+per task with piped, non-TTY stdio.
 
 ## `vt run --log=grouped -r check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/multiple_tasks__cache_off__grouped_output.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/multiple_tasks__cache_off__grouped_output.md
@@ -1,13 +1,7 @@
 # multiple_tasks__cache_off__grouped_output
 
-Tests stdio behavior in grouped mode (--log=grouped).
-
-In grouped mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are buffered per task and printed as a block on completion
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+Under `--log=grouped` with caching off, each task's output should be emitted
+as its own grouped block (one block per task, never interleaved).
 
 ## `vt run --log=grouped -r check-tty`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/single_task__cache_hit__replayed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/single_task__cache_hit__replayed.md
@@ -1,13 +1,7 @@
 # single_task__cache_hit__replayed
 
-Tests stdio behavior in grouped mode (--log=grouped).
-
-In grouped mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are buffered per task and printed as a block on completion
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+A cache-hit replay of a single task under grouped mode should reproduce the
+original grouped block from cached output.
 
 ## `vt run --log=grouped check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/single_task__cache_miss__grouped_output.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/single_task__cache_miss__grouped_output.md
@@ -1,13 +1,7 @@
 # single_task__cache_miss__grouped_output
 
-Tests stdio behavior in grouped mode (--log=grouped).
-
-In grouped mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are buffered per task and printed as a block on completion
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+On a cache miss, grouped mode should still pipe stdio and emit one block for
+the single task.
 
 ## `vt run --log=grouped check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/single_task__cache_off__grouped_output.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/single_task__cache_off__grouped_output.md
@@ -1,13 +1,7 @@
 # single_task__cache_off__grouped_output
 
-Tests stdio behavior in grouped mode (--log=grouped).
-
-In grouped mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are buffered per task and printed as a block on completion
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+Under `--log=grouped` with caching off, a single task's piped stdout/stderr
+should be printed as one grouped block; none of the fds should be TTYs.
 
 ## `vt run --log=grouped check-tty`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/stdin_is_always_null.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/stdin_is_always_null.md
@@ -1,13 +1,7 @@
 # stdin_is_always_null
 
-Tests stdio behavior in grouped mode (--log=grouped).
-
-In grouped mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are buffered per task and printed as a block on completion
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+In grouped mode, task stdin is always `/dev/null` regardless of the parent's
+stdin — piping data in from outside must not reach the task.
 
 ## `vtt pipe-stdin from-stdin -- vt run --log=grouped read-stdin`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/individual_cache_for_adt_args/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/individual_cache_for_adt_args/snapshots.toml
@@ -1,9 +1,8 @@
+[[e2e]]
+name = "individual_cache_for_extra_args"
 comment = """
 Tests that different extra args get separate cache entries
 """
-
-[[e2e]]
-name = "individual_cache_for_extra_args"
 steps = [
   { argv = [
     "vt",

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/individual_cache_for_env/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/individual_cache_for_env/snapshots.toml
@@ -1,9 +1,8 @@
+[[e2e]]
+name = "individual_cache_for_env"
 comment = """
 Tests that different env values get separate cache entries
 """
-
-[[e2e]]
-name = "individual_cache_for_env"
 steps = [
   { argv = [
     "vt",

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots.toml
@@ -1,12 +1,11 @@
-comment = """
-Test all input configuration combinations for cache behavior
-"""
-
 # 1. Positive globs only: input: ["src/**/*.ts"]
 # - Files matching the glob trigger cache invalidation
 # - Files outside the glob do NOT trigger cache invalidation
 [[e2e]]
 name = "positive_globs_only___cache_hit_on_second_run"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   # First run - cache miss
   ["vt", "run", "positive-globs-only"],
@@ -16,6 +15,9 @@ steps = [
 
 [[e2e]]
 name = "positive_globs_only___miss_on_matched_file_change"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   # Initial run
   ["vt", "run", "positive-globs-only"],
@@ -27,6 +29,9 @@ steps = [
 
 [[e2e]]
 name = "positive_globs_only___hit_on_unmatched_file_change"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   # Initial run
   ["vt", "run", "positive-globs-only"],
@@ -41,6 +46,9 @@ steps = [
 # - This tests that inference is truly disabled when only explicit globs are used
 [[e2e]]
 name = "positive_globs___hit_on_read_but_unmatched_file"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   # Initial run - reads both src/main.ts and src/utils.ts
   ["vt", "run", "positive-globs-reads-unmatched"],
@@ -55,6 +63,9 @@ steps = [
 # - Files matching negative glob are excluded
 [[e2e]]
 name = "positive_negative_globs___miss_on_non_excluded_file"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   # Initial run
   ["vt", "run", "positive-negative-globs"],
@@ -66,6 +77,9 @@ steps = [
 
 [[e2e]]
 name = "positive_negative_globs___hit_on_excluded_file"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   # Initial run
   ["vt", "run", "positive-negative-globs"],
@@ -80,6 +94,9 @@ steps = [
 # - Files NOT read by the command do NOT trigger invalidation
 [[e2e]]
 name = "auto_only___miss_on_inferred_file_change"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   # Initial run - reads src/main.ts
   ["vt", "run", "auto-only"],
@@ -91,6 +108,9 @@ steps = [
 
 [[e2e]]
 name = "auto_only___hit_on_non_inferred_file_change"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   # Initial run - reads src/main.ts (NOT utils.ts)
   ["vt", "run", "auto-only"],
@@ -105,6 +125,9 @@ steps = [
 # - Files in excluded directories don't trigger invalidation even if read
 [[e2e]]
 name = "auto_with_negative___hit_on_excluded_inferred_file"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   # Initial run - reads both src/main.ts and dist/output.js
   ["vt", "run", "auto-with-negative"],
@@ -116,6 +139,9 @@ steps = [
 
 [[e2e]]
 name = "auto_with_negative___miss_on_non_excluded_inferred_file"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   # Initial run
   ["vt", "run", "auto-with-negative"],
@@ -130,6 +156,9 @@ steps = [
 # - Negative globs apply to both explicit and inferred input
 [[e2e]]
 name = "positive_auto_negative___miss_on_explicit_glob_file"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   # Initial run
   ["vt", "run", "positive-auto-negative"],
@@ -141,6 +170,9 @@ steps = [
 
 [[e2e]]
 name = "positive_auto_negative___miss_on_inferred_file"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   # Initial run
   ["vt", "run", "positive-auto-negative"],
@@ -152,6 +184,9 @@ steps = [
 
 [[e2e]]
 name = "positive_auto_negative___hit_on_excluded_file"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   # Initial run
   ["vt", "run", "positive-auto-negative"],
@@ -166,6 +201,9 @@ steps = [
 # - Only command/env changes trigger cache invalidation
 [[e2e]]
 name = "empty_input___hit_despite_file_changes"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   # Initial run
   ["vt", "run", "empty-inputs"],
@@ -177,6 +215,9 @@ steps = [
 
 [[e2e]]
 name = "empty_input___miss_on_command_change"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   # Initial run
   [
@@ -205,6 +246,9 @@ steps = [
 # - FSPY is NOT set when fspy is disabled (explicit globs only)
 [[e2e]]
 name = "fspy_env___set_when_auto_inference_enabled"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   # Run task with auto inference - should see FSPY=1
   ["vt", "run", "check-fspy-env-with-auto"],
@@ -212,6 +256,9 @@ steps = [
 
 [[e2e]]
 name = "fspy_env___not_set_when_auto_inference_disabled"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   # Run task without auto inference - should see (undefined)
   ["vt", "run", "check-fspy-env-without-auto"],
@@ -223,6 +270,9 @@ steps = [
 # - Files outside the directory do NOT trigger cache invalidation
 [[e2e]]
 name = "folder_slash_input___miss_on_direct_and_nested_file_changes"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   ["vt", "run", "folder-slash-input"],
   # Modify a direct file in src/
@@ -240,6 +290,9 @@ steps = [
 
 [[e2e]]
 name = "folder_slash_input___hit_on_file_outside_directory"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   ["vt", "run", "folder-slash-input"],
   # Modify a file outside src/
@@ -253,6 +306,9 @@ steps = [
 # - File changes inside the folder should NOT trigger cache invalidation
 [[e2e]]
 name = "folder_input___hit_despite_file_changes_and_folder_deletion"
+comment = """
+Test all input configuration combinations for cache behavior
+"""
 steps = [
   ["vt", "run", "folder-input"],
   # Modify a file inside the folder

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots.toml
@@ -1,10 +1,8 @@
-# 1. Positive globs only: input: ["src/**/*.ts"]
-# - Files matching the glob trigger cache invalidation
-# - Files outside the glob do NOT trigger cache invalidation
 [[e2e]]
 name = "positive_globs_only___cache_hit_on_second_run"
 comment = """
-Test all input configuration combinations for cache behavior
+With only positive globs (`src/**/*.ts`) and no file changes, a second run
+should be a cache hit.
 """
 steps = [
   # First run - cache miss
@@ -16,7 +14,7 @@ steps = [
 [[e2e]]
 name = "positive_globs_only___miss_on_matched_file_change"
 comment = """
-Test all input configuration combinations for cache behavior
+Modifying a file matched by a positive glob should invalidate the cache.
 """
 steps = [
   # Initial run
@@ -30,7 +28,8 @@ steps = [
 [[e2e]]
 name = "positive_globs_only___hit_on_unmatched_file_change"
 comment = """
-Test all input configuration combinations for cache behavior
+Modifying a file outside the positive glob (e.g. under `test/`) should not
+invalidate the cache.
 """
 steps = [
   # Initial run
@@ -41,13 +40,11 @@ steps = [
   ["vt", "run", "positive-globs-only"],
 ]
 
-# 1b. Positive globs reads unmatched file: input: ["src/main.ts"], command reads src/utils.ts too
-# - File read by command but NOT matched by glob should NOT be fingerprinted
-# - This tests that inference is truly disabled when only explicit globs are used
 [[e2e]]
 name = "positive_globs___hit_on_read_but_unmatched_file"
 comment = """
-Test all input configuration combinations for cache behavior
+With only positive globs (no `auto`), files read at runtime but not matched
+by the glob should not be fingerprinted — inference is truly disabled.
 """
 steps = [
   # Initial run - reads both src/main.ts and src/utils.ts
@@ -58,13 +55,11 @@ steps = [
   ["vt", "run", "positive-globs-reads-unmatched"],
 ]
 
-# 2. Positive + negative globs: input: ["src/**", "!src/**/*.test.ts"]
-# - Files matching positive but NOT negative trigger invalidation
-# - Files matching negative glob are excluded
 [[e2e]]
 name = "positive_negative_globs___miss_on_non_excluded_file"
 comment = """
-Test all input configuration combinations for cache behavior
+A file matched by a positive glob and not by any negative glob should still
+invalidate the cache when modified.
 """
 steps = [
   # Initial run
@@ -78,7 +73,8 @@ steps = [
 [[e2e]]
 name = "positive_negative_globs___hit_on_excluded_file"
 comment = """
-Test all input configuration combinations for cache behavior
+A file matched by the negative glob should be excluded from fingerprinting
+even if it also matches a positive glob.
 """
 steps = [
   # Initial run
@@ -89,13 +85,11 @@ steps = [
   ["vt", "run", "positive-negative-globs"],
 ]
 
-# 3. Auto only: input: [{ "auto": true }]
-# - Files read by the command trigger invalidation (fspy inference)
-# - Files NOT read by the command do NOT trigger invalidation
 [[e2e]]
 name = "auto_only___miss_on_inferred_file_change"
 comment = """
-Test all input configuration combinations for cache behavior
+With `auto: true`, files read by the command (via fspy) should be fingerprinted
+and a change to such a file should invalidate the cache.
 """
 steps = [
   # Initial run - reads src/main.ts
@@ -109,7 +103,8 @@ steps = [
 [[e2e]]
 name = "auto_only___hit_on_non_inferred_file_change"
 comment = """
-Test all input configuration combinations for cache behavior
+With `auto: true`, a file never read by the command should not affect the
+cache, even if it sits next to files that are read.
 """
 steps = [
   # Initial run - reads src/main.ts (NOT utils.ts)
@@ -120,13 +115,11 @@ steps = [
   ["vt", "run", "auto-only"],
 ]
 
-# 4. Auto + negative: input: [{ "auto": true }, "!dist/**"]
-# - Inferred files are tracked, but negative globs filter them out
-# - Files in excluded directories don't trigger invalidation even if read
 [[e2e]]
 name = "auto_with_negative___hit_on_excluded_inferred_file"
 comment = """
-Test all input configuration combinations for cache behavior
+A negative glob should filter out inferred inputs — a `dist/**`-excluded file
+that the command happens to read should not invalidate the cache.
 """
 steps = [
   # Initial run - reads both src/main.ts and dist/output.js
@@ -140,7 +133,8 @@ steps = [
 [[e2e]]
 name = "auto_with_negative___miss_on_non_excluded_inferred_file"
 comment = """
-Test all input configuration combinations for cache behavior
+With `auto: true` plus a negative glob, changes to inferred inputs outside
+the excluded range should still invalidate the cache.
 """
 steps = [
   # Initial run
@@ -151,13 +145,11 @@ steps = [
   ["vt", "run", "auto-with-negative"],
 ]
 
-# 5. Positive + auto + negative: input: ["package.json", { "auto": true }, "!src/**/*.test.ts"]
-# - Explicit globs AND inferred files are both tracked
-# - Negative globs apply to both explicit and inferred input
 [[e2e]]
 name = "positive_auto_negative___miss_on_explicit_glob_file"
 comment = """
-Test all input configuration combinations for cache behavior
+When positive, `auto`, and negative globs are combined, modifying a file
+matched by the explicit positive glob should invalidate the cache.
 """
 steps = [
   # Initial run
@@ -171,7 +163,8 @@ steps = [
 [[e2e]]
 name = "positive_auto_negative___miss_on_inferred_file"
 comment = """
-Test all input configuration combinations for cache behavior
+Under combined positive + `auto` + negative config, modifying a file that
+only the `auto` inference discovered should still invalidate the cache.
 """
 steps = [
   # Initial run
@@ -185,7 +178,8 @@ steps = [
 [[e2e]]
 name = "positive_auto_negative___hit_on_excluded_file"
 comment = """
-Test all input configuration combinations for cache behavior
+Under combined positive + `auto` + negative config, a negative glob should
+still filter files contributed by either source.
 """
 steps = [
   # Initial run
@@ -196,13 +190,11 @@ steps = [
   ["vt", "run", "positive-auto-negative"],
 ]
 
-# 6. Empty input: input: []
-# - No file changes affect the cache
-# - Only command/env changes trigger cache invalidation
 [[e2e]]
 name = "empty_input___hit_despite_file_changes"
 comment = """
-Test all input configuration combinations for cache behavior
+With `input: []`, no file changes should ever invalidate the cache — only
+command/env changes can.
 """
 steps = [
   # Initial run
@@ -216,7 +208,8 @@ steps = [
 [[e2e]]
 name = "empty_input___miss_on_command_change"
 comment = """
-Test all input configuration combinations for cache behavior
+Even with `input: []`, changing the task's command should still invalidate
+the cache.
 """
 steps = [
   # Initial run
@@ -241,13 +234,11 @@ steps = [
   ],
 ]
 
-# 7. FSPY environment variable
-# - FSPY=1 is set when fspy is enabled (includes_auto is true)
-# - FSPY is NOT set when fspy is disabled (explicit globs only)
 [[e2e]]
 name = "fspy_env___set_when_auto_inference_enabled"
 comment = """
-Test all input configuration combinations for cache behavior
+When auto-inference is enabled (input includes `{auto: true}`), the task
+process should see `FSPY=1` in its environment.
 """
 steps = [
   # Run task with auto inference - should see FSPY=1
@@ -257,21 +248,19 @@ steps = [
 [[e2e]]
 name = "fspy_env___not_set_when_auto_inference_disabled"
 comment = """
-Test all input configuration combinations for cache behavior
+When auto-inference is disabled (explicit globs only), the task process
+should not see `FSPY` set.
 """
 steps = [
   # Run task without auto inference - should see (undefined)
   ["vt", "run", "check-fspy-env-without-auto"],
 ]
 
-# 8. Trailing slash input: input: ["src/"]
-# - Trailing `/` is expanded to `/**`, matching all files under that directory
-# - Direct and nested file changes trigger cache invalidation
-# - Files outside the directory do NOT trigger cache invalidation
 [[e2e]]
 name = "folder_slash_input___miss_on_direct_and_nested_file_changes"
 comment = """
-Test all input configuration combinations for cache behavior
+A trailing-slash input (`src/`) should expand to `src/**`, so both direct
+and nested file changes under it invalidate the cache.
 """
 steps = [
   ["vt", "run", "folder-slash-input"],
@@ -291,7 +280,8 @@ steps = [
 [[e2e]]
 name = "folder_slash_input___hit_on_file_outside_directory"
 comment = """
-Test all input configuration combinations for cache behavior
+With a trailing-slash input (`src/`), files outside the directory should not
+be part of the fingerprint.
 """
 steps = [
   ["vt", "run", "folder-slash-input"],
@@ -301,13 +291,11 @@ steps = [
   ["vt", "run", "folder-slash-input"],
 ]
 
-# 9. Folder path as input: input: ["src"]
-# - A bare directory name matches nothing (directories are not files)
-# - File changes inside the folder should NOT trigger cache invalidation
 [[e2e]]
 name = "folder_input___hit_despite_file_changes_and_folder_deletion"
 comment = """
-Test all input configuration combinations for cache behavior
+A bare directory name as input (`src`) matches only the directory entry,
+not its contents — neither file edits nor folder deletion affect the cache.
 """
 steps = [
   ["vt", "run", "folder-input"],

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/auto_only___hit_on_non_inferred_file_change.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/auto_only___hit_on_non_inferred_file_change.md
@@ -1,6 +1,7 @@
 # auto_only___hit_on_non_inferred_file_change
 
-Test all input configuration combinations for cache behavior
+With `auto: true`, a file never read by the command should not affect the
+cache, even if it sits next to files that are read.
 
 ## `vt run auto-only`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/auto_only___miss_on_inferred_file_change.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/auto_only___miss_on_inferred_file_change.md
@@ -1,6 +1,7 @@
 # auto_only___miss_on_inferred_file_change
 
-Test all input configuration combinations for cache behavior
+With `auto: true`, files read by the command (via fspy) should be fingerprinted
+and a change to such a file should invalidate the cache.
 
 ## `vt run auto-only`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/auto_with_negative___hit_on_excluded_inferred_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/auto_with_negative___hit_on_excluded_inferred_file.md
@@ -1,6 +1,7 @@
 # auto_with_negative___hit_on_excluded_inferred_file
 
-Test all input configuration combinations for cache behavior
+A negative glob should filter out inferred inputs — a `dist/**`-excluded file
+that the command happens to read should not invalidate the cache.
 
 ## `vt run auto-with-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/auto_with_negative___miss_on_non_excluded_inferred_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/auto_with_negative___miss_on_non_excluded_inferred_file.md
@@ -1,6 +1,7 @@
 # auto_with_negative___miss_on_non_excluded_inferred_file
 
-Test all input configuration combinations for cache behavior
+With `auto: true` plus a negative glob, changes to inferred inputs outside
+the excluded range should still invalidate the cache.
 
 ## `vt run auto-with-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/empty_input___hit_despite_file_changes.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/empty_input___hit_despite_file_changes.md
@@ -1,6 +1,7 @@
 # empty_input___hit_despite_file_changes
 
-Test all input configuration combinations for cache behavior
+With `input: []`, no file changes should ever invalidate the cache — only
+command/env changes can.
 
 ## `vt run empty-inputs`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/empty_input___miss_on_command_change.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/empty_input___miss_on_command_change.md
@@ -1,6 +1,7 @@
 # empty_input___miss_on_command_change
 
-Test all input configuration combinations for cache behavior
+Even with `input: []`, changing the task's command should still invalidate
+the cache.
 
 ## `vt run empty-inputs`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/folder_input___hit_despite_file_changes_and_folder_deletion.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/folder_input___hit_despite_file_changes_and_folder_deletion.md
@@ -1,6 +1,7 @@
 # folder_input___hit_despite_file_changes_and_folder_deletion
 
-Test all input configuration combinations for cache behavior
+A bare directory name as input (`src`) matches only the directory entry,
+not its contents — neither file edits nor folder deletion affect the cache.
 
 ## `vt run folder-input`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/folder_slash_input___hit_on_file_outside_directory.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/folder_slash_input___hit_on_file_outside_directory.md
@@ -1,6 +1,7 @@
 # folder_slash_input___hit_on_file_outside_directory
 
-Test all input configuration combinations for cache behavior
+With a trailing-slash input (`src/`), files outside the directory should not
+be part of the fingerprint.
 
 ## `vt run folder-slash-input`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/folder_slash_input___miss_on_direct_and_nested_file_changes.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/folder_slash_input___miss_on_direct_and_nested_file_changes.md
@@ -1,6 +1,7 @@
 # folder_slash_input___miss_on_direct_and_nested_file_changes
 
-Test all input configuration combinations for cache behavior
+A trailing-slash input (`src/`) should expand to `src/**`, so both direct
+and nested file changes under it invalidate the cache.
 
 ## `vt run folder-slash-input`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/fspy_env___not_set_when_auto_inference_disabled.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/fspy_env___not_set_when_auto_inference_disabled.md
@@ -1,6 +1,7 @@
 # fspy_env___not_set_when_auto_inference_disabled
 
-Test all input configuration combinations for cache behavior
+When auto-inference is disabled (explicit globs only), the task process
+should not see `FSPY` set.
 
 ## `vt run check-fspy-env-without-auto`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/fspy_env___set_when_auto_inference_enabled.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/fspy_env___set_when_auto_inference_enabled.md
@@ -1,6 +1,7 @@
 # fspy_env___set_when_auto_inference_enabled
 
-Test all input configuration combinations for cache behavior
+When auto-inference is enabled (input includes `{auto: true}`), the task
+process should see `FSPY=1` in its environment.
 
 ## `vt run check-fspy-env-with-auto`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_auto_negative___hit_on_excluded_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_auto_negative___hit_on_excluded_file.md
@@ -1,6 +1,7 @@
 # positive_auto_negative___hit_on_excluded_file
 
-Test all input configuration combinations for cache behavior
+Under combined positive + `auto` + negative config, a negative glob should
+still filter files contributed by either source.
 
 ## `vt run positive-auto-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_auto_negative___miss_on_explicit_glob_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_auto_negative___miss_on_explicit_glob_file.md
@@ -1,6 +1,7 @@
 # positive_auto_negative___miss_on_explicit_glob_file
 
-Test all input configuration combinations for cache behavior
+When positive, `auto`, and negative globs are combined, modifying a file
+matched by the explicit positive glob should invalidate the cache.
 
 ## `vt run positive-auto-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_auto_negative___miss_on_inferred_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_auto_negative___miss_on_inferred_file.md
@@ -1,6 +1,7 @@
 # positive_auto_negative___miss_on_inferred_file
 
-Test all input configuration combinations for cache behavior
+Under combined positive + `auto` + negative config, modifying a file that
+only the `auto` inference discovered should still invalidate the cache.
 
 ## `vt run positive-auto-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_globs___hit_on_read_but_unmatched_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_globs___hit_on_read_but_unmatched_file.md
@@ -1,6 +1,7 @@
 # positive_globs___hit_on_read_but_unmatched_file
 
-Test all input configuration combinations for cache behavior
+With only positive globs (no `auto`), files read at runtime but not matched
+by the glob should not be fingerprinted — inference is truly disabled.
 
 ## `vt run positive-globs-reads-unmatched`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_globs_only___cache_hit_on_second_run.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_globs_only___cache_hit_on_second_run.md
@@ -1,6 +1,7 @@
 # positive_globs_only___cache_hit_on_second_run
 
-Test all input configuration combinations for cache behavior
+With only positive globs (`src/**/*.ts`) and no file changes, a second run
+should be a cache hit.
 
 ## `vt run positive-globs-only`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_globs_only___hit_on_unmatched_file_change.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_globs_only___hit_on_unmatched_file_change.md
@@ -1,6 +1,7 @@
 # positive_globs_only___hit_on_unmatched_file_change
 
-Test all input configuration combinations for cache behavior
+Modifying a file outside the positive glob (e.g. under `test/`) should not
+invalidate the cache.
 
 ## `vt run positive-globs-only`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_globs_only___miss_on_matched_file_change.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_globs_only___miss_on_matched_file_change.md
@@ -1,6 +1,6 @@
 # positive_globs_only___miss_on_matched_file_change
 
-Test all input configuration combinations for cache behavior
+Modifying a file matched by a positive glob should invalidate the cache.
 
 ## `vt run positive-globs-only`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_negative_globs___hit_on_excluded_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_negative_globs___hit_on_excluded_file.md
@@ -1,6 +1,7 @@
 # positive_negative_globs___hit_on_excluded_file
 
-Test all input configuration combinations for cache behavior
+A file matched by the negative glob should be excluded from fingerprinting
+even if it also matches a positive glob.
 
 ## `vt run positive-negative-globs`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_negative_globs___miss_on_non_excluded_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_negative_globs___miss_on_non_excluded_file.md
@@ -1,6 +1,7 @@
 # positive_negative_globs___miss_on_non_excluded_file
 
-Test all input configuration combinations for cache behavior
+A file matched by a positive glob and not by any negative glob should still
+invalidate the cache when modified.
 
 ## `vt run positive-negative-globs`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_glob_meta_in_path/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_glob_meta_in_path/snapshots.toml
@@ -1,11 +1,10 @@
+[[e2e]]
+name = "cache_hit_then_miss_on_file_change"
 comment = """
 Test that glob meta characters in package paths are correctly escaped by wax::escape.
 Without escaping, "packages/[lib]/src/**/*.ts" would interpret [lib] as a character
 class matching 'l', 'i', or 'b' instead of the literal directory name.
 """
-
-[[e2e]]
-name = "cache_hit_then_miss_on_file_change"
 steps = [
   [
     "vt",

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots.toml
@@ -1,15 +1,14 @@
+# Auto + negative in subpackage: input: [{ "auto": true }, "!dist/**"]
+# - dist/ should be excluded even though the package is a subpackage
+# - Modifying dist/output.js should be a cache hit
+[[e2e]]
+name = "subpackage_auto_with_negative___hit_on_excluded_inferred_file"
 comment = """
 Test that negative input globs work correctly for subpackages.
 Bug: negative globs were matched against workspace-relative paths
 instead of package-relative paths, so exclusions like !dist/**
 failed for subpackages.
 """
-
-# Auto + negative in subpackage: input: [{ "auto": true }, "!dist/**"]
-# - dist/ should be excluded even though the package is a subpackage
-# - Modifying dist/output.js should be a cache hit
-[[e2e]]
-name = "subpackage_auto_with_negative___hit_on_excluded_inferred_file"
 steps = [
   # First run - reads both src/main.ts and dist/output.js
   ["vt", "run", "sub-pkg#auto-with-negative"],
@@ -21,6 +20,12 @@ steps = [
 
 [[e2e]]
 name = "subpackage_auto_with_negative___miss_on_non_excluded_inferred_file"
+comment = """
+Test that negative input globs work correctly for subpackages.
+Bug: negative globs were matched against workspace-relative paths
+instead of package-relative paths, so exclusions like !dist/**
+failed for subpackages.
+"""
 steps = [
   # First run
   ["vt", "run", "sub-pkg#auto-with-negative"],
@@ -35,6 +40,12 @@ steps = [
 # - Cache miss when sibling file changes, hit when unrelated file changes
 [[e2e]]
 name = "dotdot_positive_glob___miss_on_sibling_file_change"
+comment = """
+Test that negative input globs work correctly for subpackages.
+Bug: negative globs were matched against workspace-relative paths
+instead of package-relative paths, so exclusions like !dist/**
+failed for subpackages.
+"""
 steps = [
   ["vt", "run", "sub-pkg#dotdot-positive"],
   # Modify a file that matches ../shared/src/**
@@ -45,6 +56,12 @@ steps = [
 
 [[e2e]]
 name = "dotdot_positive_glob___hit_on_unmatched_file_change"
+comment = """
+Test that negative input globs work correctly for subpackages.
+Bug: negative globs were matched against workspace-relative paths
+instead of package-relative paths, so exclusions like !dist/**
+failed for subpackages.
+"""
 steps = [
   ["vt", "run", "sub-pkg#dotdot-positive"],
   # Modify a file NOT matched by ../shared/src/**
@@ -58,6 +75,12 @@ steps = [
 # - Negative glob excludes sibling dist/ via ..
 [[e2e]]
 name = "dotdot_positive_negative___miss_on_non_excluded_sibling_file"
+comment = """
+Test that negative input globs work correctly for subpackages.
+Bug: negative globs were matched against workspace-relative paths
+instead of package-relative paths, so exclusions like !dist/**
+failed for subpackages.
+"""
 steps = [
   ["vt", "run", "sub-pkg#dotdot-positive-negative"],
   # Modify file matching positive but NOT negative
@@ -68,6 +91,12 @@ steps = [
 
 [[e2e]]
 name = "dotdot_positive_negative___hit_on_excluded_sibling_file"
+comment = """
+Test that negative input globs work correctly for subpackages.
+Bug: negative globs were matched against workspace-relative paths
+instead of package-relative paths, so exclusions like !dist/**
+failed for subpackages.
+"""
 steps = [
   ["vt", "run", "sub-pkg#dotdot-positive-negative"],
   # Modify file in excluded sibling dist/
@@ -81,6 +110,12 @@ steps = [
 # - Negative glob excludes sibling dist/ from inferred input
 [[e2e]]
 name = "dotdot_auto_negative___hit_on_excluded_sibling_inferred_file"
+comment = """
+Test that negative input globs work correctly for subpackages.
+Bug: negative globs were matched against workspace-relative paths
+instead of package-relative paths, so exclusions like !dist/**
+failed for subpackages.
+"""
 steps = [
   ["vt", "run", "sub-pkg#dotdot-auto-negative"],
   # Modify file in excluded sibling dist/
@@ -91,6 +126,12 @@ steps = [
 
 [[e2e]]
 name = "dotdot_auto_negative___miss_on_non_excluded_sibling_inferred_file"
+comment = """
+Test that negative input globs work correctly for subpackages.
+Bug: negative globs were matched against workspace-relative paths
+instead of package-relative paths, so exclusions like !dist/**
+failed for subpackages.
+"""
 steps = [
   ["vt", "run", "sub-pkg#dotdot-auto-negative"],
   # Modify non-excluded sibling file

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots.toml
@@ -1,13 +1,10 @@
-# Auto + negative in subpackage: input: [{ "auto": true }, "!dist/**"]
-# - dist/ should be excluded even though the package is a subpackage
-# - Modifying dist/output.js should be a cache hit
 [[e2e]]
 name = "subpackage_auto_with_negative___hit_on_excluded_inferred_file"
 comment = """
-Test that negative input globs work correctly for subpackages.
-Bug: negative globs were matched against workspace-relative paths
-instead of package-relative paths, so exclusions like !dist/**
-failed for subpackages.
+A subpackage's `!dist/**` exclusion should apply package-relative, not
+workspace-relative — modifying the subpackage's own `dist/` file stays a
+cache hit. (Regression: the exclusion used to resolve against the workspace
+root.)
 """
 steps = [
   # First run - reads both src/main.ts and dist/output.js
@@ -21,10 +18,8 @@ steps = [
 [[e2e]]
 name = "subpackage_auto_with_negative___miss_on_non_excluded_inferred_file"
 comment = """
-Test that negative input globs work correctly for subpackages.
-Bug: negative globs were matched against workspace-relative paths
-instead of package-relative paths, so exclusions like !dist/**
-failed for subpackages.
+In a subpackage with `auto: true` plus `!dist/**`, changes to inferred inputs
+outside `dist/` should still invalidate the cache.
 """
 steps = [
   # First run
@@ -35,16 +30,11 @@ steps = [
   ["vt", "run", "sub-pkg#auto-with-negative"],
 ]
 
-# .. prefix positive globs: input: ["../shared/src/**"]
-# - Should find files in sibling package via ..
-# - Cache miss when sibling file changes, hit when unrelated file changes
 [[e2e]]
 name = "dotdot_positive_glob___miss_on_sibling_file_change"
 comment = """
-Test that negative input globs work correctly for subpackages.
-Bug: negative globs were matched against workspace-relative paths
-instead of package-relative paths, so exclusions like !dist/**
-failed for subpackages.
+A `../` positive glob should reach into sibling packages; modifying a matched
+sibling file should invalidate the cache.
 """
 steps = [
   ["vt", "run", "sub-pkg#dotdot-positive"],
@@ -57,10 +47,8 @@ steps = [
 [[e2e]]
 name = "dotdot_positive_glob___hit_on_unmatched_file_change"
 comment = """
-Test that negative input globs work correctly for subpackages.
-Bug: negative globs were matched against workspace-relative paths
-instead of package-relative paths, so exclusions like !dist/**
-failed for subpackages.
+A `../` positive glob should only match the paths it names — sibling files
+outside the glob (e.g. sibling `dist/`) should not affect the cache.
 """
 steps = [
   ["vt", "run", "sub-pkg#dotdot-positive"],
@@ -70,16 +58,11 @@ steps = [
   ["vt", "run", "sub-pkg#dotdot-positive"],
 ]
 
-# .. prefix positive + negative globs: input: ["../shared/**", "!../shared/dist/**"]
-# - Positive glob matches sibling package files via ..
-# - Negative glob excludes sibling dist/ via ..
 [[e2e]]
 name = "dotdot_positive_negative___miss_on_non_excluded_sibling_file"
 comment = """
-Test that negative input globs work correctly for subpackages.
-Bug: negative globs were matched against workspace-relative paths
-instead of package-relative paths, so exclusions like !dist/**
-failed for subpackages.
+With `../shared/**` plus `!../shared/dist/**`, modifying a sibling file
+outside the exclusion should invalidate the cache.
 """
 steps = [
   ["vt", "run", "sub-pkg#dotdot-positive-negative"],
@@ -92,10 +75,8 @@ steps = [
 [[e2e]]
 name = "dotdot_positive_negative___hit_on_excluded_sibling_file"
 comment = """
-Test that negative input globs work correctly for subpackages.
-Bug: negative globs were matched against workspace-relative paths
-instead of package-relative paths, so exclusions like !dist/**
-failed for subpackages.
+A `../`-prefixed negative glob should correctly exclude files in the sibling
+package's `dist/` directory.
 """
 steps = [
   ["vt", "run", "sub-pkg#dotdot-positive-negative"],
@@ -105,16 +86,11 @@ steps = [
   ["vt", "run", "sub-pkg#dotdot-positive-negative"],
 ]
 
-# .. prefix auto + negative: input: [{ "auto": true }, "!../shared/dist/**"]
-# - Auto-inferred files from sibling package are tracked
-# - Negative glob excludes sibling dist/ from inferred input
 [[e2e]]
 name = "dotdot_auto_negative___hit_on_excluded_sibling_inferred_file"
 comment = """
-Test that negative input globs work correctly for subpackages.
-Bug: negative globs were matched against workspace-relative paths
-instead of package-relative paths, so exclusions like !dist/**
-failed for subpackages.
+A `!../shared/dist/**` negative glob should filter inferred reads that land
+in the sibling package's `dist/` directory.
 """
 steps = [
   ["vt", "run", "sub-pkg#dotdot-auto-negative"],
@@ -127,10 +103,8 @@ steps = [
 [[e2e]]
 name = "dotdot_auto_negative___miss_on_non_excluded_sibling_inferred_file"
 comment = """
-Test that negative input globs work correctly for subpackages.
-Bug: negative globs were matched against workspace-relative paths
-instead of package-relative paths, so exclusions like !dist/**
-failed for subpackages.
+Under `auto: true` plus a `../` negative glob, inferred reads from sibling
+files outside the exclusion should still invalidate the cache.
 """
 steps = [
   ["vt", "run", "sub-pkg#dotdot-auto-negative"],

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_auto_negative___hit_on_excluded_sibling_inferred_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_auto_negative___hit_on_excluded_sibling_inferred_file.md
@@ -1,9 +1,7 @@
 # dotdot_auto_negative___hit_on_excluded_sibling_inferred_file
 
-Test that negative input globs work correctly for subpackages.
-Bug: negative globs were matched against workspace-relative paths
-instead of package-relative paths, so exclusions like !dist/**
-failed for subpackages.
+A `!../shared/dist/**` negative glob should filter inferred reads that land
+in the sibling package's `dist/` directory.
 
 ## `vt run sub-pkg#dotdot-auto-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_auto_negative___miss_on_non_excluded_sibling_inferred_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_auto_negative___miss_on_non_excluded_sibling_inferred_file.md
@@ -1,9 +1,7 @@
 # dotdot_auto_negative___miss_on_non_excluded_sibling_inferred_file
 
-Test that negative input globs work correctly for subpackages.
-Bug: negative globs were matched against workspace-relative paths
-instead of package-relative paths, so exclusions like !dist/**
-failed for subpackages.
+Under `auto: true` plus a `../` negative glob, inferred reads from sibling
+files outside the exclusion should still invalidate the cache.
 
 ## `vt run sub-pkg#dotdot-auto-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_positive_glob___hit_on_unmatched_file_change.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_positive_glob___hit_on_unmatched_file_change.md
@@ -1,9 +1,7 @@
 # dotdot_positive_glob___hit_on_unmatched_file_change
 
-Test that negative input globs work correctly for subpackages.
-Bug: negative globs were matched against workspace-relative paths
-instead of package-relative paths, so exclusions like !dist/**
-failed for subpackages.
+A `../` positive glob should only match the paths it names — sibling files
+outside the glob (e.g. sibling `dist/`) should not affect the cache.
 
 ## `vt run sub-pkg#dotdot-positive`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_positive_glob___miss_on_sibling_file_change.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_positive_glob___miss_on_sibling_file_change.md
@@ -1,9 +1,7 @@
 # dotdot_positive_glob___miss_on_sibling_file_change
 
-Test that negative input globs work correctly for subpackages.
-Bug: negative globs were matched against workspace-relative paths
-instead of package-relative paths, so exclusions like !dist/**
-failed for subpackages.
+A `../` positive glob should reach into sibling packages; modifying a matched
+sibling file should invalidate the cache.
 
 ## `vt run sub-pkg#dotdot-positive`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_positive_negative___hit_on_excluded_sibling_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_positive_negative___hit_on_excluded_sibling_file.md
@@ -1,9 +1,7 @@
 # dotdot_positive_negative___hit_on_excluded_sibling_file
 
-Test that negative input globs work correctly for subpackages.
-Bug: negative globs were matched against workspace-relative paths
-instead of package-relative paths, so exclusions like !dist/**
-failed for subpackages.
+A `../`-prefixed negative glob should correctly exclude files in the sibling
+package's `dist/` directory.
 
 ## `vt run sub-pkg#dotdot-positive-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_positive_negative___miss_on_non_excluded_sibling_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_positive_negative___miss_on_non_excluded_sibling_file.md
@@ -1,9 +1,7 @@
 # dotdot_positive_negative___miss_on_non_excluded_sibling_file
 
-Test that negative input globs work correctly for subpackages.
-Bug: negative globs were matched against workspace-relative paths
-instead of package-relative paths, so exclusions like !dist/**
-failed for subpackages.
+With `../shared/**` plus `!../shared/dist/**`, modifying a sibling file
+outside the exclusion should invalidate the cache.
 
 ## `vt run sub-pkg#dotdot-positive-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/subpackage_auto_with_negative___hit_on_excluded_inferred_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/subpackage_auto_with_negative___hit_on_excluded_inferred_file.md
@@ -1,9 +1,9 @@
 # subpackage_auto_with_negative___hit_on_excluded_inferred_file
 
-Test that negative input globs work correctly for subpackages.
-Bug: negative globs were matched against workspace-relative paths
-instead of package-relative paths, so exclusions like !dist/**
-failed for subpackages.
+A subpackage's `!dist/**` exclusion should apply package-relative, not
+workspace-relative — modifying the subpackage's own `dist/` file stays a
+cache hit. (Regression: the exclusion used to resolve against the workspace
+root.)
 
 ## `vt run sub-pkg#auto-with-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/subpackage_auto_with_negative___miss_on_non_excluded_inferred_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/subpackage_auto_with_negative___miss_on_non_excluded_inferred_file.md
@@ -1,9 +1,7 @@
 # subpackage_auto_with_negative___miss_on_non_excluded_inferred_file
 
-Test that negative input globs work correctly for subpackages.
-Bug: negative globs were matched against workspace-relative paths
-instead of package-relative paths, so exclusions like !dist/**
-failed for subpackages.
+In a subpackage with `auto: true` plus `!dist/**`, changes to inferred inputs
+outside `dist/` should still invalidate the cache.
 
 ## `vt run sub-pkg#auto-with-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots.toml
@@ -1,27 +1,38 @@
+# Single rw-task: compact summary shows "not cached because it modified its input"
+[[e2e]]
+name = "single_read_write_task_shows_not_cached_message"
 comment = """
 Tests that tasks modifying their own inputs (read-write overlap) are not cached.
 vtt replace-file-content reads then writes the same file — fspy detects both.
 """
-
-# Single rw-task: compact summary shows "not cached because it modified its input"
-[[e2e]]
-name = "single_read_write_task_shows_not_cached_message"
 cwd = "packages/rw-pkg"
 steps = [["vt", "run", "task"], ["vt", "run", "task"]]
 
 # Multi-task (recursive): compact summary shows stats + InputModified notice
 [[e2e]]
 name = "multi_task_with_read_write_shows_not_cached_in_summary"
+comment = """
+Tests that tasks modifying their own inputs (read-write overlap) are not cached.
+vtt replace-file-content reads then writes the same file — fspy detects both.
+"""
 steps = [["vt", "run", "-r", "task"], ["vt", "run", "-r", "task"]]
 
 # Verbose: full summary shows the overlapping path
 [[e2e]]
 name = "verbose_read_write_task_shows_path_in_full_summary"
+comment = """
+Tests that tasks modifying their own inputs (read-write overlap) are not cached.
+vtt replace-file-content reads then writes the same file — fspy detects both.
+"""
 cwd = "packages/rw-pkg"
 steps = [["vt", "run", "-v", "task"]]
 
 # Single O_RDWR open (touch-file) is also detected as read-write overlap
 [[e2e]]
 name = "single_O_RDWR_open_is_not_cached"
+comment = """
+Tests that tasks modifying their own inputs (read-write overlap) are not cached.
+vtt replace-file-content reads then writes the same file — fspy detects both.
+"""
 cwd = "packages/touch-pkg"
 steps = [["vt", "run", "task"], ["vt", "run", "task"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots.toml
@@ -1,38 +1,36 @@
-# Single rw-task: compact summary shows "not cached because it modified its input"
 [[e2e]]
 name = "single_read_write_task_shows_not_cached_message"
 comment = """
-Tests that tasks modifying their own inputs (read-write overlap) are not cached.
-vtt replace-file-content reads then writes the same file — fspy detects both.
+A single task that reads and writes the same file (fspy sees both ops)
+should be flagged as "not cached because it modified its input" in the
+compact summary.
 """
 cwd = "packages/rw-pkg"
 steps = [["vt", "run", "task"], ["vt", "run", "task"]]
 
-# Multi-task (recursive): compact summary shows stats + InputModified notice
 [[e2e]]
 name = "multi_task_with_read_write_shows_not_cached_in_summary"
 comment = """
-Tests that tasks modifying their own inputs (read-write overlap) are not cached.
-vtt replace-file-content reads then writes the same file — fspy detects both.
+In a multi-task (`-r`) run, tasks with a read-write overlap should appear in
+the compact summary stats alongside an `InputModified` notice.
 """
 steps = [["vt", "run", "-r", "task"], ["vt", "run", "-r", "task"]]
 
-# Verbose: full summary shows the overlapping path
 [[e2e]]
 name = "verbose_read_write_task_shows_path_in_full_summary"
 comment = """
-Tests that tasks modifying their own inputs (read-write overlap) are not cached.
-vtt replace-file-content reads then writes the same file — fspy detects both.
+Under `-v`, the full summary should list the exact overlapping path that
+caused the task to skip caching.
 """
 cwd = "packages/rw-pkg"
 steps = [["vt", "run", "-v", "task"]]
 
-# Single O_RDWR open (touch-file) is also detected as read-write overlap
 [[e2e]]
 name = "single_O_RDWR_open_is_not_cached"
 comment = """
-Tests that tasks modifying their own inputs (read-write overlap) are not cached.
-vtt replace-file-content reads then writes the same file — fspy detects both.
+Opening a single file with `O_RDWR` (e.g. `touch` keeping the file) should
+count as a read-write overlap and prevent caching, just like separate
+read+write syscalls.
 """
 cwd = "packages/touch-pkg"
 steps = [["vt", "run", "task"], ["vt", "run", "task"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots/multi_task_with_read_write_shows_not_cached_in_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots/multi_task_with_read_write_shows_not_cached_in_summary.md
@@ -1,7 +1,7 @@
 # multi_task_with_read_write_shows_not_cached_in_summary
 
-Tests that tasks modifying their own inputs (read-write overlap) are not cached.
-vtt replace-file-content reads then writes the same file — fspy detects both.
+In a multi-task (`-r`) run, tasks with a read-write overlap should appear in
+the compact summary stats alongside an `InputModified` notice.
 
 ## `vt run -r task`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots/single_O_RDWR_open_is_not_cached.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots/single_O_RDWR_open_is_not_cached.md
@@ -1,7 +1,8 @@
 # single_O_RDWR_open_is_not_cached
 
-Tests that tasks modifying their own inputs (read-write overlap) are not cached.
-vtt replace-file-content reads then writes the same file — fspy detects both.
+Opening a single file with `O_RDWR` (e.g. `touch` keeping the file) should
+count as a read-write overlap and prevent caching, just like separate
+read+write syscalls.
 
 ## `vt run task`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots/single_read_write_task_shows_not_cached_message.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots/single_read_write_task_shows_not_cached_message.md
@@ -1,7 +1,8 @@
 # single_read_write_task_shows_not_cached_message
 
-Tests that tasks modifying their own inputs (read-write overlap) are not cached.
-vtt replace-file-content reads then writes the same file — fspy detects both.
+A single task that reads and writes the same file (fspy sees both ops)
+should be flagged as "not cached because it modified its input" in the
+compact summary.
 
 ## `vt run task`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots/verbose_read_write_task_shows_path_in_full_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots/verbose_read_write_task_shows_path_in_full_summary.md
@@ -1,7 +1,7 @@
 # verbose_read_write_task_shows_path_in_full_summary
 
-Tests that tasks modifying their own inputs (read-write overlap) are not cached.
-vtt replace-file-content reads then writes the same file — fspy detects both.
+Under `-v`, the full summary should list the exact overlapping path that
+caused the task to skip caching.
 
 ## `vt run -v task`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots.toml
@@ -1,3 +1,7 @@
+# ─── stdout/stderr: cache off → inherited (tty) ─────────────────
+
+[[e2e]]
+name = "single_task__cache_off__inherits_stdio"
 comment = """
 Tests stdio behavior in interleaved mode (default --log mode).
 
@@ -10,45 +14,124 @@ This applies identically regardless of task count.
 `check-tty` prints whether each stdio fd is a TTY.
 `read-stdin` reads one line from stdin and prints it.
 """
-
-# ─── stdout/stderr: cache off → inherited (tty) ─────────────────
-
-[[e2e]]
-name = "single_task__cache_off__inherits_stdio"
 steps = [["vt", "run", "check-tty"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_off__inherit_stdio"
+comment = """
+Tests stdio behavior in interleaved mode (default --log mode).
+
+In interleaved mode:
+- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
+- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
+
+This applies identically regardless of task count.
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [["vt", "run", "-r", "check-tty"]]
 
 # ─── stdout/stderr: cache on, miss → piped (not-tty) ────────────
 
 [[e2e]]
 name = "single_task__cache_miss__piped_stdio"
+comment = """
+Tests stdio behavior in interleaved mode (default --log mode).
+
+In interleaved mode:
+- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
+- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
+
+This applies identically regardless of task count.
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [["vt", "run", "check-tty-cached"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_miss__piped_stdio"
+comment = """
+Tests stdio behavior in interleaved mode (default --log mode).
+
+In interleaved mode:
+- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
+- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
+
+This applies identically regardless of task count.
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [["vt", "run", "-r", "check-tty-cached"]]
 
 # ─── stdout/stderr: cache on, hit → replayed ────────────────────
 
 [[e2e]]
 name = "single_task__cache_hit__replayed"
+comment = """
+Tests stdio behavior in interleaved mode (default --log mode).
+
+In interleaved mode:
+- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
+- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
+
+This applies identically regardless of task count.
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [["vt", "run", "check-tty-cached"], ["vt", "run", "check-tty-cached"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_hit__replayed"
+comment = """
+Tests stdio behavior in interleaved mode (default --log mode).
+
+In interleaved mode:
+- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
+- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
+
+This applies identically regardless of task count.
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [["vt", "run", "-r", "check-tty-cached"], ["vt", "run", "-r", "check-tty-cached"]]
 
 # ─── stdin: cache off → inherited ───────────────────────────────
 
 [[e2e]]
 name = "cache_off_inherits_stdin"
+comment = """
+Tests stdio behavior in interleaved mode (default --log mode).
+
+In interleaved mode:
+- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
+- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
+
+This applies identically regardless of task count.
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [["vtt", "pipe-stdin", "from-stdin", "--", "vt", "run", "read-stdin"]]
 
 # ─── stdin: cache on → null ─────────────────────────────────────
 
 [[e2e]]
 name = "cache_on_gets_null_stdin"
+comment = """
+Tests stdio behavior in interleaved mode (default --log mode).
+
+In interleaved mode:
+- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
+- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
+
+This applies identically regardless of task count.
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [["vtt", "pipe-stdin", "from-stdin", "--", "vt", "run", "read-stdin-cached"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots.toml
@@ -1,137 +1,63 @@
-# ─── stdout/stderr: cache off → inherited (tty) ─────────────────
-
 [[e2e]]
 name = "single_task__cache_off__inherits_stdio"
 comment = """
-Tests stdio behavior in interleaved mode (default --log mode).
-
-In interleaved mode:
-- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
-- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
-
-This applies identically regardless of task count.
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+In interleaved mode with caching off, a single task should inherit stdio from
+the parent — all fds should be TTYs.
 """
 steps = [["vt", "run", "check-tty"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_off__inherit_stdio"
 comment = """
-Tests stdio behavior in interleaved mode (default --log mode).
-
-In interleaved mode:
-- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
-- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
-
-This applies identically regardless of task count.
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+In interleaved mode with caching off, multiple tasks under `-r` should each
+inherit stdio (TTY-preserving behavior applies per task regardless of count).
 """
 steps = [["vt", "run", "-r", "check-tty"]]
-
-# ─── stdout/stderr: cache on, miss → piped (not-tty) ────────────
 
 [[e2e]]
 name = "single_task__cache_miss__piped_stdio"
 comment = """
-Tests stdio behavior in interleaved mode (default --log mode).
-
-In interleaved mode:
-- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
-- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
-
-This applies identically regardless of task count.
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+On a cache miss in interleaved mode, stdio must be piped (not a TTY) so that
+output can be captured for future replay.
 """
 steps = [["vt", "run", "check-tty-cached"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_miss__piped_stdio"
 comment = """
-Tests stdio behavior in interleaved mode (default --log mode).
-
-In interleaved mode:
-- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
-- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
-
-This applies identically regardless of task count.
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+Across multiple tasks on a cache miss, each one should still see piped
+(non-TTY) stdio for output capture.
 """
 steps = [["vt", "run", "-r", "check-tty-cached"]]
-
-# ─── stdout/stderr: cache on, hit → replayed ────────────────────
 
 [[e2e]]
 name = "single_task__cache_hit__replayed"
 comment = """
-Tests stdio behavior in interleaved mode (default --log mode).
-
-In interleaved mode:
-- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
-- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
-
-This applies identically regardless of task count.
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+A cache-hit second run should replay the previously captured output verbatim
+instead of re-executing the task.
 """
 steps = [["vt", "run", "check-tty-cached"], ["vt", "run", "check-tty-cached"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_hit__replayed"
 comment = """
-Tests stdio behavior in interleaved mode (default --log mode).
-
-In interleaved mode:
-- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
-- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
-
-This applies identically regardless of task count.
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+Across multiple tasks, the second run should be all cache hits with each
+task's captured output replayed.
 """
 steps = [["vt", "run", "-r", "check-tty-cached"], ["vt", "run", "-r", "check-tty-cached"]]
-
-# ─── stdin: cache off → inherited ───────────────────────────────
 
 [[e2e]]
 name = "cache_off_inherits_stdin"
 comment = """
-Tests stdio behavior in interleaved mode (default --log mode).
-
-In interleaved mode:
-- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
-- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
-
-This applies identically regardless of task count.
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+With caching off, stdin piped into `vp run` should flow through to the task
+process.
 """
 steps = [["vtt", "pipe-stdin", "from-stdin", "--", "vt", "run", "read-stdin"]]
-
-# ─── stdin: cache on → null ─────────────────────────────────────
 
 [[e2e]]
 name = "cache_on_gets_null_stdin"
 comment = """
-Tests stdio behavior in interleaved mode (default --log mode).
-
-In interleaved mode:
-- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
-- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
-
-This applies identically regardless of task count.
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+With caching on, task stdin should be replaced with `/dev/null` — piping data
+in from outside must not reach the task.
 """
 steps = [["vtt", "pipe-stdin", "from-stdin", "--", "vt", "run", "read-stdin-cached"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/cache_off_inherits_stdin.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/cache_off_inherits_stdin.md
@@ -1,15 +1,7 @@
 # cache_off_inherits_stdin
 
-Tests stdio behavior in interleaved mode (default --log mode).
-
-In interleaved mode:
-- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
-- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
-
-This applies identically regardless of task count.
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+With caching off, stdin piped into `vp run` should flow through to the task
+process.
 
 ## `vtt pipe-stdin from-stdin -- vt run read-stdin`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/cache_on_gets_null_stdin.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/cache_on_gets_null_stdin.md
@@ -1,15 +1,7 @@
 # cache_on_gets_null_stdin
 
-Tests stdio behavior in interleaved mode (default --log mode).
-
-In interleaved mode:
-- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
-- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
-
-This applies identically regardless of task count.
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+With caching on, task stdin should be replaced with `/dev/null` — piping data
+in from outside must not reach the task.
 
 ## `vtt pipe-stdin from-stdin -- vt run read-stdin-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/multiple_tasks__cache_hit__replayed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/multiple_tasks__cache_hit__replayed.md
@@ -1,15 +1,7 @@
 # multiple_tasks__cache_hit__replayed
 
-Tests stdio behavior in interleaved mode (default --log mode).
-
-In interleaved mode:
-- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
-- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
-
-This applies identically regardless of task count.
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+Across multiple tasks, the second run should be all cache hits with each
+task's captured output replayed.
 
 ## `vt run -r check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/multiple_tasks__cache_miss__piped_stdio.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/multiple_tasks__cache_miss__piped_stdio.md
@@ -1,15 +1,7 @@
 # multiple_tasks__cache_miss__piped_stdio
 
-Tests stdio behavior in interleaved mode (default --log mode).
-
-In interleaved mode:
-- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
-- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
-
-This applies identically regardless of task count.
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+Across multiple tasks on a cache miss, each one should still see piped
+(non-TTY) stdio for output capture.
 
 ## `vt run -r check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/multiple_tasks__cache_off__inherit_stdio.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/multiple_tasks__cache_off__inherit_stdio.md
@@ -1,15 +1,7 @@
 # multiple_tasks__cache_off__inherit_stdio
 
-Tests stdio behavior in interleaved mode (default --log mode).
-
-In interleaved mode:
-- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
-- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
-
-This applies identically regardless of task count.
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+In interleaved mode with caching off, multiple tasks under `-r` should each
+inherit stdio (TTY-preserving behavior applies per task regardless of count).
 
 ## `vt run -r check-tty`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/single_task__cache_hit__replayed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/single_task__cache_hit__replayed.md
@@ -1,15 +1,7 @@
 # single_task__cache_hit__replayed
 
-Tests stdio behavior in interleaved mode (default --log mode).
-
-In interleaved mode:
-- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
-- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
-
-This applies identically regardless of task count.
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+A cache-hit second run should replay the previously captured output verbatim
+instead of re-executing the task.
 
 ## `vt run check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/single_task__cache_miss__piped_stdio.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/single_task__cache_miss__piped_stdio.md
@@ -1,15 +1,7 @@
 # single_task__cache_miss__piped_stdio
 
-Tests stdio behavior in interleaved mode (default --log mode).
-
-In interleaved mode:
-- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
-- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
-
-This applies identically regardless of task count.
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+On a cache miss in interleaved mode, stdio must be piped (not a TTY) so that
+output can be captured for future replay.
 
 ## `vt run check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/single_task__cache_off__inherits_stdio.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/single_task__cache_off__inherits_stdio.md
@@ -1,15 +1,7 @@
 # single_task__cache_off__inherits_stdio
 
-Tests stdio behavior in interleaved mode (default --log mode).
-
-In interleaved mode:
-- cache off  → all stdio inherited (stdin from parent, stdout/stderr to terminal)
-- cache on   → stdin is /dev/null, stdout/stderr are piped (for capture/replay)
-
-This applies identically regardless of task count.
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+In interleaved mode with caching off, a single task should inherit stdio from
+the parent — all fds should be TTYs.
 
 ## `vt run check-tty`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots.toml
@@ -1,74 +1,40 @@
-# ─── stdout/stderr: always piped (not-tty) ────────────────────
-
 [[e2e]]
 name = "single_task__cache_off__piped_stdio"
 comment = """
-Tests stdio behavior in labeled mode (--log=labeled).
-
-In labeled mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+Under `--log=labeled` with caching off, a single task's stdio should be piped
+through the line-prefixing writer (not a TTY).
 """
 steps = [["vt", "run", "--log=labeled", "check-tty"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_off__piped_stdio"
 comment = """
-Tests stdio behavior in labeled mode (--log=labeled).
-
-In labeled mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+Under `--log=labeled` with caching off, multiple tasks should each get piped
+stdio and each line should be prefixed with `[pkg#task]`.
 """
 steps = [["vt", "run", "--log=labeled", "-r", "check-tty"]]
 
 [[e2e]]
 name = "single_task__cache_miss__piped_stdio"
 comment = """
-Tests stdio behavior in labeled mode (--log=labeled).
-
-In labeled mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+On a cache miss for a single task, labeled mode should still pipe stdio and
+prefix output lines.
 """
 steps = [["vt", "run", "--log=labeled", "check-tty-cached"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_miss__piped_stdio"
 comment = """
-Tests stdio behavior in labeled mode (--log=labeled).
-
-In labeled mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+On a cache miss across multiple tasks, each task's piped output should be
+individually prefixed in labeled mode.
 """
 steps = [["vt", "run", "--log=labeled", "-r", "check-tty-cached"]]
-
-# ─── cache hit → replayed with labels ─────────────────────────
 
 [[e2e]]
 name = "single_task__cache_hit__replayed"
 comment = """
-Tests stdio behavior in labeled mode (--log=labeled).
-
-In labeled mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+A cache-hit replay of a single task under labeled mode should reproduce the
+labeled output from cached data.
 """
 steps = [
   [
@@ -88,14 +54,8 @@ steps = [
 [[e2e]]
 name = "multiple_tasks__cache_hit__replayed"
 comment = """
-Tests stdio behavior in labeled mode (--log=labeled).
-
-In labeled mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+A cache-hit replay across multiple tasks under labeled mode should reproduce
+each task's labeled output.
 """
 steps = [
   [
@@ -114,18 +74,10 @@ steps = [
   ],
 ]
 
-# ─── stdin: always null ───────────────────────────────────────
-
 [[e2e]]
 name = "stdin_is_always_null"
 comment = """
-Tests stdio behavior in labeled mode (--log=labeled).
-
-In labeled mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+In labeled mode, task stdin is always `/dev/null` regardless of the parent's
+stdin — piping data in from outside must not reach the task.
 """
 steps = [["vtt", "pipe-stdin", "from-stdin", "--", "vt", "run", "--log=labeled", "read-stdin"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots.toml
@@ -1,3 +1,7 @@
+# ─── stdout/stderr: always piped (not-tty) ────────────────────
+
+[[e2e]]
+name = "single_task__cache_off__piped_stdio"
 comment = """
 Tests stdio behavior in labeled mode (--log=labeled).
 
@@ -8,29 +12,64 @@ In labeled mode, stdio is always piped regardless of cache state:
 `check-tty` prints whether each stdio fd is a TTY.
 `read-stdin` reads one line from stdin and prints it.
 """
-
-# ─── stdout/stderr: always piped (not-tty) ────────────────────
-
-[[e2e]]
-name = "single_task__cache_off__piped_stdio"
 steps = [["vt", "run", "--log=labeled", "check-tty"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_off__piped_stdio"
+comment = """
+Tests stdio behavior in labeled mode (--log=labeled).
+
+In labeled mode, stdio is always piped regardless of cache state:
+- stdin is /dev/null
+- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [["vt", "run", "--log=labeled", "-r", "check-tty"]]
 
 [[e2e]]
 name = "single_task__cache_miss__piped_stdio"
+comment = """
+Tests stdio behavior in labeled mode (--log=labeled).
+
+In labeled mode, stdio is always piped regardless of cache state:
+- stdin is /dev/null
+- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [["vt", "run", "--log=labeled", "check-tty-cached"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_miss__piped_stdio"
+comment = """
+Tests stdio behavior in labeled mode (--log=labeled).
+
+In labeled mode, stdio is always piped regardless of cache state:
+- stdin is /dev/null
+- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [["vt", "run", "--log=labeled", "-r", "check-tty-cached"]]
 
 # ─── cache hit → replayed with labels ─────────────────────────
 
 [[e2e]]
 name = "single_task__cache_hit__replayed"
+comment = """
+Tests stdio behavior in labeled mode (--log=labeled).
+
+In labeled mode, stdio is always piped regardless of cache state:
+- stdin is /dev/null
+- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [
   [
     "vt",
@@ -48,6 +87,16 @@ steps = [
 
 [[e2e]]
 name = "multiple_tasks__cache_hit__replayed"
+comment = """
+Tests stdio behavior in labeled mode (--log=labeled).
+
+In labeled mode, stdio is always piped regardless of cache state:
+- stdin is /dev/null
+- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [
   [
     "vt",
@@ -69,4 +118,14 @@ steps = [
 
 [[e2e]]
 name = "stdin_is_always_null"
+comment = """
+Tests stdio behavior in labeled mode (--log=labeled).
+
+In labeled mode, stdio is always piped regardless of cache state:
+- stdin is /dev/null
+- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
+
+`check-tty` prints whether each stdio fd is a TTY.
+`read-stdin` reads one line from stdin and prints it.
+"""
 steps = [["vtt", "pipe-stdin", "from-stdin", "--", "vt", "run", "--log=labeled", "read-stdin"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/multiple_tasks__cache_hit__replayed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/multiple_tasks__cache_hit__replayed.md
@@ -1,13 +1,7 @@
 # multiple_tasks__cache_hit__replayed
 
-Tests stdio behavior in labeled mode (--log=labeled).
-
-In labeled mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+A cache-hit replay across multiple tasks under labeled mode should reproduce
+each task's labeled output.
 
 ## `vt run --log=labeled -r check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/multiple_tasks__cache_miss__piped_stdio.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/multiple_tasks__cache_miss__piped_stdio.md
@@ -1,13 +1,7 @@
 # multiple_tasks__cache_miss__piped_stdio
 
-Tests stdio behavior in labeled mode (--log=labeled).
-
-In labeled mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+On a cache miss across multiple tasks, each task's piped output should be
+individually prefixed in labeled mode.
 
 ## `vt run --log=labeled -r check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/multiple_tasks__cache_off__piped_stdio.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/multiple_tasks__cache_off__piped_stdio.md
@@ -1,13 +1,7 @@
 # multiple_tasks__cache_off__piped_stdio
 
-Tests stdio behavior in labeled mode (--log=labeled).
-
-In labeled mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+Under `--log=labeled` with caching off, multiple tasks should each get piped
+stdio and each line should be prefixed with `[pkg#task]`.
 
 ## `vt run --log=labeled -r check-tty`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/single_task__cache_hit__replayed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/single_task__cache_hit__replayed.md
@@ -1,13 +1,7 @@
 # single_task__cache_hit__replayed
 
-Tests stdio behavior in labeled mode (--log=labeled).
-
-In labeled mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+A cache-hit replay of a single task under labeled mode should reproduce the
+labeled output from cached data.
 
 ## `vt run --log=labeled check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/single_task__cache_miss__piped_stdio.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/single_task__cache_miss__piped_stdio.md
@@ -1,13 +1,7 @@
 # single_task__cache_miss__piped_stdio
 
-Tests stdio behavior in labeled mode (--log=labeled).
-
-In labeled mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+On a cache miss for a single task, labeled mode should still pipe stdio and
+prefix output lines.
 
 ## `vt run --log=labeled check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/single_task__cache_off__piped_stdio.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/single_task__cache_off__piped_stdio.md
@@ -1,13 +1,7 @@
 # single_task__cache_off__piped_stdio
 
-Tests stdio behavior in labeled mode (--log=labeled).
-
-In labeled mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+Under `--log=labeled` with caching off, a single task's stdio should be piped
+through the line-prefixing writer (not a TTY).
 
 ## `vt run --log=labeled check-tty`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/stdin_is_always_null.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/stdin_is_always_null.md
@@ -1,13 +1,7 @@
 # stdin_is_always_null
 
-Tests stdio behavior in labeled mode (--log=labeled).
-
-In labeled mode, stdio is always piped regardless of cache state:
-- stdin is /dev/null
-- stdout/stderr are piped through a line-prefixing writer ([pkg#task])
-
-`check-tty` prints whether each stdio fd is a TTY.
-`read-stdin` reads one line from stdin and prints it.
+In labeled mode, task stdin is always `/dev/null` regardless of the parent's
+stdin — piping data in from outside must not reach the task.
 
 ## `vtt pipe-stdin from-stdin -- vt run --log=labeled read-stdin`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/malformed_fspy_path/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/malformed_fspy_path/snapshots.toml
@@ -1,8 +1,7 @@
+[[e2e]]
+name = "malformed_observed_path_does_not_panic"
 comment = """
 Repro for issue 325: a malformed observed path must not panic when fspy
 input inference normalizes workspace-relative accesses.
 """
-
-[[e2e]]
-name = "malformed_observed_path_does_not_panic"
 steps = [{ argv = ["vt", "run", "read-malformed-path"], envs = [["TEMP", "."], ["TMP", "."]] }]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/parallel_execution/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/parallel_execution/snapshots.toml
@@ -1,10 +1,9 @@
+[[e2e]]
+name = "parallel_flag_runs_dependent_tasks_concurrently"
 comment = """
 Package b depends on a, so without --parallel they run sequentially.
 Both use a barrier requiring 2 participants — if run sequentially the
 first would wait forever and the test would timeout.
 --parallel discards dependency edges, allowing both to run at once.
 """
-
-[[e2e]]
-name = "parallel_flag_runs_dependent_tasks_concurrently"
 steps = [["vt", "run", "-r", "--parallel", "build"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/pass_args_to_task/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/pass_args_to_task/snapshots.toml
@@ -1,10 +1,9 @@
+[[e2e]]
+name = "pass_args_to_task"
 comment = """
 Tests that arguments after task name should be passed to the task
 https://github.com/voidzero-dev/vite-task/issues/285
 """
-
-[[e2e]]
-name = "pass_args_to_task"
 steps = [
   ["vt", "run", "echo", "--help"], # Should just print `help` instead of Vite task's help
   ["vt", "run", "echo", "--version"], # Should just print `version` instead of Vite task's version

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/shared_caching_input/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/shared_caching_input/snapshots.toml
@@ -1,9 +1,8 @@
+[[e2e]]
+name = "shared_caching_input"
 comment = """
 Tests that tasks with identical commands share cache entries
 """
-
-[[e2e]]
-name = "shared_caching_input"
 steps = [
   { argv = [
     "vt",

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/signal_exit/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/signal_exit/snapshots.toml
@@ -1,10 +1,9 @@
+[[e2e]]
+name = "signal_terminated_task_returns_non_zero_exit_code"
 comment = """
 Tests exit code behavior for signal-terminated processes
 Unix-only: Windows doesn't have Unix signals, so exit codes differ
 """
-
-[[e2e]]
-name = "signal_terminated_task_returns_non_zero_exit_code"
 platform = "unix"
 ignore = true
 steps = [{ argv = ["vt", "run", "abort"], comment = "SIGABRT -> exit code 134" }]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots.toml
@@ -1,17 +1,17 @@
-# Single task, cache miss → no summary at all
 [[e2e]]
 name = "single_task_cache_miss_shows_no_summary"
 comment = """
-Tests for compact and verbose summary output
+A single task on its first run (cache miss) should produce no summary line
+at all — only the task's own output.
 """
 cwd = "packages/a"
 steps = [["vt", "run", "build"]]
 
-# Single task, cache hit → compact one-liner
 [[e2e]]
 name = "single_task_cache_hit_shows_compact_summary"
 comment = """
-Tests for compact and verbose summary output
+When a single task hits the cache on a re-run, the compact one-line summary
+should be emitted.
 """
 cwd = "packages/a"
 steps = [
@@ -27,19 +27,19 @@ steps = [
   ], comment = "second run, cache hit → compact summary" },
 ]
 
-# Multi-task (recursive), all cache miss → compact summary with 0 hits
 [[e2e]]
 name = "multi_task_all_cache_miss_shows_compact_summary"
 comment = """
-Tests for compact and verbose summary output
+A multi-task (`-r`) run where every task misses should still print a compact
+summary with 0 hits.
 """
 steps = [["vt", "run", "-r", "build"]]
 
-# Multi-task (recursive), some cache hits → compact summary with hit count
 [[e2e]]
 name = "multi_task_with_cache_hits_shows_compact_summary"
 comment = """
-Tests for compact and verbose summary output
+On the second multi-task (`-r`) run, the compact summary should report the
+correct hit count.
 """
 steps = [
   { argv = [
@@ -56,28 +56,27 @@ steps = [
   ], comment = "second run, all hit" },
 ]
 
-# Single task with --verbose → full detailed summary
 [[e2e]]
 name = "single_task_verbose_shows_full_summary"
 comment = """
-Tests for compact and verbose summary output
+`vt run -v` on a single task should emit the full detailed summary, even on
+a first-run cache miss.
 """
 cwd = "packages/a"
 steps = [["vt", "run", "-v", "build"]]
 
-# Multi-task with --verbose → full detailed summary
 [[e2e]]
 name = "multi_task_verbose_shows_full_summary"
 comment = """
-Tests for compact and verbose summary output
+`vt run -r -v` should emit the full detailed summary across all tasks.
 """
 steps = [["vt", "run", "-r", "-v", "build"]]
 
-# Multi-task with --verbose after cache hits
 [[e2e]]
 name = "multi_task_verbose_with_cache_hits_shows_full_summary"
 comment = """
-Tests for compact and verbose summary output
+With `-v` on a multi-task re-run, the full summary should report per-task
+cache hits (not just overall stats).
 """
 steps = [
   { argv = [
@@ -95,19 +94,19 @@ steps = [
   ], comment = "second run, verbose with cache hits" },
 ]
 
-# --last-details with no previous run
 [[e2e]]
 name = "last_details_with_no_previous_run_shows_error"
 comment = """
-Tests for compact and verbose summary output
+`vt run --last-details` with no prior run in the workspace should produce a
+clear error rather than empty output.
 """
 steps = [["vt", "run", "--last-details"]]
 
-# --last-details after a run shows saved summary
 [[e2e]]
 name = "last_details_after_run_shows_saved_summary"
 comment = """
-Tests for compact and verbose summary output
+After a single-task run, `vt run --last-details` should display the saved
+summary from disk.
 """
 cwd = "packages/a"
 steps = [
@@ -123,11 +122,11 @@ steps = [
   ], comment = "display saved summary" },
 ]
 
-# --last-details after a multi-task run
 [[e2e]]
 name = "last_details_after_multi_task_run_shows_saved_summary"
 comment = """
-Tests for compact and verbose summary output
+After a multi-task (`-r`) run, `vt run --last-details` should display the
+saved summary covering every task.
 """
 steps = [
   { argv = [

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots.toml
@@ -1,16 +1,18 @@
-comment = """
-Tests for compact and verbose summary output
-"""
-
 # Single task, cache miss → no summary at all
 [[e2e]]
 name = "single_task_cache_miss_shows_no_summary"
+comment = """
+Tests for compact and verbose summary output
+"""
 cwd = "packages/a"
 steps = [["vt", "run", "build"]]
 
 # Single task, cache hit → compact one-liner
 [[e2e]]
 name = "single_task_cache_hit_shows_compact_summary"
+comment = """
+Tests for compact and verbose summary output
+"""
 cwd = "packages/a"
 steps = [
   { argv = [
@@ -28,11 +30,17 @@ steps = [
 # Multi-task (recursive), all cache miss → compact summary with 0 hits
 [[e2e]]
 name = "multi_task_all_cache_miss_shows_compact_summary"
+comment = """
+Tests for compact and verbose summary output
+"""
 steps = [["vt", "run", "-r", "build"]]
 
 # Multi-task (recursive), some cache hits → compact summary with hit count
 [[e2e]]
 name = "multi_task_with_cache_hits_shows_compact_summary"
+comment = """
+Tests for compact and verbose summary output
+"""
 steps = [
   { argv = [
     "vt",
@@ -51,17 +59,26 @@ steps = [
 # Single task with --verbose → full detailed summary
 [[e2e]]
 name = "single_task_verbose_shows_full_summary"
+comment = """
+Tests for compact and verbose summary output
+"""
 cwd = "packages/a"
 steps = [["vt", "run", "-v", "build"]]
 
 # Multi-task with --verbose → full detailed summary
 [[e2e]]
 name = "multi_task_verbose_shows_full_summary"
+comment = """
+Tests for compact and verbose summary output
+"""
 steps = [["vt", "run", "-r", "-v", "build"]]
 
 # Multi-task with --verbose after cache hits
 [[e2e]]
 name = "multi_task_verbose_with_cache_hits_shows_full_summary"
+comment = """
+Tests for compact and verbose summary output
+"""
 steps = [
   { argv = [
     "vt",
@@ -81,11 +98,17 @@ steps = [
 # --last-details with no previous run
 [[e2e]]
 name = "last_details_with_no_previous_run_shows_error"
+comment = """
+Tests for compact and verbose summary output
+"""
 steps = [["vt", "run", "--last-details"]]
 
 # --last-details after a run shows saved summary
 [[e2e]]
 name = "last_details_after_run_shows_saved_summary"
+comment = """
+Tests for compact and verbose summary output
+"""
 cwd = "packages/a"
 steps = [
   { argv = [
@@ -103,6 +126,9 @@ steps = [
 # --last-details after a multi-task run
 [[e2e]]
 name = "last_details_after_multi_task_run_shows_saved_summary"
+comment = """
+Tests for compact and verbose summary output
+"""
 steps = [
   { argv = [
     "vt",

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/last_details_after_multi_task_run_shows_saved_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/last_details_after_multi_task_run_shows_saved_summary.md
@@ -1,6 +1,7 @@
 # last_details_after_multi_task_run_shows_saved_summary
 
-Tests for compact and verbose summary output
+After a multi-task (`-r`) run, `vt run --last-details` should display the
+saved summary covering every task.
 
 ## `vt run -r build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/last_details_after_run_shows_saved_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/last_details_after_run_shows_saved_summary.md
@@ -1,6 +1,7 @@
 # last_details_after_run_shows_saved_summary
 
-Tests for compact and verbose summary output
+After a single-task run, `vt run --last-details` should display the saved
+summary from disk.
 
 ## `vt run build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/last_details_with_no_previous_run_shows_error.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/last_details_with_no_previous_run_shows_error.md
@@ -1,6 +1,7 @@
 # last_details_with_no_previous_run_shows_error
 
-Tests for compact and verbose summary output
+`vt run --last-details` with no prior run in the workspace should produce a
+clear error rather than empty output.
 
 ## `vt run --last-details`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/multi_task_all_cache_miss_shows_compact_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/multi_task_all_cache_miss_shows_compact_summary.md
@@ -1,6 +1,7 @@
 # multi_task_all_cache_miss_shows_compact_summary
 
-Tests for compact and verbose summary output
+A multi-task (`-r`) run where every task misses should still print a compact
+summary with 0 hits.
 
 ## `vt run -r build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/multi_task_verbose_shows_full_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/multi_task_verbose_shows_full_summary.md
@@ -1,6 +1,6 @@
 # multi_task_verbose_shows_full_summary
 
-Tests for compact and verbose summary output
+`vt run -r -v` should emit the full detailed summary across all tasks.
 
 ## `vt run -r -v build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/multi_task_verbose_with_cache_hits_shows_full_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/multi_task_verbose_with_cache_hits_shows_full_summary.md
@@ -1,6 +1,7 @@
 # multi_task_verbose_with_cache_hits_shows_full_summary
 
-Tests for compact and verbose summary output
+With `-v` on a multi-task re-run, the full summary should report per-task
+cache hits (not just overall stats).
 
 ## `vt run -r build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/multi_task_with_cache_hits_shows_compact_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/multi_task_with_cache_hits_shows_compact_summary.md
@@ -1,6 +1,7 @@
 # multi_task_with_cache_hits_shows_compact_summary
 
-Tests for compact and verbose summary output
+On the second multi-task (`-r`) run, the compact summary should report the
+correct hit count.
 
 ## `vt run -r build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/single_task_cache_hit_shows_compact_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/single_task_cache_hit_shows_compact_summary.md
@@ -1,6 +1,7 @@
 # single_task_cache_hit_shows_compact_summary
 
-Tests for compact and verbose summary output
+When a single task hits the cache on a re-run, the compact one-line summary
+should be emitted.
 
 ## `vt run build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/single_task_cache_miss_shows_no_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/single_task_cache_miss_shows_no_summary.md
@@ -1,6 +1,7 @@
 # single_task_cache_miss_shows_no_summary
 
-Tests for compact and verbose summary output
+A single task on its first run (cache miss) should produce no summary line
+at all — only the task's own output.
 
 ## `vt run build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/single_task_verbose_shows_full_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/single_task_verbose_shows_full_summary.md
@@ -1,6 +1,7 @@
 # single_task_verbose_shows_full_summary
 
-Tests for compact and verbose summary output
+`vt run -v` on a single task should emit the full detailed summary, even on
+a first-run cache miss.
 
 ## `vt run -v build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_no_trailing_newline/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_no_trailing_newline/snapshots.toml
@@ -1,7 +1,6 @@
+[[e2e]]
+name = "no_trailing_newline"
 comment = """
 Tests output handling when task has no trailing newline
 """
-
-[[e2e]]
-name = "no_trailing_newline"
 steps = [{ argv = ["vt", "run", "hello"], comment = "runs echo -n hello" }]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots.toml
@@ -1,39 +1,40 @@
 [[e2e]]
 name = "non_interactive_list_tasks"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+With piped stdin (non-interactive), `vt run` with no task argument should
+list all available tasks instead of launching the picker.
 """
 steps = [["vtt", "pipe-stdin", "--", "vt", "run"]]
 
-# Non-interactive: typo triggers "did you mean"
 [[e2e]]
 name = "non_interactive_did_you_mean"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+In non-interactive mode, a typo that has close fuzzy matches should produce
+"did you mean" suggestions.
 """
 steps = [["vtt", "pipe-stdin", "--", "vt", "run", "buid"]]
 
-# Non-interactive: typo with no fuzzy matches hides "did you mean"
 [[e2e]]
 name = "non_interactive_no_suggestions"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+In non-interactive mode, a typo with no close fuzzy matches should omit the
+"did you mean" block entirely.
 """
 steps = [["vtt", "pipe-stdin", "--", "vt", "run", "zzzzz"]]
 
-# Non-interactive: typo with -r flag errors (not cwd_only)
 [[e2e]]
 name = "non_interactive_recursive_typo_errors"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+A typoed task name combined with `-r` (not cwd-only) should error without
+listing tasks — the `-r` signal rules out the interactive selector fallback.
 """
 steps = [["vtt", "pipe-stdin", "--", "vt", "run", "-r", "buid"]]
 
-# Interactive: navigate down and select second task
 [[e2e]]
 name = "interactive_select_task"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+In interactive mode, navigating down one entry and pressing Enter should
+select the second task.
 """
 cwd = "packages/app"
 steps = [
@@ -48,11 +49,11 @@ steps = [
   ] },
 ]
 
-# Interactive: typo pre-filled in search
 [[e2e]]
 name = "interactive_select_with_typo"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+When a typoed task name launches the selector, the typo should be pre-filled
+as the initial search query.
 """
 cwd = "packages/app"
 steps = [
@@ -66,11 +67,11 @@ steps = [
   ] },
 ]
 
-# Interactive: type to search then select
 [[e2e]]
 name = "interactive_search_then_select"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+Typing characters in the selector should filter the list in real time, then
+Enter should pick the highlighted result.
 """
 cwd = "packages/app"
 steps = [
@@ -85,11 +86,11 @@ steps = [
   ] },
 ]
 
-# Interactive: escape clears query and resets filter
 [[e2e]]
 name = "interactive_escape_clears_query"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+Escape in the selector should clear the current query and restore the
+unfiltered list at cursor position 0.
 """
 cwd = "packages/app"
 steps = [
@@ -106,29 +107,29 @@ steps = [
   ] },
 ]
 
-# -r flag without task errors (not bare)
 [[e2e]]
 name = "recursive_without_task_errors"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+`vt run -r` with no task argument is not treated as a bare run — it should
+error instead of opening the selector.
 """
 cwd = "packages/app"
 steps = [["vt", "run", "-r"]]
 
-# -t flag + typo errors (not cwd_only)
 [[e2e]]
 name = "transitive_typo_errors"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+`vt run -t <typo>` is not cwd-only, so a typo should error rather than fall
+back to the interactive selector.
 """
 cwd = "packages/app"
 steps = [["vt", "run", "-t", "buid"]]
 
-# Interactive: scroll down past visible page, then select a task beyond the initial viewport
 [[e2e]]
 name = "interactive_scroll_long_list"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+With a list taller than the 8-row page, navigating past the viewport should
+scroll down, and navigating back should scroll the view up to index 0.
 """
 cwd = "packages/app"
 steps = [
@@ -159,20 +160,20 @@ steps = [
   ] },
 ]
 
-# Non-interactive: list tasks from lib package (lib tasks first, unqualified)
 [[e2e]]
 name = "non_interactive_list_tasks_from_lib"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+When listing from a subpackage's cwd, that package's tasks should appear
+first and be listed unqualified.
 """
 cwd = "packages/lib"
 steps = [["vtt", "pipe-stdin", "--", "vt", "run"]]
 
-# Interactive: select from lib package (first item is lib's task)
 [[e2e]]
 name = "interactive_select_task_from_lib"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+In the interactive selector launched from `packages/lib`, the first entry
+should be a lib-owned task.
 """
 cwd = "packages/lib"
 steps = [
@@ -185,11 +186,11 @@ steps = [
   ] },
 ]
 
-# Interactive: search for a task that only exists in another package
 [[e2e]]
 name = "interactive_search_other_package_task"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+A search query can match a task that lives only in another package; that
+task should become selectable.
 """
 cwd = "packages/app"
 steps = [
@@ -204,11 +205,11 @@ steps = [
   ] },
 ]
 
-# Interactive: '#' in query skips current-package reordering
 [[e2e]]
 name = "interactive_search_with_hash_skips_reorder"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+Including `#` in the query means "target a specific package#task" and should
+disable the current-package reordering in the filtered list.
 """
 cwd = "packages/app"
 steps = [
@@ -223,11 +224,11 @@ steps = [
   ] },
 ]
 
-# Interactive: multiple current-package matches preserve fuzzy rating order
 [[e2e]]
 name = "interactive_search_preserves_rating_within_package"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+When multiple current-package tasks match, the fuzzy-rating order between
+them should be preserved (not broken by current-package grouping).
 """
 cwd = "packages/lib"
 steps = [
@@ -242,11 +243,11 @@ steps = [
   ] },
 ]
 
-# Interactive: Enter with no matching results does nothing
 [[e2e]]
 name = "interactive_enter_with_no_results_does_nothing"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+Pressing Enter while the filtered list is empty should be a no-op — the
+selector should remain open and accept new input.
 """
 cwd = "packages/app"
 steps = [
@@ -264,11 +265,11 @@ steps = [
   ] },
 ]
 
-# Interactive: navigate into a package group, select a non-current-package task
 [[e2e]]
 name = "interactive_select_from_other_package"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+Navigating past the current-package group should expose tasks in other
+packages, which must also be selectable.
 """
 cwd = "packages/app"
 steps = [
@@ -285,19 +286,19 @@ steps = [
   ] },
 ]
 
-# Typo inside a task script should fail with an error, NOT show a list
 [[e2e]]
 name = "typo_in_task_script_fails_without_list"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+A typo inside a task's own script (i.e. a nested `vp run` command) should
+surface the real failure, not launch the task picker.
 """
 steps = [["vt", "run", "run-typo-task"]]
 
-# Interactive: Ctrl+C cancels selection and exits with code 130
 [[e2e]]
 name = "interactive_ctrl_c_cancels"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+Ctrl+C inside the interactive selector should cancel and exit 130 without
+running any task.
 """
 cwd = "packages/app"
 steps = [
@@ -310,20 +311,20 @@ steps = [
   ] },
 ]
 
-# --verbose without task: not bare, errors with "no task specifier provided"
 [[e2e]]
 name = "verbose_without_task_errors"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+`vt run --verbose` with no task argument is not bare, so it should error
+with "no task specifier provided" rather than opening the selector.
 """
 cwd = "packages/app"
 steps = [["vt", "run", "--verbose"]]
 
-# --verbose with typo: is_cwd_only is true, shows interactive selector
 [[e2e]]
 name = "verbose_with_typo_enters_selector"
 comment = """
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+`vt run --verbose <typo>` still qualifies as cwd-only, so it should fall
+back to the interactive selector pre-filled with the typo.
 """
 cwd = "packages/app"
 steps = [

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots.toml
@@ -1,29 +1,40 @@
+[[e2e]]
+name = "non_interactive_list_tasks"
 comment = """
 Non-interactive: list all tasks (piped stdin forces non-interactive mode)
 """
-
-[[e2e]]
-name = "non_interactive_list_tasks"
 steps = [["vtt", "pipe-stdin", "--", "vt", "run"]]
 
 # Non-interactive: typo triggers "did you mean"
 [[e2e]]
 name = "non_interactive_did_you_mean"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 steps = [["vtt", "pipe-stdin", "--", "vt", "run", "buid"]]
 
 # Non-interactive: typo with no fuzzy matches hides "did you mean"
 [[e2e]]
 name = "non_interactive_no_suggestions"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 steps = [["vtt", "pipe-stdin", "--", "vt", "run", "zzzzz"]]
 
 # Non-interactive: typo with -r flag errors (not cwd_only)
 [[e2e]]
 name = "non_interactive_recursive_typo_errors"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 steps = [["vtt", "pipe-stdin", "--", "vt", "run", "-r", "buid"]]
 
 # Interactive: navigate down and select second task
 [[e2e]]
 name = "interactive_select_task"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 cwd = "packages/app"
 steps = [
   { argv = [
@@ -40,6 +51,9 @@ steps = [
 # Interactive: typo pre-filled in search
 [[e2e]]
 name = "interactive_select_with_typo"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 cwd = "packages/app"
 steps = [
   { argv = [
@@ -55,6 +69,9 @@ steps = [
 # Interactive: type to search then select
 [[e2e]]
 name = "interactive_search_then_select"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 cwd = "packages/app"
 steps = [
   { argv = [
@@ -71,6 +88,9 @@ steps = [
 # Interactive: escape clears query and resets filter
 [[e2e]]
 name = "interactive_escape_clears_query"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 cwd = "packages/app"
 steps = [
   { argv = [
@@ -89,18 +109,27 @@ steps = [
 # -r flag without task errors (not bare)
 [[e2e]]
 name = "recursive_without_task_errors"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 cwd = "packages/app"
 steps = [["vt", "run", "-r"]]
 
 # -t flag + typo errors (not cwd_only)
 [[e2e]]
 name = "transitive_typo_errors"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 cwd = "packages/app"
 steps = [["vt", "run", "-t", "buid"]]
 
 # Interactive: scroll down past visible page, then select a task beyond the initial viewport
 [[e2e]]
 name = "interactive_scroll_long_list"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 cwd = "packages/app"
 steps = [
   { argv = [
@@ -133,12 +162,18 @@ steps = [
 # Non-interactive: list tasks from lib package (lib tasks first, unqualified)
 [[e2e]]
 name = "non_interactive_list_tasks_from_lib"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 cwd = "packages/lib"
 steps = [["vtt", "pipe-stdin", "--", "vt", "run"]]
 
 # Interactive: select from lib package (first item is lib's task)
 [[e2e]]
 name = "interactive_select_task_from_lib"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 cwd = "packages/lib"
 steps = [
   { argv = [
@@ -153,6 +188,9 @@ steps = [
 # Interactive: search for a task that only exists in another package
 [[e2e]]
 name = "interactive_search_other_package_task"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 cwd = "packages/app"
 steps = [
   { argv = [
@@ -169,6 +207,9 @@ steps = [
 # Interactive: '#' in query skips current-package reordering
 [[e2e]]
 name = "interactive_search_with_hash_skips_reorder"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 cwd = "packages/app"
 steps = [
   { argv = [
@@ -185,6 +226,9 @@ steps = [
 # Interactive: multiple current-package matches preserve fuzzy rating order
 [[e2e]]
 name = "interactive_search_preserves_rating_within_package"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 cwd = "packages/lib"
 steps = [
   { argv = [
@@ -201,6 +245,9 @@ steps = [
 # Interactive: Enter with no matching results does nothing
 [[e2e]]
 name = "interactive_enter_with_no_results_does_nothing"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 cwd = "packages/app"
 steps = [
   { argv = [
@@ -220,6 +267,9 @@ steps = [
 # Interactive: navigate into a package group, select a non-current-package task
 [[e2e]]
 name = "interactive_select_from_other_package"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 cwd = "packages/app"
 steps = [
   { argv = [
@@ -238,11 +288,17 @@ steps = [
 # Typo inside a task script should fail with an error, NOT show a list
 [[e2e]]
 name = "typo_in_task_script_fails_without_list"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 steps = [["vt", "run", "run-typo-task"]]
 
 # Interactive: Ctrl+C cancels selection and exits with code 130
 [[e2e]]
 name = "interactive_ctrl_c_cancels"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 cwd = "packages/app"
 steps = [
   { argv = [
@@ -257,12 +313,18 @@ steps = [
 # --verbose without task: not bare, errors with "no task specifier provided"
 [[e2e]]
 name = "verbose_without_task_errors"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 cwd = "packages/app"
 steps = [["vt", "run", "--verbose"]]
 
 # --verbose with typo: is_cwd_only is true, shows interactive selector
 [[e2e]]
 name = "verbose_with_typo_enters_selector"
+comment = """
+Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+"""
 cwd = "packages/app"
 steps = [
   { argv = [

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_ctrl_c_cancels.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_ctrl_c_cancels.md
@@ -1,6 +1,7 @@
 # interactive_ctrl_c_cancels
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+Ctrl+C inside the interactive selector should cancel and exit 130 without
+running any task.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_enter_with_no_results_does_nothing.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_enter_with_no_results_does_nothing.md
@@ -1,6 +1,7 @@
 # interactive_enter_with_no_results_does_nothing
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+Pressing Enter while the filtered list is empty should be a no-op — the
+selector should remain open and accept new input.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_escape_clears_query.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_escape_clears_query.md
@@ -1,6 +1,7 @@
 # interactive_escape_clears_query
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+Escape in the selector should clear the current query and restore the
+unfiltered list at cursor position 0.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_scroll_long_list.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_scroll_long_list.md
@@ -1,6 +1,7 @@
 # interactive_scroll_long_list
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+With a list taller than the 8-row page, navigating past the viewport should
+scroll down, and navigating back should scroll the view up to index 0.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_search_other_package_task.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_search_other_package_task.md
@@ -1,6 +1,7 @@
 # interactive_search_other_package_task
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+A search query can match a task that lives only in another package; that
+task should become selectable.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_search_preserves_rating_within_package.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_search_preserves_rating_within_package.md
@@ -1,6 +1,7 @@
 # interactive_search_preserves_rating_within_package
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+When multiple current-package tasks match, the fuzzy-rating order between
+them should be preserved (not broken by current-package grouping).
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_search_then_select.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_search_then_select.md
@@ -1,6 +1,7 @@
 # interactive_search_then_select
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+Typing characters in the selector should filter the list in real time, then
+Enter should pick the highlighted result.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_search_with_hash_skips_reorder.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_search_with_hash_skips_reorder.md
@@ -1,6 +1,7 @@
 # interactive_search_with_hash_skips_reorder
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+Including `#` in the query means "target a specific package#task" and should
+disable the current-package reordering in the filtered list.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_select_from_other_package.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_select_from_other_package.md
@@ -1,6 +1,7 @@
 # interactive_select_from_other_package
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+Navigating past the current-package group should expose tasks in other
+packages, which must also be selectable.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_select_task.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_select_task.md
@@ -1,6 +1,7 @@
 # interactive_select_task
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+In interactive mode, navigating down one entry and pressing Enter should
+select the second task.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_select_task_from_lib.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_select_task_from_lib.md
@@ -1,6 +1,7 @@
 # interactive_select_task_from_lib
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+In the interactive selector launched from `packages/lib`, the first entry
+should be a lib-owned task.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_select_with_typo.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_select_with_typo.md
@@ -1,6 +1,7 @@
 # interactive_select_with_typo
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+When a typoed task name launches the selector, the typo should be pre-filled
+as the initial search query.
 
 ## `vt run buid`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_did_you_mean.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_did_you_mean.md
@@ -1,6 +1,7 @@
 # non_interactive_did_you_mean
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+In non-interactive mode, a typo that has close fuzzy matches should produce
+"did you mean" suggestions.
 
 ## `vtt pipe-stdin -- vt run buid`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_list_tasks.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_list_tasks.md
@@ -1,6 +1,7 @@
 # non_interactive_list_tasks
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+With piped stdin (non-interactive), `vt run` with no task argument should
+list all available tasks instead of launching the picker.
 
 ## `vtt pipe-stdin -- vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_list_tasks_from_lib.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_list_tasks_from_lib.md
@@ -1,6 +1,7 @@
 # non_interactive_list_tasks_from_lib
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+When listing from a subpackage's cwd, that package's tasks should appear
+first and be listed unqualified.
 
 ## `vtt pipe-stdin -- vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_no_suggestions.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_no_suggestions.md
@@ -1,6 +1,7 @@
 # non_interactive_no_suggestions
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+In non-interactive mode, a typo with no close fuzzy matches should omit the
+"did you mean" block entirely.
 
 ## `vtt pipe-stdin -- vt run zzzzz`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_recursive_typo_errors.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_recursive_typo_errors.md
@@ -1,6 +1,7 @@
 # non_interactive_recursive_typo_errors
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+A typoed task name combined with `-r` (not cwd-only) should error without
+listing tasks — the `-r` signal rules out the interactive selector fallback.
 
 ## `vtt pipe-stdin -- vt run -r buid`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/recursive_without_task_errors.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/recursive_without_task_errors.md
@@ -1,6 +1,7 @@
 # recursive_without_task_errors
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+`vt run -r` with no task argument is not treated as a bare run — it should
+error instead of opening the selector.
 
 ## `vt run -r`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/transitive_typo_errors.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/transitive_typo_errors.md
@@ -1,6 +1,7 @@
 # transitive_typo_errors
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+`vt run -t <typo>` is not cwd-only, so a typo should error rather than fall
+back to the interactive selector.
 
 ## `vt run -t buid`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/typo_in_task_script_fails_without_list.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/typo_in_task_script_fails_without_list.md
@@ -1,6 +1,7 @@
 # typo_in_task_script_fails_without_list
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+A typo inside a task's own script (i.e. a nested `vp run` command) should
+surface the real failure, not launch the task picker.
 
 ## `vt run run-typo-task`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/verbose_with_typo_enters_selector.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/verbose_with_typo_enters_selector.md
@@ -1,6 +1,7 @@
 # verbose_with_typo_enters_selector
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+`vt run --verbose <typo>` still qualifies as cwd-only, so it should fall
+back to the interactive selector pre-filled with the typo.
 
 ## `vt run --verbose buid`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/verbose_without_task_errors.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/verbose_without_task_errors.md
@@ -1,6 +1,7 @@
 # verbose_without_task_errors
 
-Non-interactive: list all tasks (piped stdin forces non-interactive mode)
+`vt run --verbose` with no task argument is not bare, so it should error
+with "no task specifier provided" rather than opening the selector.
 
 ## `vt run --verbose`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select_truncate/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select_truncate/snapshots.toml
@@ -1,9 +1,8 @@
+[[e2e]]
+name = "interactive_long_command_truncated"
 comment = """
 Interactive: long commands are truncated to terminal width (no line wrapping)
 """
-
-[[e2e]]
-name = "interactive_long_command_truncated"
 cwd = "packages/app"
 steps = [
   { argv = [

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological_execution_order/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological_execution_order/snapshots.toml
@@ -1,16 +1,16 @@
 [[e2e]]
 name = "recursive_build_runs_dependencies_before_dependents"
 comment = """
-Tests that tasks execute in dependency (topological) order.
-Dependency chain: @topo/core <- @topo/lib <- @topo/app
+`vt run -r build` across the workspace should execute packages in
+topological order: `@topo/core` before `@topo/lib` before `@topo/app`.
 """
 steps = [{ argv = ["vt", "run", "-r", "build"], comment = "core -> lib -> app" }]
 
 [[e2e]]
 name = "transitive_build_from_app_runs_all_dependencies"
 comment = """
-Tests that tasks execute in dependency (topological) order.
-Dependency chain: @topo/core <- @topo/lib <- @topo/app
+`vt run -t build` from the leaf package should include the full transitive
+closure of its dependencies in topological order.
 """
 cwd = "packages/app"
 steps = [{ argv = ["vt", "run", "-t", "build"], comment = "core -> lib -> app" }]
@@ -18,8 +18,8 @@ steps = [{ argv = ["vt", "run", "-t", "build"], comment = "core -> lib -> app" }
 [[e2e]]
 name = "transitive_build_from_lib_runs_only_its_dependencies"
 comment = """
-Tests that tasks execute in dependency (topological) order.
-Dependency chain: @topo/core <- @topo/lib <- @topo/app
+`vt run -t build` from an intermediate package should limit the run to that
+package and its own dependencies — `@topo/app` must not run.
 """
 cwd = "packages/lib"
 steps = [{ argv = ["vt", "run", "-t", "build"], comment = "core -> lib" }]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological_execution_order/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological_execution_order/snapshots.toml
@@ -1,18 +1,25 @@
+[[e2e]]
+name = "recursive_build_runs_dependencies_before_dependents"
 comment = """
 Tests that tasks execute in dependency (topological) order.
 Dependency chain: @topo/core <- @topo/lib <- @topo/app
 """
-
-[[e2e]]
-name = "recursive_build_runs_dependencies_before_dependents"
 steps = [{ argv = ["vt", "run", "-r", "build"], comment = "core -> lib -> app" }]
 
 [[e2e]]
 name = "transitive_build_from_app_runs_all_dependencies"
+comment = """
+Tests that tasks execute in dependency (topological) order.
+Dependency chain: @topo/core <- @topo/lib <- @topo/app
+"""
 cwd = "packages/app"
 steps = [{ argv = ["vt", "run", "-t", "build"], comment = "core -> lib -> app" }]
 
 [[e2e]]
 name = "transitive_build_from_lib_runs_only_its_dependencies"
+comment = """
+Tests that tasks execute in dependency (topological) order.
+Dependency chain: @topo/core <- @topo/lib <- @topo/app
+"""
 cwd = "packages/lib"
 steps = [{ argv = ["vt", "run", "-t", "build"], comment = "core -> lib" }]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological_execution_order/snapshots/recursive_build_runs_dependencies_before_dependents.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological_execution_order/snapshots/recursive_build_runs_dependencies_before_dependents.md
@@ -1,7 +1,7 @@
 # recursive_build_runs_dependencies_before_dependents
 
-Tests that tasks execute in dependency (topological) order.
-Dependency chain: @topo/core <- @topo/lib <- @topo/app
+`vt run -r build` across the workspace should execute packages in
+topological order: `@topo/core` before `@topo/lib` before `@topo/app`.
 
 ## `vt run -r build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological_execution_order/snapshots/transitive_build_from_app_runs_all_dependencies.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological_execution_order/snapshots/transitive_build_from_app_runs_all_dependencies.md
@@ -1,7 +1,7 @@
 # transitive_build_from_app_runs_all_dependencies
 
-Tests that tasks execute in dependency (topological) order.
-Dependency chain: @topo/core <- @topo/lib <- @topo/app
+`vt run -t build` from the leaf package should include the full transitive
+closure of its dependencies in topological order.
 
 ## `vt run -t build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological_execution_order/snapshots/transitive_build_from_lib_runs_only_its_dependencies.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological_execution_order/snapshots/transitive_build_from_lib_runs_only_its_dependencies.md
@@ -1,7 +1,7 @@
 # transitive_build_from_lib_runs_only_its_dependencies
 
-Tests that tasks execute in dependency (topological) order.
-Dependency chain: @topo/core <- @topo/lib <- @topo/app
+`vt run -t build` from an intermediate package should limit the run to that
+package and its own dependencies — `@topo/app` must not run.
 
 ## `vt run -t build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_task_smoke/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_task_smoke/snapshots.toml
@@ -1,9 +1,8 @@
+[[e2e]]
+name = "cache_hit_after_file_modification"
 comment = """
 Tests cache miss when input file is modified
 """
-
-[[e2e]]
-name = "cache_hit_after_file_modification"
 steps = [
   { argv = [
     "vt",

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/workspace_root_self_reference/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/workspace_root_self_reference/snapshots.toml
@@ -1,33 +1,18 @@
 [[e2e]]
 name = "recursive_build_skips_root_self_reference"
 comment = """
-Tests that workspace root self-referencing tasks don't cause infinite recursion.
-Root build = `vt run -r build` (delegates to all packages recursively).
-
-Skip rule: `vt run -r build` from root produces the same query as the
-nested `vt run -r build` in root's script, so root's expansion is skipped.
-Only packages a and b actually run.
-
-Prune rule: `vt run build` from root produces a ContainingPackage query,
-but root's script `vt run -r build` produces an All query. The queries
-differ so the skip rule doesn't fire. Instead the prune rule removes root
-from the nested result, leaving only a and b.
+`vt run -r build` from the workspace root, when root's own `build` script is
+itself `vt run -r build`, should hit the skip rule: the nested expansion is
+the same query, so root's step is skipped and only packages a and b run.
 """
 steps = [{ argv = ["vt", "run", "-r", "build"], comment = "only a and b run, root is skipped" }]
 
 [[e2e]]
 name = "build_from_root_prunes_root_from_nested_expansion"
 comment = """
-Tests that workspace root self-referencing tasks don't cause infinite recursion.
-Root build = `vt run -r build` (delegates to all packages recursively).
-
-Skip rule: `vt run -r build` from root produces the same query as the
-nested `vt run -r build` in root's script, so root's expansion is skipped.
-Only packages a and b actually run.
-
-Prune rule: `vt run build` from root produces a ContainingPackage query,
-but root's script `vt run -r build` produces an All query. The queries
-differ so the skip rule doesn't fire. Instead the prune rule removes root
-from the nested result, leaving only a and b.
+`vt run build` from root produces a `ContainingPackage` query, while root's
+script (`vt run -r build`) produces an `All` query, so the skip rule does
+not apply. The prune rule should instead remove root from the nested result,
+again leaving only a and b.
 """
 steps = [{ argv = ["vt", "run", "build"], comment = "only a and b run under root, root is pruned" }]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/workspace_root_self_reference/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/workspace_root_self_reference/snapshots.toml
@@ -1,3 +1,5 @@
+[[e2e]]
+name = "recursive_build_skips_root_self_reference"
 comment = """
 Tests that workspace root self-referencing tasks don't cause infinite recursion.
 Root build = `vt run -r build` (delegates to all packages recursively).
@@ -11,11 +13,21 @@ but root's script `vt run -r build` produces an All query. The queries
 differ so the skip rule doesn't fire. Instead the prune rule removes root
 from the nested result, leaving only a and b.
 """
-
-[[e2e]]
-name = "recursive_build_skips_root_self_reference"
 steps = [{ argv = ["vt", "run", "-r", "build"], comment = "only a and b run, root is skipped" }]
 
 [[e2e]]
 name = "build_from_root_prunes_root_from_nested_expansion"
+comment = """
+Tests that workspace root self-referencing tasks don't cause infinite recursion.
+Root build = `vt run -r build` (delegates to all packages recursively).
+
+Skip rule: `vt run -r build` from root produces the same query as the
+nested `vt run -r build` in root's script, so root's expansion is skipped.
+Only packages a and b actually run.
+
+Prune rule: `vt run build` from root produces a ContainingPackage query,
+but root's script `vt run -r build` produces an All query. The queries
+differ so the skip rule doesn't fire. Instead the prune rule removes root
+from the nested result, leaving only a and b.
+"""
 steps = [{ argv = ["vt", "run", "build"], comment = "only a and b run under root, root is pruned" }]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/workspace_root_self_reference/snapshots/build_from_root_prunes_root_from_nested_expansion.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/workspace_root_self_reference/snapshots/build_from_root_prunes_root_from_nested_expansion.md
@@ -1,16 +1,9 @@
 # build_from_root_prunes_root_from_nested_expansion
 
-Tests that workspace root self-referencing tasks don't cause infinite recursion.
-Root build = `vt run -r build` (delegates to all packages recursively).
-
-Skip rule: `vt run -r build` from root produces the same query as the
-nested `vt run -r build` in root's script, so root's expansion is skipped.
-Only packages a and b actually run.
-
-Prune rule: `vt run build` from root produces a ContainingPackage query,
-but root's script `vt run -r build` produces an All query. The queries
-differ so the skip rule doesn't fire. Instead the prune rule removes root
-from the nested result, leaving only a and b.
+`vt run build` from root produces a `ContainingPackage` query, while root's
+script (`vt run -r build`) produces an `All` query, so the skip rule does
+not apply. The prune rule should instead remove root from the nested result,
+again leaving only a and b.
 
 ## `vt run build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/workspace_root_self_reference/snapshots/recursive_build_skips_root_self_reference.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/workspace_root_self_reference/snapshots/recursive_build_skips_root_self_reference.md
@@ -1,16 +1,8 @@
 # recursive_build_skips_root_self_reference
 
-Tests that workspace root self-referencing tasks don't cause infinite recursion.
-Root build = `vt run -r build` (delegates to all packages recursively).
-
-Skip rule: `vt run -r build` from root produces the same query as the
-nested `vt run -r build` in root's script, so root's expansion is skipped.
-Only packages a and b actually run.
-
-Prune rule: `vt run build` from root produces a ContainingPackage query,
-but root's script `vt run -r build` produces an All query. The queries
-differ so the skip rule doesn't fire. Instead the prune rule removes root
-from the nested result, leaving only a and b.
+`vt run -r build` from the workspace root, when root's own `build` script is
+itself `vt run -r build`, should hit the skip rule: the nested expansion is
+the same query, so root's step is skipped and only packages a and b run.
 
 ## `vt run -r build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/main.rs
+++ b/crates/vite_task_bin/tests/e2e_snapshots/main.rs
@@ -184,6 +184,9 @@ impl WriteKey {
 #[derive(serde::Deserialize, Debug)]
 struct E2e {
     pub name: Str,
+    /// Free-form description rendered under the H1 heading of the generated snapshot.
+    #[serde(default)]
+    pub comment: Option<Str>,
     #[serde(default)]
     pub cwd: RelativePathBuf,
     pub steps: Vec<Step>,
@@ -198,10 +201,6 @@ struct E2e {
 
 #[derive(serde::Deserialize, Default)]
 struct SnapshotsFile {
-    /// Free-form description shared by every case in this file. Rendered under
-    /// the H1 heading of each generated snapshot.
-    #[serde(default)]
-    pub comment: Option<Str>,
     #[serde(rename = "e2e", default)] // toml usually uses singular for arrays
     pub e2e_cases: Vec<E2e>,
 }
@@ -262,7 +261,6 @@ fn run_case(
     fixture_name: &str,
     case_index: usize,
     e2e: &E2e,
-    file_comment: Option<&str>,
 ) -> Result<(), String> {
     let snapshots = snapshot_test::Snapshots::new(fixture_path.join("snapshots"));
 
@@ -296,7 +294,7 @@ fn run_case(
 
     let mut e2e_outputs = String::new();
     e2e_outputs.push_str(vite_str::format!("# {}\n", e2e.name).as_str());
-    if let Some(comment) = file_comment {
+    if let Some(comment) = e2e.comment.as_deref() {
         // Normalize CRLF → LF; on Windows, git checkouts with autocrlf embed
         // `\r\n` inside TOML multi-line strings, which would make `actual`
         // diverge from the stored `.md` (loaded via `\r\n` → `\n` normalization).
@@ -500,7 +498,6 @@ fn main() {
                 Arc::from(fixture_path.file_name().unwrap().to_str().unwrap());
             assert_identifier_like("fixture folder", &fixture_name);
             let cases_file = load_snapshots_file(&fixture_path);
-            let file_comment: Arc<Option<Str>> = Arc::new(cases_file.comment);
             cases_file.e2e_cases.into_iter().enumerate().filter_map({
                 let fixture_path = Arc::clone(&fixture_path);
                 let fixture_name = Arc::clone(&fixture_name);
@@ -523,18 +520,10 @@ fn main() {
                     let fixture_path = Arc::clone(&fixture_path);
                     let fixture_name = Arc::clone(&fixture_name);
                     let tmp_dir_path = tmp_dir_path.clone();
-                    let file_comment = Arc::clone(&file_comment);
                     Some(
                         libtest_mimic::Trial::test(trial_name.as_str(), move || {
-                            run_case(
-                                &tmp_dir_path,
-                                &fixture_path,
-                                &fixture_name,
-                                case_index,
-                                &e2e,
-                                file_comment.as_deref(),
-                            )
-                            .map_err(Into::into)
+                            run_case(&tmp_dir_path, &fixture_path, &fixture_name, case_index, &e2e)
+                                .map_err(Into::into)
                         })
                         .with_ignored_flag(ignored),
                     )


### PR DESCRIPTION
## Summary

- Drops the file-level `comment` field from `snapshots.toml` in the e2e harness; a `comment` now lives on each `[[e2e]]` entry and renders under that case's H1 heading.
- Migrates every existing top-level comment into per-case comments, each written to describe what that individual case verifies (cache behaviors, stdio modes, selector flows, etc.).

## Test plan

- [ ] `cargo test -p vite_task_bin --test e2e_snapshots` passes (148/148 locally)
- [ ] Spot-check a few regenerated `.md` snapshots to confirm the new comments read sensibly under each H1

🤖 Generated with [Claude Code](https://claude.com/claude-code)