### PR TITLE
fix(ui): improve unrecognized database version error message

### DIFF
--- a/crates/vite_task/src/session/cache/mod.rs
+++ b/crates/vite_task/src/session/cache/mod.rs
@@ -176,7 +176,7 @@ pub fn split_path(path: &str) -> (Option<&str>, &str) {
 
 impl ExecutionCache {
     #[tracing::instrument(level = "debug", skip_all)]
-    pub fn load_from_path(path: &AbsolutePath) -> anyhow::Result<Self> {
+    pub fn load_from_path(path: &AbsolutePath, program_name: &str) -> anyhow::Result<Self> {
         tracing::info!("Creating task cache directory at {:?}", path);
         std::fs::create_dir_all(path)?;
 
@@ -211,7 +211,11 @@ impl ExecutionCache {
                 }
                 11 => break, // current version
                 12.. => {
-                    return Err(anyhow::anyhow!("Unrecognized database version: {user_version}"));
+                    return Err(anyhow::anyhow!(
+                        "Unrecognized database version: {user_version}. \
+                         The cache may have been created by a newer version of Vite Task. \
+                         Run `{program_name} cache clean` to remove it."
+                    ));
                 }
             }
         }

--- a/crates/vite_task/src/session/mod.rs
+++ b/crates/vite_task/src/session/mod.rs
@@ -554,8 +554,9 @@ impl<'a> Session<'a> {
     ///
     /// Returns an error if the cache database cannot be loaded or created.
     pub fn cache(&self) -> anyhow::Result<&ExecutionCache> {
-        self.cache
-            .get_or_try_init(|| ExecutionCache::load_from_path(&self.cache_path, &self.program_name))
+        self.cache.get_or_try_init(|| {
+            ExecutionCache::load_from_path(&self.cache_path, &self.program_name)
+        })
     }
 
     pub fn workspace_path(&self) -> Arc<AbsolutePath> {

--- a/crates/vite_task/src/session/mod.rs
+++ b/crates/vite_task/src/session/mod.rs
@@ -554,7 +554,8 @@ impl<'a> Session<'a> {
     ///
     /// Returns an error if the cache database cannot be loaded or created.
     pub fn cache(&self) -> anyhow::Result<&ExecutionCache> {
-        self.cache.get_or_try_init(|| ExecutionCache::load_from_path(&self.cache_path))
+        self.cache
+            .get_or_try_init(|| ExecutionCache::load_from_path(&self.cache_path, &self.program_name))
     }
 
     pub fn workspace_path(&self) -> Arc<AbsolutePath> {


### PR DESCRIPTION
## Summary
Enhanced the error message displayed when an incompatible cache database version is encountered, providing users with actionable guidance on how to resolve the issue.

## Example Message

```
Unrecognized database version: 12. The cache may have been created by a newer version of Vite Task. Run `vp cache clean` to remove it.
```

## Key Changes
- Modified `ExecutionCache::load_from_path()` to accept a `program_name` parameter, allowing the error message to reference the actual program name
- Updated the cache version mismatch error message to:
  - Explain that the cache may have been created by a newer version of Vite Task
  - Provide a specific command (`{program_name} cache clean`) that users can run to resolve the issue
- Updated the `Session::cache()` method to pass `self.program_name` when initializing the execution cache

## Implementation Details
The error message now guides users toward a self-service resolution by suggesting they run the cache clean command, which should reduce support burden and improve user experience when cache incompatibilities occur.

https://claude.ai/code/session_01R6o7gtdDeEVkd6TXNgNi5q