### PR TITLE
fix(ci): update oxc-project/setup-rust action version comments to v1.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           persist-credentials: false
           submodules: true
 
-      - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.0
+      - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.2
         with:
           save-cache: ${{ github.ref_name == 'main' }}
           cache-key: clippy
@@ -107,7 +107,7 @@ jobs:
             CARGO_HOME,{{ DEV_DRIVE }}/.cargo
             RUSTUP_HOME,{{ DEV_DRIVE }}/.rustup
 
-      - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.0
+      - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.2
         with:
           save-cache: ${{ github.ref_name == 'main' }}
           cache-key: test
@@ -220,7 +220,7 @@ jobs:
           persist-credentials: false
           submodules: true
 
-      - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.0
+      - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.2
         with:
           save-cache: ${{ github.ref_name == 'main' }}
           cache-key: fmt


### PR DESCRIPTION
## Summary
Updated version comments in the CI workflow to reflect the correct version of the `oxc-project/setup-rust` action being used.

## Changes
- Updated version comment from `v1.0.0` to `v1.0.2` for the `oxc-project/setup-rust` action across three CI jobs:
  - Clippy job (line 55)
  - Test job (line 110)
  - Format job (line 223)

## Details
The action reference itself (commit SHA `d286d43bc1f606abbd98096666ff8be68c8d5f57`) remains unchanged; only the version comment annotations have been updated to accurately reflect the version being used. This ensures consistency between the actual action version and its documentation in the workflow file.

https://claude.ai/code/session_01Ea2fdDbjcYDAoVmjjfGxX5