### PR TITLE
fix(ci): unblock security analysis

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,6 +19,6 @@ concurrency:
 jobs:
   security:
     name: Security Analysis
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
-      - uses: oxc-project/security-action@4211cd3f56ba742507263ea4a999f3be4165a53c # v1.0.1
+      - uses: oxc-project/security-action@f14eeb22b9ee0f7d3b242e5017ed0fdfada66f74 # v1.0.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,9 +3358,9 @@ checksum = "43d0e35dc7d73976a53c7e6d7d177ef804a0c0ee774ec77bcc520c2216fd7cbe"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ stackalloc = "1.2.1"
 subprocess_test = { path = "crates/subprocess_test" }
 supports-color = "3.0.1"
 syscalls = { version = "0.6.18", default-features = false }
-tar = "0.4.43"
+tar = "0.4.45"
 tempfile = "3.14.0"
 test-log = { version = "0.2.18", features = ["trace"] }
 thiserror = "2"

--- a/crates/fspy/Cargo.toml
+++ b/crates/fspy/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fspy"
 version = "0.1.0"
 edition = "2024"
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/fspy_e2e/Cargo.toml
+++ b/crates/fspy_e2e/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fspy_e2e"
 version = "0.0.0"
 edition.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/fspy_preload_unix/Cargo.toml
+++ b/crates/fspy_preload_unix/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "fspy_preload_unix"
 edition = "2024"
+license.workspace = true
 publish = false
 
 [lib]

--- a/crates/fspy_preload_windows/Cargo.toml
+++ b/crates/fspy_preload_windows/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fspy_preload_windows"
 version = "0.1.0"
 edition.workspace = true
+license.workspace = true
 publish = false
 
 [lib]

--- a/crates/fspy_seccomp_unotify/Cargo.toml
+++ b/crates/fspy_seccomp_unotify/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
 edition = "2024"
+license.workspace = true
 publish = false
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/fspy_shared/Cargo.toml
+++ b/crates/fspy_shared/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fspy_shared"
 version = "0.0.0"
 edition = "2024"
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/fspy_shared_unix/Cargo.toml
+++ b/crates/fspy_shared_unix/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fspy_shared_unix"
 version = "0.0.0"
 edition.workspace = true
+license.workspace = true
 publish = false
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/preload_test_lib/Cargo.toml
+++ b/crates/preload_test_lib/Cargo.toml
@@ -2,6 +2,7 @@
 name = "preload_test_lib"
 version = "0.0.0"
 edition.workspace = true
+license.workspace = true
 publish = false
 
 [lib]


### PR DESCRIPTION
## Summary
- Run the security workflow on `ubuntu-latest` so the runner provides `cargo` for the `cargo-deny` step.
- Update the pinned `oxc-project/security-action` reference to v1.0.2.
- Update `tar` to 0.4.45 to clear current RustSec advisories.
- Add workspace license metadata to fspy-related crates used by cargo-deny checks.

## Verification
- `zizmor --strict-collection --show-audit-urls=always --min-severity=medium .`
- `cargo deny check --config <(curl -fsSL https://raw.githubusercontent.com/oxc-project/security-action/v1.0.2/deny.toml)`
- `git diff --check`
- `cargo check --locked`