### PR TITLE
chore(deps): replace serde_yml with serde_norway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3062,25 +3062,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_yaml_ng"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3807,10 +3807,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "utf8-chars"
@@ -4096,7 +4096,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "serde_yaml_ng",
+ "serde_norway",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,16 +1771,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "line-clipping"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3081,18 +3071,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3819,6 +3807,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "utf8-chars"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4102,7 +4096,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml_ng",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ rustc-hash = "2.1.1"
 seccompiler = { git = "https://github.com/rust-vmm/seccompiler", rev = "08587106340b8e3cb361c7561411510039436857" }
 serde = "1.0.219"
 serde_json = "1.0.140"
-serde_yml = "0.0.12"
+serde_yaml_ng = "0.10.0"
 sha2 = "0.10.9"
 shared_memory = "0.12.4"
 shell-escape = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ rustc-hash = "2.1.1"
 seccompiler = { git = "https://github.com/rust-vmm/seccompiler", rev = "08587106340b8e3cb361c7561411510039436857" }
 serde = "1.0.219"
 serde_json = "1.0.140"
-serde_yaml_ng = "0.10.0"
+serde_norway = "0.9.42"
 sha2 = "0.10.9"
 shared_memory = "0.12.4"
 shell-escape = "0.1.5"

--- a/crates/vite_workspace/Cargo.toml
+++ b/crates/vite_workspace/Cargo.toml
@@ -14,7 +14,7 @@ rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 # use `preserve_order` feature to preserve the order of the fields in `package.json`
 serde_json = { workspace = true, features = ["preserve_order"] }
-serde_yml = { workspace = true }
+serde_yaml_ng = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 vec1 = { workspace = true, features = ["smallvec-v1"] }

--- a/crates/vite_workspace/Cargo.toml
+++ b/crates/vite_workspace/Cargo.toml
@@ -14,7 +14,7 @@ rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 # use `preserve_order` feature to preserve the order of the fields in `package.json`
 serde_json = { workspace = true, features = ["preserve_order"] }
-serde_yaml_ng = { workspace = true }
+serde_norway = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 vec1 = { workspace = true, features = ["smallvec-v1"] }

--- a/crates/vite_workspace/src/error.rs
+++ b/crates/vite_workspace/src/error.rs
@@ -43,10 +43,10 @@ pub enum Error {
     },
 
     #[error("Failed to parse YAML file at {file_path:?}")]
-    SerdeYml {
+    SerdeYaml {
         file_path: Arc<AbsolutePath>,
         #[source]
-        serde_yml_error: serde_yml::Error,
+        serde_yaml_error: serde_yaml_ng::Error,
     },
 
     #[error(transparent)]

--- a/crates/vite_workspace/src/error.rs
+++ b/crates/vite_workspace/src/error.rs
@@ -46,7 +46,7 @@ pub enum Error {
     SerdeYaml {
         file_path: Arc<AbsolutePath>,
         #[source]
-        serde_yaml_error: serde_yaml_ng::Error,
+        serde_yaml_error: serde_norway::Error,
     },
 
     #[error(transparent)]

--- a/crates/vite_workspace/src/lib.rs
+++ b/crates/vite_workspace/src/lib.rs
@@ -248,10 +248,10 @@ pub fn load_package_graph(
     let mut graph_builder = PackageGraphBuilder::default();
     let workspaces = match &workspace_root.workspace_file {
         WorkspaceFile::PnpmWorkspaceYaml(file_with_path) => {
-            let workspace: PnpmWorkspace = serde_yml::from_slice(file_with_path.content())
-                .map_err(|e| Error::SerdeYml {
+            let workspace: PnpmWorkspace = serde_yaml_ng::from_slice(file_with_path.content())
+                .map_err(|e| Error::SerdeYaml {
                     file_path: Arc::clone(file_with_path.path()),
-                    serde_yml_error: e,
+                    serde_yaml_error: e,
                 })?;
             workspace.packages
         }

--- a/crates/vite_workspace/src/lib.rs
+++ b/crates/vite_workspace/src/lib.rs
@@ -248,7 +248,7 @@ pub fn load_package_graph(
     let mut graph_builder = PackageGraphBuilder::default();
     let workspaces = match &workspace_root.workspace_file {
         WorkspaceFile::PnpmWorkspaceYaml(file_with_path) => {
-            let workspace: PnpmWorkspace = serde_yaml_ng::from_slice(file_with_path.content())
+            let workspace: PnpmWorkspace = serde_norway::from_slice(file_with_path.content())
                 .map_err(|e| Error::SerdeYaml {
                     file_path: Arc::clone(file_with_path.path()),
                     serde_yaml_error: e,


### PR DESCRIPTION
## Motivation

The Security Analysis job (which runs `cargo deny check` whenever `Cargo.lock` changes) fails on every PR that touches `Cargo.lock` because `serde_yml v0.0.12` trips [RUSTSEC-2025-0068](https://rustsec.org/advisories/RUSTSEC-2025-0068): the crate is unsound (`Serializer.emitter` can segfault), the upstream project has been archived, and the advisory explicitly states "No safe upgrade is available". The only fix is to move off `serde_yml`. Example failure: [run 24874266956 on #352](https://github.com/voidzero-dev/vite-task/actions/runs/24874266956/job/72827299235?pr=352).

## Summary

- Replace `serde_yml = "0.0.12"` with `serde_norway = "0.9.42"` in the workspace `Cargo.toml` and in `crates/vite_workspace/Cargo.toml`.
- Update `vite_workspace::load_package_graph` to call `serde_norway::from_slice` for `pnpm-workspace.yaml`.
- Rename the error variant `Error::SerdeYml { serde_yml_error: serde_yml::Error }` → `Error::SerdeYaml { serde_yaml_error: serde_norway::Error }` so the type stays generic over the backing crate.
- Regenerate `Cargo.lock` (adds `serde_norway`, `unsafe-libyaml-norway`; drops `serde_yml`, `libyaml-safer`, and their exclusive transitive deps).

## Why `serde_norway` over the other forks

`serde_yml`'s RUSTSEC advisory lists four alternatives; both maintained `serde_yaml` forks (`serde_norway` and `serde_yaml_ng`) are drop-in compatible. `serde_norway` is more actively maintained (last release Dec 2024 vs May 2024), dual-licensed MIT/Apache-2.0, and ships its own `unsafe-libyaml-norway` fork of the C bindings so future advisories against libyaml can be patched without waiting on upstream.

## Test plan

- [x] `cargo deny check --config <oxc security-action deny.toml>` → `advisories ok, bans ok, licenses ok, sources ok` (was `unsound: RUSTSEC-2025-0068` before)
- [x] `cargo test -p vite_workspace` → 79 passed
- [x] `cargo clippy -p vite_workspace --all-targets -- -D warnings` → clean