### PR TITLE
fix: preserve PATHEXT for Windows cached tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- **Fixed** Windows cached tasks can now run package shims rewritten through PowerShell; default env passthrough now preserves `PATHEXT` ([#366](https://github.com/voidzero-dev/vite-task/pull/366))
 - **Added** Platform support for targets without `input` auto-inference (e.g. Android). Tasks still run; those relying on auto-inference run uncached, with the summary noting that `input` must be configured manually to enable caching ([#352](https://github.com/voidzero-dev/vite-task/pull/352))
 - **Fixed** `vp run` no longer aborts with `failed to prepare the command for injection: Invalid argument` when the user environment already has `LD_PRELOAD` (Linux) or `DYLD_INSERT_LIBRARIES` (macOS) set. The tracer shim is now appended to any existing value and placed last, so user preloads keep their symbol-interposition precedence ([#340](https://github.com/voidzero-dev/vite-task/issues/340))
 - **Changed** Arguments passed after a task name (e.g. `vp run test some-filter`) are now forwarded only to that task. Tasks pulled in via `dependsOn` no longer receive them ([#324](https://github.com/voidzero-dev/vite-task/issues/324))

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/.gitignore
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/.gitignore
@@ -1,0 +1,3 @@
+# This fixture intentionally tracks package-shim files under node_modules/.bin.
+!node_modules
+!node_modules/**

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/node_modules/.bin/probe-cli.cmd
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/node_modules/.bin/probe-cli.cmd
@@ -1,0 +1,4 @@
+@ECHO off
+REM Use the .exe suffix intentionally: PowerShell process launch still depends on PATHEXT here.
+vtt.exe write-file marker.txt shim-ran
+vtt.exe print shim-ran

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/node_modules/.bin/probe-cli.ps1
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/node_modules/.bin/probe-cli.ps1
@@ -1,0 +1,4 @@
+# Use the .exe suffix intentionally: PowerShell process launch still depends on PATHEXT here.
+vtt.exe write-file marker.txt shim-ran
+vtt.exe print shim-ran
+exit $LASTEXITCODE

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/package.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "windows-powershell-shim-pathext"
+}

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/snapshots.toml
@@ -1,0 +1,4 @@
+[[e2e]]
+name = "powershell_package_shim_keeps_pathext"
+platform = "windows"
+steps = [["vt", "run", "probe"], ["vtt", "print-file", "marker.txt"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/snapshots.toml
@@ -1,4 +1,23 @@
 [[e2e]]
 name = "powershell_package_shim_keeps_pathext"
 platform = "windows"
-steps = [["vt", "run", "probe"], ["vtt", "print-file", "marker.txt"]]
+comment = """
+Cached Windows tasks run with a sanitized environment, and pnpm-style package
+`.cmd` shims in `node_modules/.bin` are rewritten at plan time to invoke their
+`.ps1` sibling via `powershell.exe -File`. PowerShell needs `PATHEXT` in that
+environment to launch native executables — even when the executable name is
+written out with a `.exe` extension — so `PATHEXT` must be preserved in the
+default untracked env passthrough.
+"""
+steps = [
+  { argv = [
+    "vt",
+    "run",
+    "probe",
+  ], comment = "rewritten to `powershell.exe -File probe-cli.ps1`; the shim launches `vtt.exe write-file` to write `marker.txt`" },
+  { argv = [
+    "vtt",
+    "print-file",
+    "marker.txt",
+  ], comment = "marker is present only if the shim's `vtt.exe` launch succeeded" },
+]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/snapshots/powershell_package_shim_keeps_pathext.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/snapshots/powershell_package_shim_keeps_pathext.md
@@ -1,6 +1,15 @@
 # powershell_package_shim_keeps_pathext
 
+Cached Windows tasks run with a sanitized environment, and pnpm-style package
+`.cmd` shims in `node_modules/.bin` are rewritten at plan time to invoke their
+`.ps1` sibling via `powershell.exe -File`. PowerShell needs `PATHEXT` in that
+environment to launch native executables — even when the executable name is
+written out with a `.exe` extension — so `PATHEXT` must be preserved in the
+default untracked env passthrough.
+
 ## `vt run probe`
+
+rewritten to `powershell.exe -File probe-cli.ps1`; the shim launches `vtt.exe write-file` to write `marker.txt`
 
 ```
 $ probe-cli
@@ -8,6 +17,8 @@ shim-ran
 ```
 
 ## `vtt print-file marker.txt`
+
+marker is present only if the shim's `vtt.exe` launch succeeded
 
 ```
 shim-ran

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/snapshots/powershell_package_shim_keeps_pathext.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/snapshots/powershell_package_shim_keeps_pathext.md
@@ -1,0 +1,14 @@
+# powershell_package_shim_keeps_pathext
+
+## `vt run probe`
+
+```
+$ probe-cli
+shim-ran
+```
+
+## `vtt print-file marker.txt`
+
+```
+shim-ran
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/vite-task.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/vite-task.json
@@ -1,0 +1,10 @@
+{
+  "cache": true,
+  "tasks": {
+    "probe": {
+      "command": "probe-cli",
+      "cache": true,
+      "input": []
+    }
+  }
+}

--- a/crates/vite_task_graph/src/config/mod.rs
+++ b/crates/vite_task_graph/src/config/mod.rs
@@ -382,6 +382,7 @@ pub const DEFAULT_UNTRACKED_ENV: &[&str] = &[
     "HOMEDRIVE",
     "HOMEPATH",
     "WINDIR",
+    "PATHEXT",
     "ProgramFiles",
     "ProgramFiles[(]x86[)]", // Parens escaped for glob syntax (Turborepo uses literal `ProgramFiles(x86)`)
     // IDE specific (exact matches)


### PR DESCRIPTION
Fixes #365.

Preserves PATHEXT in the default Windows environment passthrough so PowerShell package shims can resolve node.exe during cached task execution.

<details>
<summary>Why PATHEXT is required</summary>

In the issue repro, `marker-cli` is exposed through a pnpm-generated `node_modules/.bin/marker-cli.ps1` shim. On Windows, that shim sets `$exe = ".exe"` and then falls back to invoking Node by name:

```powershell
& "node$exe" "$basedir/../marker-cli/bin/marker-cli.mjs" $args
```

So the actual command is `& "node.exe" ...`.

When `PATHEXT` is missing from the sanitized cached-task environment, PowerShell can still locate `node.exe` with `Get-Command node.exe`, but native invocation by name does not run correctly: `& "node.exe" --version` produces no output, `$LASTEXITCODE` is unset, and the repro marker file is not created. Restoring `PATHEXT` with `.EXE` makes the same shim execute normally and create the marker.

This is why preserving `PATHEXT` fixes the cached PowerShell shim path without changing fspy or the shim rewrite itself.
</details>

Verified with the issue repro on Windows, `cargo fmt --check`, `cargo build -p vite_task_bin`, and `cargo test -p vite_task_plan --test plan_snapshots -- windows_cmd_shim_rewrite`.