### PR TITLE
ci(musl): replace corepack with oxc-project/setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,18 +139,7 @@ jobs:
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         if: ${{ matrix.target == 'x86_64-apple-darwin' }}
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .node-version
-          architecture: x64
-        if: ${{ matrix.target == 'x86_64-apple-darwin' }}
-
       - uses: oxc-project/setup-node@4c26e7cb3605b6bdef5450dacd02c434b10fd8ba # v1.2.0
-        if: ${{ matrix.target != 'x86_64-apple-darwin' }}
-
-      # `pnpm install` prepares test bins used in snapshot tests
-      # Must run after setup-node so correct native binaries are installed
-      - run: pnpm install
 
       - name: Run ignored tests
         run: ${{ matrix.cargo_cmd }} test --target ${{ matrix.build_target }} -- --ignored
@@ -201,10 +190,12 @@ jobs:
       - name: Run tests
         run: cargo test
 
-      - uses: oxc-project/setup-node@4c26e7cb3605b6bdef5450dacd02c434b10fd8ba # v1.2.0
+      # oxc-project/setup-node calls actions/setup-node, which only ships glibc
+      # Node binaries that can't run on Alpine's musl. The container's bundled
+      # Node is musl-native, so just install pnpm directly via npm.
+      - name: Install pnpm
+        run: npm install -g pnpm
 
-      # `pnpm install` prepares test bins used in snapshot tests
-      # Must run after setup-node so correct native binaries are installed
       - run: pnpm install
 
       - name: Run ignored tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,11 +190,7 @@ jobs:
       - name: Run tests
         run: cargo test
 
-      # Alpine ships musl Node; actions/setup-node only has glibc binaries.
-      - name: Install pnpm
-        run: npm install -g pnpm
-
-      - run: pnpm install
+      - uses: oxc-project/setup-node@6d1b0ae8445197eb4ee006b276f8e5b29e4a544d # auto-skip-alpine
 
       - name: Run ignored tests
         run: cargo test -- --ignored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,13 +132,6 @@ jobs:
       - name: Run tests
         run: ${{ matrix.cargo_cmd }} test --target ${{ matrix.build_target }}
 
-      # For x86_64-apple-darwin on arm64 runner, install x64 node so fspy preload dylib
-      # (compiled for x86_64) can be injected into node processes running under Rosetta.
-      # oxc-project/setup-node doesn't support the architecture input, so use
-      # pnpm/action-setup + actions/setup-node directly.
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
-        if: ${{ matrix.target == 'x86_64-apple-darwin' }}
-
       - uses: oxc-project/setup-node@4c26e7cb3605b6bdef5450dacd02c434b10fd8ba # v1.2.0
 
       - name: Run ignored tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Run tests
         run: cargo test
 
-      - uses: oxc-project/setup-node@6d1b0ae8445197eb4ee006b276f8e5b29e4a544d # auto-skip-alpine
+      - uses: oxc-project/setup-node@a866f096daf8febf6999d4227cbc424f1ac7eddc # auto-skip-alpine
 
       - name: Run ignored tests
         run: cargo test -- --ignored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,9 +190,7 @@ jobs:
       - name: Run tests
         run: cargo test
 
-      # oxc-project/setup-node calls actions/setup-node, which only ships glibc
-      # Node binaries that can't run on Alpine's musl. The container's bundled
-      # Node is musl-native, so just install pnpm directly via npm.
+      # Alpine ships musl Node; actions/setup-node only has glibc binaries.
       - name: Install pnpm
         run: npm install -g pnpm
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,11 @@ jobs:
       - name: Run tests
         run: ${{ matrix.cargo_cmd }} test --target ${{ matrix.build_target }}
 
+      # x86_64-apple-darwin runs on arm64 runner under Rosetta; install x64 Node
+      # so fspy's x86_64 preload dylib can be injected into spawned node procs.
       - uses: oxc-project/setup-node@ab97f03642370d79a7e96dd286bd02a1be40e0ba # v1.3.0
+        with:
+          architecture: ${{ matrix.target == 'x86_64-apple-darwin' && 'x64' || '' }}
 
       - name: Run ignored tests
         run: ${{ matrix.cargo_cmd }} test --target ${{ matrix.build_target }} -- --ignored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Run tests
         run: ${{ matrix.cargo_cmd }} test --target ${{ matrix.build_target }}
 
-      - uses: oxc-project/setup-node@4c26e7cb3605b6bdef5450dacd02c434b10fd8ba # v1.2.0
+      - uses: oxc-project/setup-node@ab97f03642370d79a7e96dd286bd02a1be40e0ba # v1.3.0
 
       - name: Run ignored tests
         run: ${{ matrix.cargo_cmd }} test --target ${{ matrix.build_target }} -- --ignored
@@ -183,7 +183,7 @@ jobs:
       - name: Run tests
         run: cargo test
 
-      - uses: oxc-project/setup-node@a866f096daf8febf6999d4227cbc424f1ac7eddc # auto-skip-alpine
+      - uses: oxc-project/setup-node@ab97f03642370d79a7e96dd286bd02a1be40e0ba # v1.3.0
 
       - name: Run ignored tests
         run: cargo test -- --ignored
@@ -204,7 +204,7 @@ jobs:
           tools: cargo-shear@1.11.1,cargo-autoinherit@0.1.6
           components: clippy rust-docs rustfmt
 
-      - uses: oxc-project/setup-node@4c26e7cb3605b6bdef5450dacd02c434b10fd8ba # v1.2.0
+      - uses: oxc-project/setup-node@ab97f03642370d79a7e96dd286bd02a1be40e0ba # v1.3.0
       - run: pnpm oxfmt --check
       - run: cargo autoinherit && git diff --exit-code
       - run: cargo shear --deny-warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,10 +201,11 @@ jobs:
       - name: Run tests
         run: cargo test
 
-      - name: Install pnpm and Node tools
-        run: |
-          corepack enable
-          pnpm install
+      - uses: oxc-project/setup-node@4c26e7cb3605b6bdef5450dacd02c434b10fd8ba # v1.2.0
+
+      # `pnpm install` prepares test bins used in snapshot tests
+      # Must run after setup-node so correct native binaries are installed
+      - run: pnpm install
 
       - name: Run ignored tests
         run: cargo test -- --ignored


### PR DESCRIPTION
## Summary

The musl test job runs in a Node Alpine container and used `corepack enable` to bootstrap pnpm. Node 25 unbundles corepack, so the renovate bump from `node:22-alpine3.21` to `node:25-alpine3.21` (#361) fails with `corepack: command not found` (see [run 24967913479](https://github.com/voidzero-dev/vite-task/actions/runs/24967913479/job/73105843537?pr=361)).

Use `oxc-project/setup-node@v1.2.0`, which installs pnpm directly and gates the pnpm-store cache to `main` (save on main, restore-only on PRs). Mirrors the existing pattern at `.github/workflows/ci.yml:148-153` (action + follow-up `pnpm install` for test bins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)