### PR TITLE
chore: disable crate publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = ["crates/*"]
 authors = ["Vite+ Authors"]
 edition = "2024"
 license = "MIT"
+publish = false
 rust-version = "1.89.0"
 
 [workspace.lints.rust]

--- a/crates/fspy_detours_sys/Cargo.toml
+++ b/crates/fspy_detours_sys/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 rust-version.workspace = true
 
 [build-dependencies]

--- a/crates/fspy_preload_windows/Cargo.toml
+++ b/crates/fspy_preload_windows/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fspy_preload_windows"
 version = "0.1.0"
 edition.workspace = true
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/vite_graph_ser/Cargo.toml
+++ b/crates/vite_graph_ser/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 rust-version.workspace = true
 
 [dependencies]

--- a/crates/vite_path/Cargo.toml
+++ b/crates/vite_path/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 rust-version.workspace = true
 
 [dependencies]

--- a/crates/vite_str/Cargo.toml
+++ b/crates/vite_str/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 rust-version.workspace = true
 
 [dependencies]

--- a/crates/vite_task_bin/Cargo.toml
+++ b/crates/vite_task_bin/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 rust-version.workspace = true
 
 [[bin]]

--- a/crates/vite_task_graph/Cargo.toml
+++ b/crates/vite_task_graph/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 rust-version.workspace = true
 
 [dependencies]

--- a/crates/vite_tui/Cargo.toml
+++ b/crates/vite_tui/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition.workspace = true
 include = ["/src"]
 license.workspace = true
+publish = false
 readme = "README.md"
 rust-version.workspace = true
 


### PR DESCRIPTION
## Summary
- add `publish = false` to workspace package metadata
- mark remaining crate manifests as non-publishable

## Validation
- `cargo metadata --no-deps --format-version 1`