### PR TITLE
test(e2e): stop wrapping snapshot comments

### DIFF
--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/color_env_handling/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/color_env_handling/snapshots.toml
@@ -1,12 +1,7 @@
 [[e2e]]
 name = "force_color_env_is_always_one_in_cached_child"
 comment = """
-The parent shell sets `FORCE_COLOR=0`, but a cached task's child always sees
-`FORCE_COLOR=1`. Color-related env vars are not passed through by default for
-cached tasks — the runner injects `FORCE_COLOR=1` so cached output is always
-colored, and the reporter strips colors at display time when the terminal
-does not support them. (For uncached tasks the parent's environment flows
-through untouched.)
+The parent shell sets `FORCE_COLOR=0`, but a cached task's child always sees `FORCE_COLOR=1`. Color-related env vars are not passed through by default for cached tasks — the runner injects `FORCE_COLOR=1` so cached output is always colored, and the reporter strips colors at display time when the terminal does not support them. (For uncached tasks the parent's environment flows through untouched.)
 """
 steps = [
   { argv = [
@@ -24,22 +19,9 @@ steps = [
 [[e2e]]
 name = "cached_output_keeps_colors_across_force_color_values"
 comment = """
-A task that emits ANSI escape sequences is run twice. Each cache entry
-carries the raw coloured bytes — the runner spawns cached tasks with
-`FORCE_COLOR=1` regardless of the parent's value — and the reporter
-strips colours at the writer level only when the user's terminal cannot
-render them.
+A task that emits ANSI escape sequences is run twice. Each cache entry carries the raw coloured bytes — the runner spawns cached tasks with `FORCE_COLOR=1` regardless of the parent's value — and the reporter strips colours at the writer level only when the user's terminal cannot render them.
 
-Plain-text snapshot steps use the default `vt100::Screen::contents()`
-renderer, which flattens any rendered ANSI styling into plain characters
-(so colors don't pollute snapshots). The two `formatted-snapshot = true`
-steps switch to `vt100::Screen::rows_formatted` (joined with newlines),
-which preserves SGR escapes without emitting cursor positioning or other
-rendering state — the latter varies across platforms and would make the
-snapshot flaky. Bytes are then routed through `std::ascii::escape_default`
-so escapes appear as `\\xNN`. Those two steps prove that the cached
-bytes contained colour all along — even when the corresponding initial
-run had displayed them in plain text.
+Plain-text snapshot steps use the default `vt100::Screen::contents()` renderer, which flattens any rendered ANSI styling into plain characters (so colors don't pollute snapshots). The two `formatted-snapshot = true` steps switch to `vt100::Screen::rows_formatted` (joined with newlines), which preserves SGR escapes without emitting cursor positioning or other rendering state — the latter varies across platforms and would make the snapshot flaky. Bytes are then routed through `std::ascii::escape_default` so escapes appear as `\\xNN`. Those two steps prove that the cached bytes contained colour all along — even when the corresponding initial run had displayed them in plain text.
 """
 
 [[e2e.steps]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/color_env_handling/snapshots/cached_output_keeps_colors_across_force_color_values.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/color_env_handling/snapshots/cached_output_keeps_colors_across_force_color_values.md
@@ -1,21 +1,8 @@
 # cached_output_keeps_colors_across_force_color_values
 
-A task that emits ANSI escape sequences is run twice. Each cache entry
-carries the raw coloured bytes — the runner spawns cached tasks with
-`FORCE_COLOR=1` regardless of the parent's value — and the reporter
-strips colours at the writer level only when the user's terminal cannot
-render them.
+A task that emits ANSI escape sequences is run twice. Each cache entry carries the raw coloured bytes — the runner spawns cached tasks with `FORCE_COLOR=1` regardless of the parent's value — and the reporter strips colours at the writer level only when the user's terminal cannot render them.
 
-Plain-text snapshot steps use the default `vt100::Screen::contents()`
-renderer, which flattens any rendered ANSI styling into plain characters
-(so colors don't pollute snapshots). The two `formatted-snapshot = true`
-steps switch to `vt100::Screen::rows_formatted` (joined with newlines),
-which preserves SGR escapes without emitting cursor positioning or other
-rendering state — the latter varies across platforms and would make the
-snapshot flaky. Bytes are then routed through `std::ascii::escape_default`
-so escapes appear as `\xNN`. Those two steps prove that the cached
-bytes contained colour all along — even when the corresponding initial
-run had displayed them in plain text.
+Plain-text snapshot steps use the default `vt100::Screen::contents()` renderer, which flattens any rendered ANSI styling into plain characters (so colors don't pollute snapshots). The two `formatted-snapshot = true` steps switch to `vt100::Screen::rows_formatted` (joined with newlines), which preserves SGR escapes without emitting cursor positioning or other rendering state — the latter varies across platforms and would make the snapshot flaky. Bytes are then routed through `std::ascii::escape_default` so escapes appear as `\xNN`. Those two steps prove that the cached bytes contained colour all along — even when the corresponding initial run had displayed them in plain text.
 
 ## `FORCE_COLOR=1 vt run print-colored-a`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/color_env_handling/snapshots/force_color_env_is_always_one_in_cached_child.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/color_env_handling/snapshots/force_color_env_is_always_one_in_cached_child.md
@@ -1,11 +1,6 @@
 # force_color_env_is_always_one_in_cached_child
 
-The parent shell sets `FORCE_COLOR=0`, but a cached task's child always sees
-`FORCE_COLOR=1`. Color-related env vars are not passed through by default for
-cached tasks — the runner injects `FORCE_COLOR=1` so cached output is always
-colored, and the reporter strips colors at display time when the terminal
-does not support them. (For uncached tasks the parent's environment flows
-through untouched.)
+The parent shell sets `FORCE_COLOR=0`, but a cached task's child always sees `FORCE_COLOR=1`. Color-related env vars are not passed through by default for cached tasks — the runner injects `FORCE_COLOR=1` so cached output is always colored, and the reporter strips colors at display time when the terminal does not support them. (For uncached tasks the parent's environment flows through untouched.)
 
 ## `FORCE_COLOR=0 vt run print-force-color`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots.toml
@@ -1,35 +1,27 @@
 [[e2e]]
 name = "independent_tasks_run_concurrently"
 comment = """
-Two packages with no dependency relationship should run concurrently. Both tasks
-participate in a 2-way barrier, so sequential execution would hang forever and
-time out.
+Two packages with no dependency relationship should run concurrently. Both tasks participate in a 2-way barrier, so sequential execution would hang forever and time out.
 """
 steps = [["vt", "run", "-r", "build"]]
 
 [[e2e]]
 name = "failure_kills_concurrent_tasks"
 comment = """
-When one concurrent task fails, the sibling running under inherited stdio must
-be cancelled. Task a exits 1 after the shared barrier, task b hangs after it —
-completing without timeout proves cancellation killed b.
+When one concurrent task fails, the sibling running under inherited stdio must be cancelled. Task a exits 1 after the shared barrier, task b hangs after it — completing without timeout proves cancellation killed b.
 """
 steps = [["vt", "run", "-r", "test"]]
 
 [[e2e]]
 name = "failure_kills_concurrent_cached_tasks"
 comment = """
-Same failure-cancellation scenario, but with `--cache` so execution goes through
-the piped stdio / fspy path (spawn_with_tracking) instead of the inherited-stdio
-path.
+Same failure-cancellation scenario, but with `--cache` so execution goes through the piped stdio / fspy path (spawn_with_tracking) instead of the inherited-stdio path.
 """
 steps = [["vt", "run", "-r", "--cache", "test"]]
 
 [[e2e]]
 name = "failure_kills_daemonized_concurrent_tasks"
 comment = """
-Cancellation must also kill a sibling that has daemonized — closing stdout/stderr
-(EOF on the pipe) while the process itself stays alive. The runner must reach
-the process via the cancellation token + Job Object, not by pipe closure.
+Cancellation must also kill a sibling that has daemonized — closing stdout/stderr (EOF on the pipe) while the process itself stays alive. The runner must reach the process via the cancellation token + Job Object, not by pipe closure.
 """
 steps = [["vt", "run", "-r", "--cache", "daemon"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots/failure_kills_concurrent_cached_tasks.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots/failure_kills_concurrent_cached_tasks.md
@@ -1,8 +1,6 @@
 # failure_kills_concurrent_cached_tasks
 
-Same failure-cancellation scenario, but with `--cache` so execution goes through
-the piped stdio / fspy path (spawn_with_tracking) instead of the inherited-stdio
-path.
+Same failure-cancellation scenario, but with `--cache` so execution goes through the piped stdio / fspy path (spawn_with_tracking) instead of the inherited-stdio path.
 
 ## `vt run -r --cache test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots/failure_kills_concurrent_tasks.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots/failure_kills_concurrent_tasks.md
@@ -1,8 +1,6 @@
 # failure_kills_concurrent_tasks
 
-When one concurrent task fails, the sibling running under inherited stdio must
-be cancelled. Task a exits 1 after the shared barrier, task b hangs after it —
-completing without timeout proves cancellation killed b.
+When one concurrent task fails, the sibling running under inherited stdio must be cancelled. Task a exits 1 after the shared barrier, task b hangs after it — completing without timeout proves cancellation killed b.
 
 ## `vt run -r test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots/failure_kills_daemonized_concurrent_tasks.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots/failure_kills_daemonized_concurrent_tasks.md
@@ -1,8 +1,6 @@
 # failure_kills_daemonized_concurrent_tasks
 
-Cancellation must also kill a sibling that has daemonized — closing stdout/stderr
-(EOF on the pipe) while the process itself stays alive. The runner must reach
-the process via the cancellation token + Job Object, not by pipe closure.
+Cancellation must also kill a sibling that has daemonized — closing stdout/stderr (EOF on the pipe) while the process itself stays alive. The runner must reach the process via the cancellation token + Job Object, not by pipe closure.
 
 ## `vt run -r --cache daemon`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots/independent_tasks_run_concurrently.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/concurrent_execution/snapshots/independent_tasks_run_concurrently.md
@@ -1,8 +1,6 @@
 # independent_tasks_run_concurrently
 
-Two packages with no dependency relationship should run concurrently. Both tasks
-participate in a 2-way barrier, so sequential execution would hang forever and
-time out.
+Two packages with no dependency relationship should run concurrently. Both tasks participate in a 2-way barrier, so sequential execution would hang forever and time out.
 
 ## `vt run -r build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ctrl_c/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ctrl_c/snapshots.toml
@@ -34,8 +34,7 @@ steps = [
 [[e2e]]
 name = "ctrl_c_prevents_future_tasks"
 comment = """
-Ctrl+C while running sequentially (b depends on a) should terminate a and
-prevent b from being scheduled.
+Ctrl+C while running sequentially (b depends on a) should terminate a and prevent b from being scheduled.
 """
 steps = [
   { argv = [
@@ -53,8 +52,7 @@ steps = [
 [[e2e]]
 name = "ctrl_c_prevents_caching"
 comment = """
-A task interrupted by Ctrl+C must not populate the cache, even if it happens to
-exit 0 — the following run should be a cache miss, not a hit.
+A task interrupted by Ctrl+C must not populate the cache, even if it happens to exit 0 — the following run should be a cache miss, not a hit.
 """
 steps = [
   { argv = [

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ctrl_c/snapshots/ctrl_c_prevents_caching.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ctrl_c/snapshots/ctrl_c_prevents_caching.md
@@ -1,7 +1,6 @@
 # ctrl_c_prevents_caching
 
-A task interrupted by Ctrl+C must not populate the cache, even if it happens to
-exit 0 — the following run should be a cache miss, not a hit.
+A task interrupted by Ctrl+C must not populate the cache, even if it happens to exit 0 — the following run should be a cache miss, not a hit.
 
 ## `vt run @ctrl-c/a#dev`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ctrl_c/snapshots/ctrl_c_prevents_future_tasks.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ctrl_c/snapshots/ctrl_c_prevents_future_tasks.md
@@ -1,7 +1,6 @@
 # ctrl_c_prevents_future_tasks
 
-Ctrl+C while running sequentially (b depends on a) should terminate a and
-prevent b from being scheduled.
+Ctrl+C while running sequentially (b depends on a) should terminate a and prevent b from being scheduled.
 
 ## `vt run -r --no-cache dev`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit_codes/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit_codes/snapshots.toml
@@ -15,8 +15,7 @@ steps = [{ argv = ["vt", "run", "-r", "fail"], comment = "pkg-a fails, pkg-b is 
 [[e2e]]
 name = "dependency_failure_fast_fails_dependents"
 comment = """
-When a dependency fails under `-t`, dependents should be skipped rather than
-run anyway.
+When a dependency fails under `-t`, dependents should be skipped rather than run anyway.
 """
 cwd = "packages/pkg-b"
 steps = [{ argv = ["vt", "run", "-t", "check"], comment = "pkg-a fails, pkg-b is skipped" }]
@@ -24,8 +23,7 @@ steps = [{ argv = ["vt", "run", "-t", "check"], comment = "pkg-a fails, pkg-b is
 [[e2e]]
 name = "chained_command_with____stops_at_first_failure"
 comment = """
-In a `&&`-chained command, a non-zero exit from the first sub-command should
-short-circuit and skip the rest.
+In a `&&`-chained command, a non-zero exit from the first sub-command should short-circuit and skip the rest.
 """
 steps = [
   { argv = [

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit_codes/snapshots/chained_command_with____stops_at_first_failure.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit_codes/snapshots/chained_command_with____stops_at_first_failure.md
@@ -1,7 +1,6 @@
 # chained_command_with____stops_at_first_failure
 
-In a `&&`-chained command, a non-zero exit from the first sub-command should
-short-circuit and skip the rest.
+In a `&&`-chained command, a non-zero exit from the first sub-command should short-circuit and skip the rest.
 
 ## `vt run pkg-a#chained`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit_codes/snapshots/dependency_failure_fast_fails_dependents.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/exit_codes/snapshots/dependency_failure_fast_fails_dependents.md
@@ -1,7 +1,6 @@
 # dependency_failure_fast_fails_dependents
 
-When a dependency fails under `-t`, dependents should be skipped rather than
-run anyway.
+When a dependency fails under `-t`, dependents should be skipped rather than run anyway.
 
 ## `vt run -t check`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots.toml
@@ -1,47 +1,41 @@
 [[e2e]]
 name = "partial_match_warns_for_unmatched_filter"
 comment = """
-When some `--filter` flags match and one does not, the run should proceed and
-warn only for the unmatched filter.
+When some `--filter` flags match and one does not, the run should proceed and warn only for the unmatched filter.
 """
 steps = [["vt", "run", "--filter", "@test/app", "--filter", "nonexistent", "build"]]
 
 [[e2e]]
 name = "multiple_unmatched_filters_warn_individually"
 comment = """
-Each unmatched `--filter` should produce its own warning — warnings must not
-be collapsed into a single message.
+Each unmatched `--filter` should produce its own warning — warnings must not be collapsed into a single message.
 """
 steps = [["vt", "run", "--filter", "@test/app", "--filter", "nope1", "--filter", "nope2", "build"]]
 
 [[e2e]]
 name = "whitespace_split_filter_warns_for_unmatched_token"
 comment = """
-A whitespace-split `--filter` argument should warn about each of its individual
-unmatched tokens.
+A whitespace-split `--filter` argument should warn about each of its individual unmatched tokens.
 """
 steps = [["vt", "run", "--filter", "@test/app nope", "build"]]
 
 [[e2e]]
 name = "unmatched_exclusion_filter_does_not_warn"
 comment = """
-An exclusion filter (`!...`) that matches nothing should be silent; only
-unmatched inclusion filters warn.
+An exclusion filter (`!...`) that matches nothing should be silent; only unmatched inclusion filters warn.
 """
 steps = [["vt", "run", "--filter", "@test/app", "--filter", "!nonexistent", "build"]]
 
 [[e2e]]
 name = "unmatched_glob_filter_warns"
 comment = """
-A glob `--filter` that matches no packages should warn like any other
-unmatched inclusion filter.
+A glob `--filter` that matches no packages should warn like any other unmatched inclusion filter.
 """
 steps = [["vt", "run", "--filter", "@test/app", "--filter", "@nope/*", "build"]]
 
 [[e2e]]
 name = "unmatched_directory_filter_warns"
 comment = """
-A directory-style `--filter` (`./packages/...`) that points nowhere should
-warn just like an unmatched name filter.
+A directory-style `--filter` (`./packages/...`) that points nowhere should warn just like an unmatched name filter.
 """
 steps = [["vt", "run", "--filter", "@test/app", "--filter", "./packages/nope", "build"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/multiple_unmatched_filters_warn_individually.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/multiple_unmatched_filters_warn_individually.md
@@ -1,7 +1,6 @@
 # multiple_unmatched_filters_warn_individually
 
-Each unmatched `--filter` should produce its own warning — warnings must not
-be collapsed into a single message.
+Each unmatched `--filter` should produce its own warning — warnings must not be collapsed into a single message.
 
 ## `vt run --filter @test/app --filter nope1 --filter nope2 build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/partial_match_warns_for_unmatched_filter.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/partial_match_warns_for_unmatched_filter.md
@@ -1,7 +1,6 @@
 # partial_match_warns_for_unmatched_filter
 
-When some `--filter` flags match and one does not, the run should proceed and
-warn only for the unmatched filter.
+When some `--filter` flags match and one does not, the run should proceed and warn only for the unmatched filter.
 
 ## `vt run --filter @test/app --filter nonexistent build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/unmatched_directory_filter_warns.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/unmatched_directory_filter_warns.md
@@ -1,7 +1,6 @@
 # unmatched_directory_filter_warns
 
-A directory-style `--filter` (`./packages/...`) that points nowhere should
-warn just like an unmatched name filter.
+A directory-style `--filter` (`./packages/...`) that points nowhere should warn just like an unmatched name filter.
 
 ## `vt run --filter @test/app --filter ./packages/nope build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/unmatched_exclusion_filter_does_not_warn.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/unmatched_exclusion_filter_does_not_warn.md
@@ -1,7 +1,6 @@
 # unmatched_exclusion_filter_does_not_warn
 
-An exclusion filter (`!...`) that matches nothing should be silent; only
-unmatched inclusion filters warn.
+An exclusion filter (`!...`) that matches nothing should be silent; only unmatched inclusion filters warn.
 
 ## `vt run --filter @test/app --filter !nonexistent build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/unmatched_glob_filter_warns.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/unmatched_glob_filter_warns.md
@@ -1,7 +1,6 @@
 # unmatched_glob_filter_warns
 
-A glob `--filter` that matches no packages should warn like any other
-unmatched inclusion filter.
+A glob `--filter` that matches no packages should warn like any other unmatched inclusion filter.
 
 ## `vt run --filter @test/app --filter @nope/* build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/whitespace_split_filter_warns_for_unmatched_token.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/whitespace_split_filter_warns_for_unmatched_token.md
@@ -1,7 +1,6 @@
 # whitespace_split_filter_warns_for_unmatched_token
 
-A whitespace-split `--filter` argument should warn about each of its individual
-unmatched tokens.
+A whitespace-split `--filter` argument should warn about each of its individual unmatched tokens.
 
 ## `vt run --filter '@test/app nope' build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots.toml
@@ -1,8 +1,7 @@
 [[e2e]]
 name = "root_glob___matches_src_files"
 comment = """
-A root-package glob should match files under the package's own `src/` —
-modifying such a file invalidates the cache.
+A root-package glob should match files under the package's own `src/` — modifying such a file invalidates the cache.
 """
 steps = [
   ["vt", "run", "root-glob-test"],
@@ -15,8 +14,7 @@ steps = [
 [[e2e]]
 name = "root_glob___unmatched_directory"
 comment = """
-Modifying a file outside the glob pattern (e.g. `other/`) should leave the
-cache hit intact.
+Modifying a file outside the glob pattern (e.g. `other/`) should leave the cache hit intact.
 """
 steps = [
   ["vt", "run", "root-glob-test"],
@@ -29,8 +27,7 @@ steps = [
 [[e2e]]
 name = "root_glob___subpackage_path_unmatched_by_relative_glob"
 comment = """
-A relative glob anchored at the root package should not reach into
-`packages/<sub>/src/` — a subpackage file change stays a cache hit.
+A relative glob anchored at the root package should not reach into `packages/<sub>/src/` — a subpackage file change stays a cache hit.
 """
 steps = [
   ["vt", "run", "root-glob-test"],
@@ -43,8 +40,7 @@ steps = [
 [[e2e]]
 name = "root_glob_with_cwd___glob_relative_to_package_not_cwd"
 comment = """
-Even when the task declares a custom `cwd`, its glob stays anchored at the
-package root — `src/**` still matches `src/root.ts`.
+Even when the task declares a custom `cwd`, its glob stays anchored at the package root — `src/**` still matches `src/root.ts`.
 """
 steps = [
   ["vt", "run", "root-glob-with-cwd"],
@@ -70,8 +66,7 @@ steps = [
 [[e2e]]
 name = "subpackage_glob___unmatched_directory_in_subpackage"
 comment = """
-Changes to a sibling directory within the subpackage that the glob does not
-cover (e.g. `other/`) should leave the cache hit intact.
+Changes to a sibling directory within the subpackage that the glob does not cover (e.g. `other/`) should leave the cache hit intact.
 """
 steps = [
   ["vt", "run", "sub-pkg#sub-glob-test"],
@@ -84,8 +79,7 @@ steps = [
 [[e2e]]
 name = "subpackage_glob___root_path_unmatched_by_relative_glob"
 comment = """
-A subpackage-anchored relative glob should not reach up into the root
-package's `src/` — a root-package file change stays a cache hit.
+A subpackage-anchored relative glob should not reach up into the root package's `src/` — a root-package file change stays a cache hit.
 """
 steps = [
   ["vt", "run", "sub-pkg#sub-glob-test"],
@@ -98,8 +92,7 @@ steps = [
 [[e2e]]
 name = "subpackage_glob_with_cwd___glob_relative_to_package_not_cwd"
 comment = """
-A custom `cwd` on a subpackage task should not shift its glob base — `src/**`
-still resolves relative to the subpackage directory.
+A custom `cwd` on a subpackage task should not shift its glob base — `src/**` still resolves relative to the subpackage directory.
 """
 steps = [
   ["vt", "run", "sub-pkg#sub-glob-with-cwd"],

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/root_glob___matches_src_files.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/root_glob___matches_src_files.md
@@ -1,7 +1,6 @@
 # root_glob___matches_src_files
 
-A root-package glob should match files under the package's own `src/` —
-modifying such a file invalidates the cache.
+A root-package glob should match files under the package's own `src/` — modifying such a file invalidates the cache.
 
 ## `vt run root-glob-test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/root_glob___subpackage_path_unmatched_by_relative_glob.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/root_glob___subpackage_path_unmatched_by_relative_glob.md
@@ -1,7 +1,6 @@
 # root_glob___subpackage_path_unmatched_by_relative_glob
 
-A relative glob anchored at the root package should not reach into
-`packages/<sub>/src/` — a subpackage file change stays a cache hit.
+A relative glob anchored at the root package should not reach into `packages/<sub>/src/` — a subpackage file change stays a cache hit.
 
 ## `vt run root-glob-test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/root_glob___unmatched_directory.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/root_glob___unmatched_directory.md
@@ -1,7 +1,6 @@
 # root_glob___unmatched_directory
 
-Modifying a file outside the glob pattern (e.g. `other/`) should leave the
-cache hit intact.
+Modifying a file outside the glob pattern (e.g. `other/`) should leave the cache hit intact.
 
 ## `vt run root-glob-test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/root_glob_with_cwd___glob_relative_to_package_not_cwd.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/root_glob_with_cwd___glob_relative_to_package_not_cwd.md
@@ -1,7 +1,6 @@
 # root_glob_with_cwd___glob_relative_to_package_not_cwd
 
-Even when the task declares a custom `cwd`, its glob stays anchored at the
-package root — `src/**` still matches `src/root.ts`.
+Even when the task declares a custom `cwd`, its glob stays anchored at the package root — `src/**` still matches `src/root.ts`.
 
 ## `vt run root-glob-with-cwd`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/subpackage_glob___root_path_unmatched_by_relative_glob.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/subpackage_glob___root_path_unmatched_by_relative_glob.md
@@ -1,7 +1,6 @@
 # subpackage_glob___root_path_unmatched_by_relative_glob
 
-A subpackage-anchored relative glob should not reach up into the root
-package's `src/` — a root-package file change stays a cache hit.
+A subpackage-anchored relative glob should not reach up into the root package's `src/` — a root-package file change stays a cache hit.
 
 ## `vt run sub-pkg#sub-glob-test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/subpackage_glob___unmatched_directory_in_subpackage.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/subpackage_glob___unmatched_directory_in_subpackage.md
@@ -1,7 +1,6 @@
 # subpackage_glob___unmatched_directory_in_subpackage
 
-Changes to a sibling directory within the subpackage that the glob does not
-cover (e.g. `other/`) should leave the cache hit intact.
+Changes to a sibling directory within the subpackage that the glob does not cover (e.g. `other/`) should leave the cache hit intact.
 
 ## `vt run sub-pkg#sub-glob-test`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/subpackage_glob_with_cwd___glob_relative_to_package_not_cwd.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/glob_base_test/snapshots/subpackage_glob_with_cwd___glob_relative_to_package_not_cwd.md
@@ -1,7 +1,6 @@
 # subpackage_glob_with_cwd___glob_relative_to_package_not_cwd
 
-A custom `cwd` on a subpackage task should not shift its glob base — `src/**`
-still resolves relative to the subpackage directory.
+A custom `cwd` on a subpackage task should not shift its glob base — `src/**` still resolves relative to the subpackage directory.
 
 ## `vt run sub-pkg#sub-glob-with-cwd`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots.toml
@@ -1,40 +1,35 @@
 [[e2e]]
 name = "single_task__cache_off__grouped_output"
 comment = """
-Under `--log=grouped` with caching off, a single task's piped stdout/stderr
-should be printed as one grouped block; none of the fds should be TTYs.
+Under `--log=grouped` with caching off, a single task's piped stdout/stderr should be printed as one grouped block; none of the fds should be TTYs.
 """
 steps = [["vt", "run", "--log=grouped", "check-tty"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_off__grouped_output"
 comment = """
-Under `--log=grouped` with caching off, each task's output should be emitted
-as its own grouped block (one block per task, never interleaved).
+Under `--log=grouped` with caching off, each task's output should be emitted as its own grouped block (one block per task, never interleaved).
 """
 steps = [["vt", "run", "--log=grouped", "-r", "check-tty"]]
 
 [[e2e]]
 name = "single_task__cache_miss__grouped_output"
 comment = """
-On a cache miss, grouped mode should still pipe stdio and emit one block for
-the single task.
+On a cache miss, grouped mode should still pipe stdio and emit one block for the single task.
 """
 steps = [["vt", "run", "--log=grouped", "check-tty-cached"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_miss__grouped_output"
 comment = """
-On a cache miss across multiple tasks, grouped mode should emit one block
-per task with piped, non-TTY stdio.
+On a cache miss across multiple tasks, grouped mode should emit one block per task with piped, non-TTY stdio.
 """
 steps = [["vt", "run", "--log=grouped", "-r", "check-tty-cached"]]
 
 [[e2e]]
 name = "single_task__cache_hit__replayed"
 comment = """
-A cache-hit replay of a single task under grouped mode should reproduce the
-original grouped block from cached output.
+A cache-hit replay of a single task under grouped mode should reproduce the original grouped block from cached output.
 """
 steps = [
   [
@@ -54,8 +49,7 @@ steps = [
 [[e2e]]
 name = "multiple_tasks__cache_hit__replayed"
 comment = """
-Cache-hit replays for multiple tasks under grouped mode should each produce
-their own block, matching the original (non-replayed) output.
+Cache-hit replays for multiple tasks under grouped mode should each produce their own block, matching the original (non-replayed) output.
 """
 steps = [
   [
@@ -77,7 +71,6 @@ steps = [
 [[e2e]]
 name = "stdin_is_always_null"
 comment = """
-In grouped mode, task stdin is always `/dev/null` regardless of the parent's
-stdin — piping data in from outside must not reach the task.
+In grouped mode, task stdin is always `/dev/null` regardless of the parent's stdin — piping data in from outside must not reach the task.
 """
 steps = [["vtt", "pipe-stdin", "from-stdin", "--", "vt", "run", "--log=grouped", "read-stdin"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/multiple_tasks__cache_hit__replayed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/multiple_tasks__cache_hit__replayed.md
@@ -1,7 +1,6 @@
 # multiple_tasks__cache_hit__replayed
 
-Cache-hit replays for multiple tasks under grouped mode should each produce
-their own block, matching the original (non-replayed) output.
+Cache-hit replays for multiple tasks under grouped mode should each produce their own block, matching the original (non-replayed) output.
 
 ## `vt run --log=grouped -r check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/multiple_tasks__cache_miss__grouped_output.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/multiple_tasks__cache_miss__grouped_output.md
@@ -1,7 +1,6 @@
 # multiple_tasks__cache_miss__grouped_output
 
-On a cache miss across multiple tasks, grouped mode should emit one block
-per task with piped, non-TTY stdio.
+On a cache miss across multiple tasks, grouped mode should emit one block per task with piped, non-TTY stdio.
 
 ## `vt run --log=grouped -r check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/multiple_tasks__cache_off__grouped_output.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/multiple_tasks__cache_off__grouped_output.md
@@ -1,7 +1,6 @@
 # multiple_tasks__cache_off__grouped_output
 
-Under `--log=grouped` with caching off, each task's output should be emitted
-as its own grouped block (one block per task, never interleaved).
+Under `--log=grouped` with caching off, each task's output should be emitted as its own grouped block (one block per task, never interleaved).
 
 ## `vt run --log=grouped -r check-tty`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/single_task__cache_hit__replayed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/single_task__cache_hit__replayed.md
@@ -1,7 +1,6 @@
 # single_task__cache_hit__replayed
 
-A cache-hit replay of a single task under grouped mode should reproduce the
-original grouped block from cached output.
+A cache-hit replay of a single task under grouped mode should reproduce the original grouped block from cached output.
 
 ## `vt run --log=grouped check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/single_task__cache_miss__grouped_output.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/single_task__cache_miss__grouped_output.md
@@ -1,7 +1,6 @@
 # single_task__cache_miss__grouped_output
 
-On a cache miss, grouped mode should still pipe stdio and emit one block for
-the single task.
+On a cache miss, grouped mode should still pipe stdio and emit one block for the single task.
 
 ## `vt run --log=grouped check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/single_task__cache_off__grouped_output.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/single_task__cache_off__grouped_output.md
@@ -1,7 +1,6 @@
 # single_task__cache_off__grouped_output
 
-Under `--log=grouped` with caching off, a single task's piped stdout/stderr
-should be printed as one grouped block; none of the fds should be TTYs.
+Under `--log=grouped` with caching off, a single task's piped stdout/stderr should be printed as one grouped block; none of the fds should be TTYs.
 
 ## `vt run --log=grouped check-tty`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/stdin_is_always_null.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/grouped_stdio/snapshots/stdin_is_always_null.md
@@ -1,7 +1,6 @@
 # stdin_is_always_null
 
-In grouped mode, task stdin is always `/dev/null` regardless of the parent's
-stdin — piping data in from outside must not reach the task.
+In grouped mode, task stdin is always `/dev/null` regardless of the parent's stdin — piping data in from outside must not reach the task.
 
 ## `vtt pipe-stdin from-stdin -- vt run --log=grouped read-stdin`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots.toml
@@ -1,8 +1,7 @@
 [[e2e]]
 name = "positive_globs_only___cache_hit_on_second_run"
 comment = """
-With only positive globs (`src/**/*.ts`) and no file changes, a second run
-should be a cache hit.
+With only positive globs (`src/**/*.ts`) and no file changes, a second run should be a cache hit.
 """
 steps = [
   # First run - cache miss
@@ -28,8 +27,7 @@ steps = [
 [[e2e]]
 name = "positive_globs_only___hit_on_unmatched_file_change"
 comment = """
-Modifying a file outside the positive glob (e.g. under `test/`) should not
-invalidate the cache.
+Modifying a file outside the positive glob (e.g. under `test/`) should not invalidate the cache.
 """
 steps = [
   # Initial run
@@ -43,8 +41,7 @@ steps = [
 [[e2e]]
 name = "positive_globs___hit_on_read_but_unmatched_file"
 comment = """
-With only positive globs (no `auto`), files read at runtime but not matched
-by the glob should not be fingerprinted — inference is truly disabled.
+With only positive globs (no `auto`), files read at runtime but not matched by the glob should not be fingerprinted — inference is truly disabled.
 """
 steps = [
   # Initial run - reads both src/main.ts and src/utils.ts
@@ -58,8 +55,7 @@ steps = [
 [[e2e]]
 name = "positive_negative_globs___miss_on_non_excluded_file"
 comment = """
-A file matched by a positive glob and not by any negative glob should still
-invalidate the cache when modified.
+A file matched by a positive glob and not by any negative glob should still invalidate the cache when modified.
 """
 steps = [
   # Initial run
@@ -73,8 +69,7 @@ steps = [
 [[e2e]]
 name = "positive_negative_globs___hit_on_excluded_file"
 comment = """
-A file matched by the negative glob should be excluded from fingerprinting
-even if it also matches a positive glob.
+A file matched by the negative glob should be excluded from fingerprinting even if it also matches a positive glob.
 """
 steps = [
   # Initial run
@@ -88,8 +83,7 @@ steps = [
 [[e2e]]
 name = "auto_only___miss_on_inferred_file_change"
 comment = """
-With `auto: true`, files read by the command (via fspy) should be fingerprinted
-and a change to such a file should invalidate the cache.
+With `auto: true`, files read by the command (via fspy) should be fingerprinted and a change to such a file should invalidate the cache.
 """
 steps = [
   # Initial run - reads src/main.ts
@@ -103,8 +97,7 @@ steps = [
 [[e2e]]
 name = "auto_only___hit_on_non_inferred_file_change"
 comment = """
-With `auto: true`, a file never read by the command should not affect the
-cache, even if it sits next to files that are read.
+With `auto: true`, a file never read by the command should not affect the cache, even if it sits next to files that are read.
 """
 steps = [
   # Initial run - reads src/main.ts (NOT utils.ts)
@@ -118,8 +111,7 @@ steps = [
 [[e2e]]
 name = "auto_with_negative___hit_on_excluded_inferred_file"
 comment = """
-A negative glob should filter out inferred inputs — a `dist/**`-excluded file
-that the command happens to read should not invalidate the cache.
+A negative glob should filter out inferred inputs — a `dist/**`-excluded file that the command happens to read should not invalidate the cache.
 """
 steps = [
   # Initial run - reads both src/main.ts and dist/output.js
@@ -133,8 +125,7 @@ steps = [
 [[e2e]]
 name = "auto_with_negative___miss_on_non_excluded_inferred_file"
 comment = """
-With `auto: true` plus a negative glob, changes to inferred inputs outside
-the excluded range should still invalidate the cache.
+With `auto: true` plus a negative glob, changes to inferred inputs outside the excluded range should still invalidate the cache.
 """
 steps = [
   # Initial run
@@ -148,8 +139,7 @@ steps = [
 [[e2e]]
 name = "positive_auto_negative___miss_on_explicit_glob_file"
 comment = """
-When positive, `auto`, and negative globs are combined, modifying a file
-matched by the explicit positive glob should invalidate the cache.
+When positive, `auto`, and negative globs are combined, modifying a file matched by the explicit positive glob should invalidate the cache.
 """
 steps = [
   # Initial run
@@ -163,8 +153,7 @@ steps = [
 [[e2e]]
 name = "positive_auto_negative___miss_on_inferred_file"
 comment = """
-Under combined positive + `auto` + negative config, modifying a file that
-only the `auto` inference discovered should still invalidate the cache.
+Under combined positive + `auto` + negative config, modifying a file that only the `auto` inference discovered should still invalidate the cache.
 """
 steps = [
   # Initial run
@@ -178,8 +167,7 @@ steps = [
 [[e2e]]
 name = "positive_auto_negative___hit_on_excluded_file"
 comment = """
-Under combined positive + `auto` + negative config, a negative glob should
-still filter files contributed by either source.
+Under combined positive + `auto` + negative config, a negative glob should still filter files contributed by either source.
 """
 steps = [
   # Initial run
@@ -193,8 +181,7 @@ steps = [
 [[e2e]]
 name = "empty_input___hit_despite_file_changes"
 comment = """
-With `input: []`, no file changes should ever invalidate the cache — only
-command/env changes can.
+With `input: []`, no file changes should ever invalidate the cache — only command/env changes can.
 """
 steps = [
   # Initial run
@@ -208,8 +195,7 @@ steps = [
 [[e2e]]
 name = "empty_input___miss_on_command_change"
 comment = """
-Even with `input: []`, changing the task's command should still invalidate
-the cache.
+Even with `input: []`, changing the task's command should still invalidate the cache.
 """
 steps = [
   # Initial run
@@ -237,8 +223,7 @@ steps = [
 [[e2e]]
 name = "fspy_env___set_when_auto_inference_enabled"
 comment = """
-When auto-inference is enabled (input includes `{auto: true}`), the task
-process should see `FSPY=1` in its environment.
+When auto-inference is enabled (input includes `{auto: true}`), the task process should see `FSPY=1` in its environment.
 """
 steps = [
   # Run task with auto inference - should see FSPY=1
@@ -248,8 +233,7 @@ steps = [
 [[e2e]]
 name = "fspy_env___not_set_when_auto_inference_disabled"
 comment = """
-When auto-inference is disabled (explicit globs only), the task process
-should not see `FSPY` set.
+When auto-inference is disabled (explicit globs only), the task process should not see `FSPY` set.
 """
 steps = [
   # Run task without auto inference - should see (undefined)
@@ -259,8 +243,7 @@ steps = [
 [[e2e]]
 name = "folder_slash_input___miss_on_direct_and_nested_file_changes"
 comment = """
-A trailing-slash input (`src/`) should expand to `src/**`, so both direct
-and nested file changes under it invalidate the cache.
+A trailing-slash input (`src/`) should expand to `src/**`, so both direct and nested file changes under it invalidate the cache.
 """
 steps = [
   ["vt", "run", "folder-slash-input"],
@@ -280,8 +263,7 @@ steps = [
 [[e2e]]
 name = "folder_slash_input___hit_on_file_outside_directory"
 comment = """
-With a trailing-slash input (`src/`), files outside the directory should not
-be part of the fingerprint.
+With a trailing-slash input (`src/`), files outside the directory should not be part of the fingerprint.
 """
 steps = [
   ["vt", "run", "folder-slash-input"],
@@ -294,8 +276,7 @@ steps = [
 [[e2e]]
 name = "folder_input___hit_despite_file_changes_and_folder_deletion"
 comment = """
-A bare directory name as input (`src`) matches only the directory entry,
-not its contents — neither file edits nor folder deletion affect the cache.
+A bare directory name as input (`src`) matches only the directory entry, not its contents — neither file edits nor folder deletion affect the cache.
 """
 steps = [
   ["vt", "run", "folder-input"],

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/auto_only___hit_on_non_inferred_file_change.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/auto_only___hit_on_non_inferred_file_change.md
@@ -1,7 +1,6 @@
 # auto_only___hit_on_non_inferred_file_change
 
-With `auto: true`, a file never read by the command should not affect the
-cache, even if it sits next to files that are read.
+With `auto: true`, a file never read by the command should not affect the cache, even if it sits next to files that are read.
 
 ## `vt run auto-only`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/auto_only___miss_on_inferred_file_change.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/auto_only___miss_on_inferred_file_change.md
@@ -1,7 +1,6 @@
 # auto_only___miss_on_inferred_file_change
 
-With `auto: true`, files read by the command (via fspy) should be fingerprinted
-and a change to such a file should invalidate the cache.
+With `auto: true`, files read by the command (via fspy) should be fingerprinted and a change to such a file should invalidate the cache.
 
 ## `vt run auto-only`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/auto_with_negative___hit_on_excluded_inferred_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/auto_with_negative___hit_on_excluded_inferred_file.md
@@ -1,7 +1,6 @@
 # auto_with_negative___hit_on_excluded_inferred_file
 
-A negative glob should filter out inferred inputs — a `dist/**`-excluded file
-that the command happens to read should not invalidate the cache.
+A negative glob should filter out inferred inputs — a `dist/**`-excluded file that the command happens to read should not invalidate the cache.
 
 ## `vt run auto-with-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/auto_with_negative___miss_on_non_excluded_inferred_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/auto_with_negative___miss_on_non_excluded_inferred_file.md
@@ -1,7 +1,6 @@
 # auto_with_negative___miss_on_non_excluded_inferred_file
 
-With `auto: true` plus a negative glob, changes to inferred inputs outside
-the excluded range should still invalidate the cache.
+With `auto: true` plus a negative glob, changes to inferred inputs outside the excluded range should still invalidate the cache.
 
 ## `vt run auto-with-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/empty_input___hit_despite_file_changes.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/empty_input___hit_despite_file_changes.md
@@ -1,7 +1,6 @@
 # empty_input___hit_despite_file_changes
 
-With `input: []`, no file changes should ever invalidate the cache — only
-command/env changes can.
+With `input: []`, no file changes should ever invalidate the cache — only command/env changes can.
 
 ## `vt run empty-inputs`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/empty_input___miss_on_command_change.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/empty_input___miss_on_command_change.md
@@ -1,7 +1,6 @@
 # empty_input___miss_on_command_change
 
-Even with `input: []`, changing the task's command should still invalidate
-the cache.
+Even with `input: []`, changing the task's command should still invalidate the cache.
 
 ## `vt run empty-inputs`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/folder_input___hit_despite_file_changes_and_folder_deletion.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/folder_input___hit_despite_file_changes_and_folder_deletion.md
@@ -1,7 +1,6 @@
 # folder_input___hit_despite_file_changes_and_folder_deletion
 
-A bare directory name as input (`src`) matches only the directory entry,
-not its contents — neither file edits nor folder deletion affect the cache.
+A bare directory name as input (`src`) matches only the directory entry, not its contents — neither file edits nor folder deletion affect the cache.
 
 ## `vt run folder-input`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/folder_slash_input___hit_on_file_outside_directory.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/folder_slash_input___hit_on_file_outside_directory.md
@@ -1,7 +1,6 @@
 # folder_slash_input___hit_on_file_outside_directory
 
-With a trailing-slash input (`src/`), files outside the directory should not
-be part of the fingerprint.
+With a trailing-slash input (`src/`), files outside the directory should not be part of the fingerprint.
 
 ## `vt run folder-slash-input`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/folder_slash_input___miss_on_direct_and_nested_file_changes.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/folder_slash_input___miss_on_direct_and_nested_file_changes.md
@@ -1,7 +1,6 @@
 # folder_slash_input___miss_on_direct_and_nested_file_changes
 
-A trailing-slash input (`src/`) should expand to `src/**`, so both direct
-and nested file changes under it invalidate the cache.
+A trailing-slash input (`src/`) should expand to `src/**`, so both direct and nested file changes under it invalidate the cache.
 
 ## `vt run folder-slash-input`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/fspy_env___not_set_when_auto_inference_disabled.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/fspy_env___not_set_when_auto_inference_disabled.md
@@ -1,7 +1,6 @@
 # fspy_env___not_set_when_auto_inference_disabled
 
-When auto-inference is disabled (explicit globs only), the task process
-should not see `FSPY` set.
+When auto-inference is disabled (explicit globs only), the task process should not see `FSPY` set.
 
 ## `vt run check-fspy-env-without-auto`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/fspy_env___set_when_auto_inference_enabled.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/fspy_env___set_when_auto_inference_enabled.md
@@ -1,7 +1,6 @@
 # fspy_env___set_when_auto_inference_enabled
 
-When auto-inference is enabled (input includes `{auto: true}`), the task
-process should see `FSPY=1` in its environment.
+When auto-inference is enabled (input includes `{auto: true}`), the task process should see `FSPY=1` in its environment.
 
 ## `vt run check-fspy-env-with-auto`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_auto_negative___hit_on_excluded_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_auto_negative___hit_on_excluded_file.md
@@ -1,7 +1,6 @@
 # positive_auto_negative___hit_on_excluded_file
 
-Under combined positive + `auto` + negative config, a negative glob should
-still filter files contributed by either source.
+Under combined positive + `auto` + negative config, a negative glob should still filter files contributed by either source.
 
 ## `vt run positive-auto-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_auto_negative___miss_on_explicit_glob_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_auto_negative___miss_on_explicit_glob_file.md
@@ -1,7 +1,6 @@
 # positive_auto_negative___miss_on_explicit_glob_file
 
-When positive, `auto`, and negative globs are combined, modifying a file
-matched by the explicit positive glob should invalidate the cache.
+When positive, `auto`, and negative globs are combined, modifying a file matched by the explicit positive glob should invalidate the cache.
 
 ## `vt run positive-auto-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_auto_negative___miss_on_inferred_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_auto_negative___miss_on_inferred_file.md
@@ -1,7 +1,6 @@
 # positive_auto_negative___miss_on_inferred_file
 
-Under combined positive + `auto` + negative config, modifying a file that
-only the `auto` inference discovered should still invalidate the cache.
+Under combined positive + `auto` + negative config, modifying a file that only the `auto` inference discovered should still invalidate the cache.
 
 ## `vt run positive-auto-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_globs___hit_on_read_but_unmatched_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_globs___hit_on_read_but_unmatched_file.md
@@ -1,7 +1,6 @@
 # positive_globs___hit_on_read_but_unmatched_file
 
-With only positive globs (no `auto`), files read at runtime but not matched
-by the glob should not be fingerprinted — inference is truly disabled.
+With only positive globs (no `auto`), files read at runtime but not matched by the glob should not be fingerprinted — inference is truly disabled.
 
 ## `vt run positive-globs-reads-unmatched`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_globs_only___cache_hit_on_second_run.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_globs_only___cache_hit_on_second_run.md
@@ -1,7 +1,6 @@
 # positive_globs_only___cache_hit_on_second_run
 
-With only positive globs (`src/**/*.ts`) and no file changes, a second run
-should be a cache hit.
+With only positive globs (`src/**/*.ts`) and no file changes, a second run should be a cache hit.
 
 ## `vt run positive-globs-only`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_globs_only___hit_on_unmatched_file_change.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_globs_only___hit_on_unmatched_file_change.md
@@ -1,7 +1,6 @@
 # positive_globs_only___hit_on_unmatched_file_change
 
-Modifying a file outside the positive glob (e.g. under `test/`) should not
-invalidate the cache.
+Modifying a file outside the positive glob (e.g. under `test/`) should not invalidate the cache.
 
 ## `vt run positive-globs-only`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_negative_globs___hit_on_excluded_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_negative_globs___hit_on_excluded_file.md
@@ -1,7 +1,6 @@
 # positive_negative_globs___hit_on_excluded_file
 
-A file matched by the negative glob should be excluded from fingerprinting
-even if it also matches a positive glob.
+A file matched by the negative glob should be excluded from fingerprinting even if it also matches a positive glob.
 
 ## `vt run positive-negative-globs`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_negative_globs___miss_on_non_excluded_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/positive_negative_globs___miss_on_non_excluded_file.md
@@ -1,7 +1,6 @@
 # positive_negative_globs___miss_on_non_excluded_file
 
-A file matched by a positive glob and not by any negative glob should still
-invalidate the cache when modified.
+A file matched by a positive glob and not by any negative glob should still invalidate the cache when modified.
 
 ## `vt run positive-negative-globs`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_glob_meta_in_path/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_glob_meta_in_path/snapshots.toml
@@ -1,9 +1,7 @@
 [[e2e]]
 name = "cache_hit_then_miss_on_file_change"
 comment = """
-Test that glob meta characters in package paths are correctly escaped by wax::escape.
-Without escaping, "packages/[lib]/src/**/*.ts" would interpret [lib] as a character
-class matching 'l', 'i', or 'b' instead of the literal directory name.
+Test that glob meta characters in package paths are correctly escaped by wax::escape. Without escaping, "packages/[lib]/src/**/*.ts" would interpret [lib] as a character class matching 'l', 'i', or 'b' instead of the literal directory name.
 """
 steps = [
   [

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_glob_meta_in_path/snapshots/cache_hit_then_miss_on_file_change.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_glob_meta_in_path/snapshots/cache_hit_then_miss_on_file_change.md
@@ -1,8 +1,6 @@
 # cache_hit_then_miss_on_file_change
 
-Test that glob meta characters in package paths are correctly escaped by wax::escape.
-Without escaping, "packages/[lib]/src/**/*.ts" would interpret [lib] as a character
-class matching 'l', 'i', or 'b' instead of the literal directory name.
+Test that glob meta characters in package paths are correctly escaped by wax::escape. Without escaping, "packages/[lib]/src/**/*.ts" would interpret [lib] as a character class matching 'l', 'i', or 'b' instead of the literal directory name.
 
 ## `vt run [lib]#build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots.toml
@@ -1,10 +1,7 @@
 [[e2e]]
 name = "subpackage_auto_with_negative___hit_on_excluded_inferred_file"
 comment = """
-A subpackage's `!dist/**` exclusion should apply package-relative, not
-workspace-relative — modifying the subpackage's own `dist/` file stays a
-cache hit. (Regression: the exclusion used to resolve against the workspace
-root.)
+A subpackage's `!dist/**` exclusion should apply package-relative, not workspace-relative — modifying the subpackage's own `dist/` file stays a cache hit. (Regression: the exclusion used to resolve against the workspace root.)
 """
 steps = [
   # First run - reads both src/main.ts and dist/output.js
@@ -18,8 +15,7 @@ steps = [
 [[e2e]]
 name = "subpackage_auto_with_negative___miss_on_non_excluded_inferred_file"
 comment = """
-In a subpackage with `auto: true` plus `!dist/**`, changes to inferred inputs
-outside `dist/` should still invalidate the cache.
+In a subpackage with `auto: true` plus `!dist/**`, changes to inferred inputs outside `dist/` should still invalidate the cache.
 """
 steps = [
   # First run
@@ -33,8 +29,7 @@ steps = [
 [[e2e]]
 name = "dotdot_positive_glob___miss_on_sibling_file_change"
 comment = """
-A `../` positive glob should reach into sibling packages; modifying a matched
-sibling file should invalidate the cache.
+A `../` positive glob should reach into sibling packages; modifying a matched sibling file should invalidate the cache.
 """
 steps = [
   ["vt", "run", "sub-pkg#dotdot-positive"],
@@ -47,8 +42,7 @@ steps = [
 [[e2e]]
 name = "dotdot_positive_glob___hit_on_unmatched_file_change"
 comment = """
-A `../` positive glob should only match the paths it names — sibling files
-outside the glob (e.g. sibling `dist/`) should not affect the cache.
+A `../` positive glob should only match the paths it names — sibling files outside the glob (e.g. sibling `dist/`) should not affect the cache.
 """
 steps = [
   ["vt", "run", "sub-pkg#dotdot-positive"],
@@ -61,8 +55,7 @@ steps = [
 [[e2e]]
 name = "dotdot_positive_negative___miss_on_non_excluded_sibling_file"
 comment = """
-With `../shared/**` plus `!../shared/dist/**`, modifying a sibling file
-outside the exclusion should invalidate the cache.
+With `../shared/**` plus `!../shared/dist/**`, modifying a sibling file outside the exclusion should invalidate the cache.
 """
 steps = [
   ["vt", "run", "sub-pkg#dotdot-positive-negative"],
@@ -75,8 +68,7 @@ steps = [
 [[e2e]]
 name = "dotdot_positive_negative___hit_on_excluded_sibling_file"
 comment = """
-A `../`-prefixed negative glob should correctly exclude files in the sibling
-package's `dist/` directory.
+A `../`-prefixed negative glob should correctly exclude files in the sibling package's `dist/` directory.
 """
 steps = [
   ["vt", "run", "sub-pkg#dotdot-positive-negative"],
@@ -89,8 +81,7 @@ steps = [
 [[e2e]]
 name = "dotdot_auto_negative___hit_on_excluded_sibling_inferred_file"
 comment = """
-A `!../shared/dist/**` negative glob should filter inferred reads that land
-in the sibling package's `dist/` directory.
+A `!../shared/dist/**` negative glob should filter inferred reads that land in the sibling package's `dist/` directory.
 """
 steps = [
   ["vt", "run", "sub-pkg#dotdot-auto-negative"],
@@ -103,8 +94,7 @@ steps = [
 [[e2e]]
 name = "dotdot_auto_negative___miss_on_non_excluded_sibling_inferred_file"
 comment = """
-Under `auto: true` plus a `../` negative glob, inferred reads from sibling
-files outside the exclusion should still invalidate the cache.
+Under `auto: true` plus a `../` negative glob, inferred reads from sibling files outside the exclusion should still invalidate the cache.
 """
 steps = [
   ["vt", "run", "sub-pkg#dotdot-auto-negative"],

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_auto_negative___hit_on_excluded_sibling_inferred_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_auto_negative___hit_on_excluded_sibling_inferred_file.md
@@ -1,7 +1,6 @@
 # dotdot_auto_negative___hit_on_excluded_sibling_inferred_file
 
-A `!../shared/dist/**` negative glob should filter inferred reads that land
-in the sibling package's `dist/` directory.
+A `!../shared/dist/**` negative glob should filter inferred reads that land in the sibling package's `dist/` directory.
 
 ## `vt run sub-pkg#dotdot-auto-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_auto_negative___miss_on_non_excluded_sibling_inferred_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_auto_negative___miss_on_non_excluded_sibling_inferred_file.md
@@ -1,7 +1,6 @@
 # dotdot_auto_negative___miss_on_non_excluded_sibling_inferred_file
 
-Under `auto: true` plus a `../` negative glob, inferred reads from sibling
-files outside the exclusion should still invalidate the cache.
+Under `auto: true` plus a `../` negative glob, inferred reads from sibling files outside the exclusion should still invalidate the cache.
 
 ## `vt run sub-pkg#dotdot-auto-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_positive_glob___hit_on_unmatched_file_change.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_positive_glob___hit_on_unmatched_file_change.md
@@ -1,7 +1,6 @@
 # dotdot_positive_glob___hit_on_unmatched_file_change
 
-A `../` positive glob should only match the paths it names — sibling files
-outside the glob (e.g. sibling `dist/`) should not affect the cache.
+A `../` positive glob should only match the paths it names — sibling files outside the glob (e.g. sibling `dist/`) should not affect the cache.
 
 ## `vt run sub-pkg#dotdot-positive`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_positive_glob___miss_on_sibling_file_change.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_positive_glob___miss_on_sibling_file_change.md
@@ -1,7 +1,6 @@
 # dotdot_positive_glob___miss_on_sibling_file_change
 
-A `../` positive glob should reach into sibling packages; modifying a matched
-sibling file should invalidate the cache.
+A `../` positive glob should reach into sibling packages; modifying a matched sibling file should invalidate the cache.
 
 ## `vt run sub-pkg#dotdot-positive`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_positive_negative___hit_on_excluded_sibling_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_positive_negative___hit_on_excluded_sibling_file.md
@@ -1,7 +1,6 @@
 # dotdot_positive_negative___hit_on_excluded_sibling_file
 
-A `../`-prefixed negative glob should correctly exclude files in the sibling
-package's `dist/` directory.
+A `../`-prefixed negative glob should correctly exclude files in the sibling package's `dist/` directory.
 
 ## `vt run sub-pkg#dotdot-positive-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_positive_negative___miss_on_non_excluded_sibling_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/dotdot_positive_negative___miss_on_non_excluded_sibling_file.md
@@ -1,7 +1,6 @@
 # dotdot_positive_negative___miss_on_non_excluded_sibling_file
 
-With `../shared/**` plus `!../shared/dist/**`, modifying a sibling file
-outside the exclusion should invalidate the cache.
+With `../shared/**` plus `!../shared/dist/**`, modifying a sibling file outside the exclusion should invalidate the cache.
 
 ## `vt run sub-pkg#dotdot-positive-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/subpackage_auto_with_negative___hit_on_excluded_inferred_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/subpackage_auto_with_negative___hit_on_excluded_inferred_file.md
@@ -1,9 +1,6 @@
 # subpackage_auto_with_negative___hit_on_excluded_inferred_file
 
-A subpackage's `!dist/**` exclusion should apply package-relative, not
-workspace-relative — modifying the subpackage's own `dist/` file stays a
-cache hit. (Regression: the exclusion used to resolve against the workspace
-root.)
+A subpackage's `!dist/**` exclusion should apply package-relative, not workspace-relative — modifying the subpackage's own `dist/` file stays a cache hit. (Regression: the exclusion used to resolve against the workspace root.)
 
 ## `vt run sub-pkg#auto-with-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/subpackage_auto_with_negative___miss_on_non_excluded_inferred_file.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_negative_glob_subpackage/snapshots/subpackage_auto_with_negative___miss_on_non_excluded_inferred_file.md
@@ -1,7 +1,6 @@
 # subpackage_auto_with_negative___miss_on_non_excluded_inferred_file
 
-In a subpackage with `auto: true` plus `!dist/**`, changes to inferred inputs
-outside `dist/` should still invalidate the cache.
+In a subpackage with `auto: true` plus `!dist/**`, changes to inferred inputs outside `dist/` should still invalidate the cache.
 
 ## `vt run sub-pkg#auto-with-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots.toml
@@ -1,9 +1,7 @@
 [[e2e]]
 name = "single_read_write_task_shows_not_cached_message"
 comment = """
-A single task that reads and writes the same file (fspy sees both ops)
-should be flagged as "not cached because it modified its input" in the
-compact summary.
+A single task that reads and writes the same file (fspy sees both ops) should be flagged as "not cached because it modified its input" in the compact summary.
 """
 cwd = "packages/rw-pkg"
 steps = [["vt", "run", "task"], ["vt", "run", "task"]]
@@ -11,16 +9,14 @@ steps = [["vt", "run", "task"], ["vt", "run", "task"]]
 [[e2e]]
 name = "multi_task_with_read_write_shows_not_cached_in_summary"
 comment = """
-In a multi-task (`-r`) run, tasks with a read-write overlap should appear in
-the compact summary stats alongside an `InputModified` notice.
+In a multi-task (`-r`) run, tasks with a read-write overlap should appear in the compact summary stats alongside an `InputModified` notice.
 """
 steps = [["vt", "run", "-r", "task"], ["vt", "run", "-r", "task"]]
 
 [[e2e]]
 name = "verbose_read_write_task_shows_path_in_full_summary"
 comment = """
-Under `-v`, the full summary should list the exact overlapping path that
-caused the task to skip caching.
+Under `-v`, the full summary should list the exact overlapping path that caused the task to skip caching.
 """
 cwd = "packages/rw-pkg"
 steps = [["vt", "run", "-v", "task"]]
@@ -28,9 +24,7 @@ steps = [["vt", "run", "-v", "task"]]
 [[e2e]]
 name = "single_O_RDWR_open_is_not_cached"
 comment = """
-Opening a single file with `O_RDWR` (e.g. `touch` keeping the file) should
-count as a read-write overlap and prevent caching, just like separate
-read+write syscalls.
+Opening a single file with `O_RDWR` (e.g. `touch` keeping the file) should count as a read-write overlap and prevent caching, just like separate read+write syscalls.
 """
 cwd = "packages/touch-pkg"
 steps = [["vt", "run", "task"], ["vt", "run", "task"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots/multi_task_with_read_write_shows_not_cached_in_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots/multi_task_with_read_write_shows_not_cached_in_summary.md
@@ -1,7 +1,6 @@
 # multi_task_with_read_write_shows_not_cached_in_summary
 
-In a multi-task (`-r`) run, tasks with a read-write overlap should appear in
-the compact summary stats alongside an `InputModified` notice.
+In a multi-task (`-r`) run, tasks with a read-write overlap should appear in the compact summary stats alongside an `InputModified` notice.
 
 ## `vt run -r task`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots/single_O_RDWR_open_is_not_cached.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots/single_O_RDWR_open_is_not_cached.md
@@ -1,8 +1,6 @@
 # single_O_RDWR_open_is_not_cached
 
-Opening a single file with `O_RDWR` (e.g. `touch` keeping the file) should
-count as a read-write overlap and prevent caching, just like separate
-read+write syscalls.
+Opening a single file with `O_RDWR` (e.g. `touch` keeping the file) should count as a read-write overlap and prevent caching, just like separate read+write syscalls.
 
 ## `vt run task`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots/single_read_write_task_shows_not_cached_message.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots/single_read_write_task_shows_not_cached_message.md
@@ -1,8 +1,6 @@
 # single_read_write_task_shows_not_cached_message
 
-A single task that reads and writes the same file (fspy sees both ops)
-should be flagged as "not cached because it modified its input" in the
-compact summary.
+A single task that reads and writes the same file (fspy sees both ops) should be flagged as "not cached because it modified its input" in the compact summary.
 
 ## `vt run task`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots/verbose_read_write_task_shows_path_in_full_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/snapshots/verbose_read_write_task_shows_path_in_full_summary.md
@@ -1,7 +1,6 @@
 # verbose_read_write_task_shows_path_in_full_summary
 
-Under `-v`, the full summary should list the exact overlapping path that
-caused the task to skip caching.
+Under `-v`, the full summary should list the exact overlapping path that caused the task to skip caching.
 
 ## `vt run -v task`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots.toml
@@ -1,63 +1,55 @@
 [[e2e]]
 name = "single_task__cache_off__inherits_stdio"
 comment = """
-In interleaved mode with caching off, a single task should inherit stdio from
-the parent — all fds should be TTYs.
+In interleaved mode with caching off, a single task should inherit stdio from the parent — all fds should be TTYs.
 """
 steps = [["vt", "run", "check-tty"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_off__inherit_stdio"
 comment = """
-In interleaved mode with caching off, multiple tasks under `-r` should each
-inherit stdio (TTY-preserving behavior applies per task regardless of count).
+In interleaved mode with caching off, multiple tasks under `-r` should each inherit stdio (TTY-preserving behavior applies per task regardless of count).
 """
 steps = [["vt", "run", "-r", "check-tty"]]
 
 [[e2e]]
 name = "single_task__cache_miss__piped_stdio"
 comment = """
-On a cache miss in interleaved mode, stdio must be piped (not a TTY) so that
-output can be captured for future replay.
+On a cache miss in interleaved mode, stdio must be piped (not a TTY) so that output can be captured for future replay.
 """
 steps = [["vt", "run", "check-tty-cached"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_miss__piped_stdio"
 comment = """
-Across multiple tasks on a cache miss, each one should still see piped
-(non-TTY) stdio for output capture.
+Across multiple tasks on a cache miss, each one should still see piped (non-TTY) stdio for output capture.
 """
 steps = [["vt", "run", "-r", "check-tty-cached"]]
 
 [[e2e]]
 name = "single_task__cache_hit__replayed"
 comment = """
-A cache-hit second run should replay the previously captured output verbatim
-instead of re-executing the task.
+A cache-hit second run should replay the previously captured output verbatim instead of re-executing the task.
 """
 steps = [["vt", "run", "check-tty-cached"], ["vt", "run", "check-tty-cached"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_hit__replayed"
 comment = """
-Across multiple tasks, the second run should be all cache hits with each
-task's captured output replayed.
+Across multiple tasks, the second run should be all cache hits with each task's captured output replayed.
 """
 steps = [["vt", "run", "-r", "check-tty-cached"], ["vt", "run", "-r", "check-tty-cached"]]
 
 [[e2e]]
 name = "cache_off_inherits_stdin"
 comment = """
-With caching off, stdin piped into `vp run` should flow through to the task
-process.
+With caching off, stdin piped into `vp run` should flow through to the task process.
 """
 steps = [["vtt", "pipe-stdin", "from-stdin", "--", "vt", "run", "read-stdin"]]
 
 [[e2e]]
 name = "cache_on_gets_null_stdin"
 comment = """
-With caching on, task stdin should be replaced with `/dev/null` — piping data
-in from outside must not reach the task.
+With caching on, task stdin should be replaced with `/dev/null` — piping data in from outside must not reach the task.
 """
 steps = [["vtt", "pipe-stdin", "from-stdin", "--", "vt", "run", "read-stdin-cached"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/cache_off_inherits_stdin.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/cache_off_inherits_stdin.md
@@ -1,7 +1,6 @@
 # cache_off_inherits_stdin
 
-With caching off, stdin piped into `vp run` should flow through to the task
-process.
+With caching off, stdin piped into `vp run` should flow through to the task process.
 
 ## `vtt pipe-stdin from-stdin -- vt run read-stdin`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/cache_on_gets_null_stdin.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/cache_on_gets_null_stdin.md
@@ -1,7 +1,6 @@
 # cache_on_gets_null_stdin
 
-With caching on, task stdin should be replaced with `/dev/null` — piping data
-in from outside must not reach the task.
+With caching on, task stdin should be replaced with `/dev/null` — piping data in from outside must not reach the task.
 
 ## `vtt pipe-stdin from-stdin -- vt run read-stdin-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/multiple_tasks__cache_hit__replayed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/multiple_tasks__cache_hit__replayed.md
@@ -1,7 +1,6 @@
 # multiple_tasks__cache_hit__replayed
 
-Across multiple tasks, the second run should be all cache hits with each
-task's captured output replayed.
+Across multiple tasks, the second run should be all cache hits with each task's captured output replayed.
 
 ## `vt run -r check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/multiple_tasks__cache_miss__piped_stdio.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/multiple_tasks__cache_miss__piped_stdio.md
@@ -1,7 +1,6 @@
 # multiple_tasks__cache_miss__piped_stdio
 
-Across multiple tasks on a cache miss, each one should still see piped
-(non-TTY) stdio for output capture.
+Across multiple tasks on a cache miss, each one should still see piped (non-TTY) stdio for output capture.
 
 ## `vt run -r check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/multiple_tasks__cache_off__inherit_stdio.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/multiple_tasks__cache_off__inherit_stdio.md
@@ -1,7 +1,6 @@
 # multiple_tasks__cache_off__inherit_stdio
 
-In interleaved mode with caching off, multiple tasks under `-r` should each
-inherit stdio (TTY-preserving behavior applies per task regardless of count).
+In interleaved mode with caching off, multiple tasks under `-r` should each inherit stdio (TTY-preserving behavior applies per task regardless of count).
 
 ## `vt run -r check-tty`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/single_task__cache_hit__replayed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/single_task__cache_hit__replayed.md
@@ -1,7 +1,6 @@
 # single_task__cache_hit__replayed
 
-A cache-hit second run should replay the previously captured output verbatim
-instead of re-executing the task.
+A cache-hit second run should replay the previously captured output verbatim instead of re-executing the task.
 
 ## `vt run check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/single_task__cache_miss__piped_stdio.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/single_task__cache_miss__piped_stdio.md
@@ -1,7 +1,6 @@
 # single_task__cache_miss__piped_stdio
 
-On a cache miss in interleaved mode, stdio must be piped (not a TTY) so that
-output can be captured for future replay.
+On a cache miss in interleaved mode, stdio must be piped (not a TTY) so that output can be captured for future replay.
 
 ## `vt run check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/single_task__cache_off__inherits_stdio.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/interleaved_stdio/snapshots/single_task__cache_off__inherits_stdio.md
@@ -1,7 +1,6 @@
 # single_task__cache_off__inherits_stdio
 
-In interleaved mode with caching off, a single task should inherit stdio from
-the parent — all fds should be TTYs.
+In interleaved mode with caching off, a single task should inherit stdio from the parent — all fds should be TTYs.
 
 ## `vt run check-tty`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots.toml
@@ -1,40 +1,35 @@
 [[e2e]]
 name = "single_task__cache_off__piped_stdio"
 comment = """
-Under `--log=labeled` with caching off, a single task's stdio should be piped
-through the line-prefixing writer (not a TTY).
+Under `--log=labeled` with caching off, a single task's stdio should be piped through the line-prefixing writer (not a TTY).
 """
 steps = [["vt", "run", "--log=labeled", "check-tty"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_off__piped_stdio"
 comment = """
-Under `--log=labeled` with caching off, multiple tasks should each get piped
-stdio and each line should be prefixed with `[pkg#task]`.
+Under `--log=labeled` with caching off, multiple tasks should each get piped stdio and each line should be prefixed with `[pkg#task]`.
 """
 steps = [["vt", "run", "--log=labeled", "-r", "check-tty"]]
 
 [[e2e]]
 name = "single_task__cache_miss__piped_stdio"
 comment = """
-On a cache miss for a single task, labeled mode should still pipe stdio and
-prefix output lines.
+On a cache miss for a single task, labeled mode should still pipe stdio and prefix output lines.
 """
 steps = [["vt", "run", "--log=labeled", "check-tty-cached"]]
 
 [[e2e]]
 name = "multiple_tasks__cache_miss__piped_stdio"
 comment = """
-On a cache miss across multiple tasks, each task's piped output should be
-individually prefixed in labeled mode.
+On a cache miss across multiple tasks, each task's piped output should be individually prefixed in labeled mode.
 """
 steps = [["vt", "run", "--log=labeled", "-r", "check-tty-cached"]]
 
 [[e2e]]
 name = "single_task__cache_hit__replayed"
 comment = """
-A cache-hit replay of a single task under labeled mode should reproduce the
-labeled output from cached data.
+A cache-hit replay of a single task under labeled mode should reproduce the labeled output from cached data.
 """
 steps = [
   [
@@ -54,8 +49,7 @@ steps = [
 [[e2e]]
 name = "multiple_tasks__cache_hit__replayed"
 comment = """
-A cache-hit replay across multiple tasks under labeled mode should reproduce
-each task's labeled output.
+A cache-hit replay across multiple tasks under labeled mode should reproduce each task's labeled output.
 """
 steps = [
   [
@@ -77,7 +71,6 @@ steps = [
 [[e2e]]
 name = "stdin_is_always_null"
 comment = """
-In labeled mode, task stdin is always `/dev/null` regardless of the parent's
-stdin — piping data in from outside must not reach the task.
+In labeled mode, task stdin is always `/dev/null` regardless of the parent's stdin — piping data in from outside must not reach the task.
 """
 steps = [["vtt", "pipe-stdin", "from-stdin", "--", "vt", "run", "--log=labeled", "read-stdin"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/multiple_tasks__cache_hit__replayed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/multiple_tasks__cache_hit__replayed.md
@@ -1,7 +1,6 @@
 # multiple_tasks__cache_hit__replayed
 
-A cache-hit replay across multiple tasks under labeled mode should reproduce
-each task's labeled output.
+A cache-hit replay across multiple tasks under labeled mode should reproduce each task's labeled output.
 
 ## `vt run --log=labeled -r check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/multiple_tasks__cache_miss__piped_stdio.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/multiple_tasks__cache_miss__piped_stdio.md
@@ -1,7 +1,6 @@
 # multiple_tasks__cache_miss__piped_stdio
 
-On a cache miss across multiple tasks, each task's piped output should be
-individually prefixed in labeled mode.
+On a cache miss across multiple tasks, each task's piped output should be individually prefixed in labeled mode.
 
 ## `vt run --log=labeled -r check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/multiple_tasks__cache_off__piped_stdio.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/multiple_tasks__cache_off__piped_stdio.md
@@ -1,7 +1,6 @@
 # multiple_tasks__cache_off__piped_stdio
 
-Under `--log=labeled` with caching off, multiple tasks should each get piped
-stdio and each line should be prefixed with `[pkg#task]`.
+Under `--log=labeled` with caching off, multiple tasks should each get piped stdio and each line should be prefixed with `[pkg#task]`.
 
 ## `vt run --log=labeled -r check-tty`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/single_task__cache_hit__replayed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/single_task__cache_hit__replayed.md
@@ -1,7 +1,6 @@
 # single_task__cache_hit__replayed
 
-A cache-hit replay of a single task under labeled mode should reproduce the
-labeled output from cached data.
+A cache-hit replay of a single task under labeled mode should reproduce the labeled output from cached data.
 
 ## `vt run --log=labeled check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/single_task__cache_miss__piped_stdio.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/single_task__cache_miss__piped_stdio.md
@@ -1,7 +1,6 @@
 # single_task__cache_miss__piped_stdio
 
-On a cache miss for a single task, labeled mode should still pipe stdio and
-prefix output lines.
+On a cache miss for a single task, labeled mode should still pipe stdio and prefix output lines.
 
 ## `vt run --log=labeled check-tty-cached`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/single_task__cache_off__piped_stdio.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/single_task__cache_off__piped_stdio.md
@@ -1,7 +1,6 @@
 # single_task__cache_off__piped_stdio
 
-Under `--log=labeled` with caching off, a single task's stdio should be piped
-through the line-prefixing writer (not a TTY).
+Under `--log=labeled` with caching off, a single task's stdio should be piped through the line-prefixing writer (not a TTY).
 
 ## `vt run --log=labeled check-tty`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/stdin_is_always_null.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/labeled_stdio/snapshots/stdin_is_always_null.md
@@ -1,7 +1,6 @@
 # stdin_is_always_null
 
-In labeled mode, task stdin is always `/dev/null` regardless of the parent's
-stdin — piping data in from outside must not reach the task.
+In labeled mode, task stdin is always `/dev/null` regardless of the parent's stdin — piping data in from outside must not reach the task.
 
 ## `vtt pipe-stdin from-stdin -- vt run --log=labeled read-stdin`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/malformed_fspy_path/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/malformed_fspy_path/snapshots.toml
@@ -1,7 +1,6 @@
 [[e2e]]
 name = "malformed_observed_path_does_not_panic"
 comment = """
-Repro for issue 325: a malformed observed path must not panic when fspy
-input inference normalizes workspace-relative accesses.
+Repro for issue 325: a malformed observed path must not panic when fspy input inference normalizes workspace-relative accesses.
 """
 steps = [{ argv = ["vt", "run", "read-malformed-path"], envs = [["TEMP", "."], ["TMP", "."]] }]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/malformed_fspy_path/snapshots/malformed_observed_path_does_not_panic.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/malformed_fspy_path/snapshots/malformed_observed_path_does_not_panic.md
@@ -1,7 +1,6 @@
 # malformed_observed_path_does_not_panic
 
-Repro for issue 325: a malformed observed path must not panic when fspy
-input inference normalizes workspace-relative accesses.
+Repro for issue 325: a malformed observed path must not panic when fspy input inference normalizes workspace-relative accesses.
 
 ## `TEMP=. TMP=. vt run read-malformed-path`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/output_cache_test/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/output_cache_test/snapshots.toml
@@ -1,9 +1,7 @@
 [[e2e]]
 name = "output_globs___files_restored_on_cache_hit"
 comment = """
-With explicit output globs (`dist/**`), the first run writes a file to
-`dist/`. After deleting `dist/`, a second run with no input changes is a
-cache hit and the archived output file is restored.
+With explicit output globs (`dist/**`), the first run writes a file to `dist/`. After deleting `dist/`, a second run with no input changes is a cache hit and the archived output file is restored.
 """
 steps = [
   { argv = [
@@ -37,10 +35,7 @@ steps = [
 [[e2e]]
 name = "output_globs___old_archive_removed_on_rewrite"
 comment = """
-When a cached task re-runs (cache miss because an input changed), it
-writes a new archive and the previous archive file is cleaned up. After
-two cache-missing runs of the same task the cache directory still
-contains only one `.tar.zst` archive.
+When a cached task re-runs (cache miss because an input changed), it writes a new archive and the previous archive file is cleaned up. After two cache-missing runs of the same task the cache directory still contains only one `.tar.zst` archive.
 """
 steps = [
   { argv = [
@@ -78,8 +73,7 @@ steps = [
 [[e2e]]
 name = "output_globs___negative_excludes_files_from_archive"
 comment = """
-A file matched by a negative output glob is not archived, so it is not
-restored on cache hit.
+A file matched by a negative output glob is not archived, so it is not restored on cache hit.
 """
 steps = [
   { argv = [

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/output_cache_test/snapshots/output_globs___files_restored_on_cache_hit.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/output_cache_test/snapshots/output_globs___files_restored_on_cache_hit.md
@@ -1,8 +1,6 @@
 # output_globs___files_restored_on_cache_hit
 
-With explicit output globs (`dist/**`), the first run writes a file to
-`dist/`. After deleting `dist/`, a second run with no input changes is a
-cache hit and the archived output file is restored.
+With explicit output globs (`dist/**`), the first run writes a file to `dist/`. After deleting `dist/`, a second run with no input changes is a cache hit and the archived output file is restored.
 
 ## `vt run build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/output_cache_test/snapshots/output_globs___negative_excludes_files_from_archive.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/output_cache_test/snapshots/output_globs___negative_excludes_files_from_archive.md
@@ -1,7 +1,6 @@
 # output_globs___negative_excludes_files_from_archive
 
-A file matched by a negative output glob is not archived, so it is not
-restored on cache hit.
+A file matched by a negative output glob is not archived, so it is not restored on cache hit.
 
 ## `vt run build-with-negative`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/output_cache_test/snapshots/output_globs___old_archive_removed_on_rewrite.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/output_cache_test/snapshots/output_globs___old_archive_removed_on_rewrite.md
@@ -1,9 +1,6 @@
 # output_globs___old_archive_removed_on_rewrite
 
-When a cached task re-runs (cache miss because an input changed), it
-writes a new archive and the previous archive file is cleaned up. After
-two cache-missing runs of the same task the cache directory still
-contains only one `.tar.zst` archive.
+When a cached task re-runs (cache miss because an input changed), it writes a new archive and the previous archive file is cleaned up. After two cache-missing runs of the same task the cache directory still contains only one `.tar.zst` archive.
 
 ## `vt run build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/parallel_execution/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/parallel_execution/snapshots.toml
@@ -1,9 +1,6 @@
 [[e2e]]
 name = "parallel_flag_runs_dependent_tasks_concurrently"
 comment = """
-Package b depends on a, so without --parallel they run sequentially.
-Both use a barrier requiring 2 participants — if run sequentially the
-first would wait forever and the test would timeout.
---parallel discards dependency edges, allowing both to run at once.
+Package b depends on a, so without --parallel they run sequentially. Both use a barrier requiring 2 participants — if run sequentially the first would wait forever and the test would timeout. --parallel discards dependency edges, allowing both to run at once.
 """
 steps = [["vt", "run", "-r", "--parallel", "build"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/parallel_execution/snapshots/parallel_flag_runs_dependent_tasks_concurrently.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/parallel_execution/snapshots/parallel_flag_runs_dependent_tasks_concurrently.md
@@ -1,9 +1,6 @@
 # parallel_flag_runs_dependent_tasks_concurrently
 
-Package b depends on a, so without --parallel they run sequentially.
-Both use a barrier requiring 2 participants — if run sequentially the
-first would wait forever and the test would timeout.
---parallel discards dependency edges, allowing both to run at once.
+Package b depends on a, so without --parallel they run sequentially. Both use a barrier requiring 2 participants — if run sequentially the first would wait forever and the test would timeout. --parallel discards dependency edges, allowing both to run at once.
 
 ## `vt run -r --parallel build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/pass_args_to_task/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/pass_args_to_task/snapshots.toml
@@ -1,8 +1,7 @@
 [[e2e]]
 name = "pass_args_to_task"
 comment = """
-Tests that arguments after task name should be passed to the task
-https://github.com/voidzero-dev/vite-task/issues/285
+Tests that arguments after task name should be passed to the task https://github.com/voidzero-dev/vite-task/issues/285
 """
 steps = [
   ["vt", "run", "echo", "--help"], # Should just print `help` instead of Vite task's help

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/pass_args_to_task/snapshots/pass_args_to_task.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/pass_args_to_task/snapshots/pass_args_to_task.md
@@ -1,7 +1,6 @@
 # pass_args_to_task
 
-Tests that arguments after task name should be passed to the task
-https://github.com/voidzero-dev/vite-task/issues/285
+Tests that arguments after task name should be passed to the task https://github.com/voidzero-dev/vite-task/issues/285
 
 ## `vt run echo --help`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/preexisting_ld_preload/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/preexisting_ld_preload/snapshots.toml
@@ -6,23 +6,11 @@ name = "preexisting_ld_preload"
 # assumptions don't hold.
 platform = "linux-gnu"
 comment = """
-Reproduces #340 and verifies that fspy tolerates a user-supplied
-`LD_PRELOAD` by appending its shim instead of rejecting the spawn.
-Appending (not prepending) also preserves symbol-interposition order:
-the user's preload runs first, so short-circuited calls remain
-invisible to fspy — what the OS actually executed is what fspy records.
+Reproduces #340 and verifies that fspy tolerates a user-supplied `LD_PRELOAD` by appending its shim instead of rejecting the spawn. Appending (not prepending) also preserves symbol-interposition order: the user's preload runs first, so short-circuited calls remain invisible to fspy — what the OS actually executed is what fspy records.
 
-`preload_test_lib` (built as a cdylib artifact dep) intercepts
-`open`/`openat` and short-circuits any path containing the marker
-`preload_test_short_circuit`, returning `ENOENT` without forwarding.
-Every other path is forwarded via `RTLD_NEXT` so fspy still observes
-the real syscall.
+`preload_test_lib` (built as a cdylib artifact dep) intercepts `open`/`openat` and short-circuits any path containing the marker `preload_test_short_circuit`, returning `ENOENT` without forwarding. Every other path is forwarded via `RTLD_NEXT` so fspy still observes the real syscall.
 
-The `read` task prints two files. `real.txt` goes through the full
-interposer chain and is tracked as an input. `preload_test_short_circuit.txt`
-is short-circuited by the user preload; fspy never sees it and does not
-track it. Modifying the short-circuited file must therefore be a cache
-hit; modifying the real file must be a miss.
+The `read` task prints two files. `real.txt` goes through the full interposer chain and is tracked as an input. `preload_test_short_circuit.txt` is short-circuited by the user preload; fspy never sees it and does not track it. Modifying the short-circuited file must therefore be a cache hit; modifying the real file must be a miss.
 """
 steps = [
   { argv = [

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/preexisting_ld_preload/snapshots/preexisting_ld_preload.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/preexisting_ld_preload/snapshots/preexisting_ld_preload.md
@@ -1,22 +1,10 @@
 # preexisting_ld_preload
 
-Reproduces #340 and verifies that fspy tolerates a user-supplied
-`LD_PRELOAD` by appending its shim instead of rejecting the spawn.
-Appending (not prepending) also preserves symbol-interposition order:
-the user's preload runs first, so short-circuited calls remain
-invisible to fspy — what the OS actually executed is what fspy records.
+Reproduces #340 and verifies that fspy tolerates a user-supplied `LD_PRELOAD` by appending its shim instead of rejecting the spawn. Appending (not prepending) also preserves symbol-interposition order: the user's preload runs first, so short-circuited calls remain invisible to fspy — what the OS actually executed is what fspy records.
 
-`preload_test_lib` (built as a cdylib artifact dep) intercepts
-`open`/`openat` and short-circuits any path containing the marker
-`preload_test_short_circuit`, returning `ENOENT` without forwarding.
-Every other path is forwarded via `RTLD_NEXT` so fspy still observes
-the real syscall.
+`preload_test_lib` (built as a cdylib artifact dep) intercepts `open`/`openat` and short-circuits any path containing the marker `preload_test_short_circuit`, returning `ENOENT` without forwarding. Every other path is forwarded via `RTLD_NEXT` so fspy still observes the real syscall.
 
-The `read` task prints two files. `real.txt` goes through the full
-interposer chain and is tracked as an input. `preload_test_short_circuit.txt`
-is short-circuited by the user preload; fspy never sees it and does not
-track it. Modifying the short-circuited file must therefore be a cache
-hit; modifying the real file must be a miss.
+The `read` task prints two files. `real.txt` goes through the full interposer chain and is tracked as an input. `preload_test_short_circuit.txt` is short-circuited by the user preload; fspy never sees it and does not track it. Modifying the short-circuited file must therefore be a cache hit; modifying the real file must be a miss.
 
 ## `LD_PRELOAD=<PRELOAD_TEST_LIB_PATH> vt run read`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/signal_exit/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/signal_exit/snapshots.toml
@@ -1,8 +1,7 @@
 [[e2e]]
 name = "signal_terminated_task_returns_non_zero_exit_code"
 comment = """
-Tests exit code behavior for signal-terminated processes
-Unix-only: Windows doesn't have Unix signals, so exit codes differ
+Tests exit code behavior for signal-terminated processes Unix-only: Windows doesn't have Unix signals, so exit codes differ
 """
 platform = "unix"
 ignore = true

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/signal_exit/snapshots/signal_terminated_task_returns_non_zero_exit_code.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/signal_exit/snapshots/signal_terminated_task_returns_non_zero_exit_code.md
@@ -1,7 +1,6 @@
 # signal_terminated_task_returns_non_zero_exit_code
 
-Tests exit code behavior for signal-terminated processes
-Unix-only: Windows doesn't have Unix signals, so exit codes differ
+Tests exit code behavior for signal-terminated processes Unix-only: Windows doesn't have Unix signals, so exit codes differ
 
 ## `vt run abort`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots.toml
@@ -1,8 +1,7 @@
 [[e2e]]
 name = "single_task_cache_miss_shows_no_summary"
 comment = """
-A single task on its first run (cache miss) should produce no summary line
-at all — only the task's own output.
+A single task on its first run (cache miss) should produce no summary line at all — only the task's own output.
 """
 cwd = "packages/a"
 steps = [["vt", "run", "build"]]
@@ -10,8 +9,7 @@ steps = [["vt", "run", "build"]]
 [[e2e]]
 name = "single_task_cache_hit_shows_compact_summary"
 comment = """
-When a single task hits the cache on a re-run, the compact one-line summary
-should be emitted.
+When a single task hits the cache on a re-run, the compact one-line summary should be emitted.
 """
 cwd = "packages/a"
 steps = [
@@ -30,16 +28,14 @@ steps = [
 [[e2e]]
 name = "multi_task_all_cache_miss_shows_compact_summary"
 comment = """
-A multi-task (`-r`) run where every task misses should still print a compact
-summary with 0 hits.
+A multi-task (`-r`) run where every task misses should still print a compact summary with 0 hits.
 """
 steps = [["vt", "run", "-r", "build"]]
 
 [[e2e]]
 name = "multi_task_with_cache_hits_shows_compact_summary"
 comment = """
-On the second multi-task (`-r`) run, the compact summary should report the
-correct hit count.
+On the second multi-task (`-r`) run, the compact summary should report the correct hit count.
 """
 steps = [
   { argv = [
@@ -59,8 +55,7 @@ steps = [
 [[e2e]]
 name = "single_task_verbose_shows_full_summary"
 comment = """
-`vt run -v` on a single task should emit the full detailed summary, even on
-a first-run cache miss.
+`vt run -v` on a single task should emit the full detailed summary, even on a first-run cache miss.
 """
 cwd = "packages/a"
 steps = [["vt", "run", "-v", "build"]]
@@ -75,8 +70,7 @@ steps = [["vt", "run", "-r", "-v", "build"]]
 [[e2e]]
 name = "multi_task_verbose_with_cache_hits_shows_full_summary"
 comment = """
-With `-v` on a multi-task re-run, the full summary should report per-task
-cache hits (not just overall stats).
+With `-v` on a multi-task re-run, the full summary should report per-task cache hits (not just overall stats).
 """
 steps = [
   { argv = [
@@ -97,16 +91,14 @@ steps = [
 [[e2e]]
 name = "last_details_with_no_previous_run_shows_error"
 comment = """
-`vt run --last-details` with no prior run in the workspace should produce a
-clear error rather than empty output.
+`vt run --last-details` with no prior run in the workspace should produce a clear error rather than empty output.
 """
 steps = [["vt", "run", "--last-details"]]
 
 [[e2e]]
 name = "last_details_after_run_shows_saved_summary"
 comment = """
-After a single-task run, `vt run --last-details` should display the saved
-summary from disk.
+After a single-task run, `vt run --last-details` should display the saved summary from disk.
 """
 cwd = "packages/a"
 steps = [
@@ -125,8 +117,7 @@ steps = [
 [[e2e]]
 name = "last_details_after_multi_task_run_shows_saved_summary"
 comment = """
-After a multi-task (`-r`) run, `vt run --last-details` should display the
-saved summary covering every task.
+After a multi-task (`-r`) run, `vt run --last-details` should display the saved summary covering every task.
 """
 steps = [
   { argv = [

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/last_details_after_multi_task_run_shows_saved_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/last_details_after_multi_task_run_shows_saved_summary.md
@@ -1,7 +1,6 @@
 # last_details_after_multi_task_run_shows_saved_summary
 
-After a multi-task (`-r`) run, `vt run --last-details` should display the
-saved summary covering every task.
+After a multi-task (`-r`) run, `vt run --last-details` should display the saved summary covering every task.
 
 ## `vt run -r build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/last_details_after_run_shows_saved_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/last_details_after_run_shows_saved_summary.md
@@ -1,7 +1,6 @@
 # last_details_after_run_shows_saved_summary
 
-After a single-task run, `vt run --last-details` should display the saved
-summary from disk.
+After a single-task run, `vt run --last-details` should display the saved summary from disk.
 
 ## `vt run build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/last_details_with_no_previous_run_shows_error.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/last_details_with_no_previous_run_shows_error.md
@@ -1,7 +1,6 @@
 # last_details_with_no_previous_run_shows_error
 
-`vt run --last-details` with no prior run in the workspace should produce a
-clear error rather than empty output.
+`vt run --last-details` with no prior run in the workspace should produce a clear error rather than empty output.
 
 ## `vt run --last-details`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/multi_task_all_cache_miss_shows_compact_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/multi_task_all_cache_miss_shows_compact_summary.md
@@ -1,7 +1,6 @@
 # multi_task_all_cache_miss_shows_compact_summary
 
-A multi-task (`-r`) run where every task misses should still print a compact
-summary with 0 hits.
+A multi-task (`-r`) run where every task misses should still print a compact summary with 0 hits.
 
 ## `vt run -r build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/multi_task_verbose_with_cache_hits_shows_full_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/multi_task_verbose_with_cache_hits_shows_full_summary.md
@@ -1,7 +1,6 @@
 # multi_task_verbose_with_cache_hits_shows_full_summary
 
-With `-v` on a multi-task re-run, the full summary should report per-task
-cache hits (not just overall stats).
+With `-v` on a multi-task re-run, the full summary should report per-task cache hits (not just overall stats).
 
 ## `vt run -r build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/multi_task_with_cache_hits_shows_compact_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/multi_task_with_cache_hits_shows_compact_summary.md
@@ -1,7 +1,6 @@
 # multi_task_with_cache_hits_shows_compact_summary
 
-On the second multi-task (`-r`) run, the compact summary should report the
-correct hit count.
+On the second multi-task (`-r`) run, the compact summary should report the correct hit count.
 
 ## `vt run -r build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/single_task_cache_hit_shows_compact_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/single_task_cache_hit_shows_compact_summary.md
@@ -1,7 +1,6 @@
 # single_task_cache_hit_shows_compact_summary
 
-When a single task hits the cache on a re-run, the compact one-line summary
-should be emitted.
+When a single task hits the cache on a re-run, the compact one-line summary should be emitted.
 
 ## `vt run build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/single_task_cache_miss_shows_no_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/single_task_cache_miss_shows_no_summary.md
@@ -1,7 +1,6 @@
 # single_task_cache_miss_shows_no_summary
 
-A single task on its first run (cache miss) should produce no summary line
-at all — only the task's own output.
+A single task on its first run (cache miss) should produce no summary line at all — only the task's own output.
 
 ## `vt run build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/single_task_verbose_shows_full_summary.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/summary_output/snapshots/single_task_verbose_shows_full_summary.md
@@ -1,7 +1,6 @@
 # single_task_verbose_shows_full_summary
 
-`vt run -v` on a single task should emit the full detailed summary, even on
-a first-run cache miss.
+`vt run -v` on a single task should emit the full detailed summary, even on a first-run cache miss.
 
 ## `vt run -v build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots.toml
@@ -1,40 +1,35 @@
 [[e2e]]
 name = "non_interactive_list_tasks"
 comment = """
-With piped stdin (non-interactive), `vt run` with no task argument should
-list all available tasks instead of launching the picker.
+With piped stdin (non-interactive), `vt run` with no task argument should list all available tasks instead of launching the picker.
 """
 steps = [["vtt", "pipe-stdin", "--", "vt", "run"]]
 
 [[e2e]]
 name = "non_interactive_did_you_mean"
 comment = """
-In non-interactive mode, a typo that has close fuzzy matches should produce
-"did you mean" suggestions.
+In non-interactive mode, a typo that has close fuzzy matches should produce "did you mean" suggestions.
 """
 steps = [["vtt", "pipe-stdin", "--", "vt", "run", "buid"]]
 
 [[e2e]]
 name = "non_interactive_no_suggestions"
 comment = """
-In non-interactive mode, a typo with no close fuzzy matches should omit the
-"did you mean" block entirely.
+In non-interactive mode, a typo with no close fuzzy matches should omit the "did you mean" block entirely.
 """
 steps = [["vtt", "pipe-stdin", "--", "vt", "run", "zzzzz"]]
 
 [[e2e]]
 name = "non_interactive_recursive_typo_errors"
 comment = """
-A typoed task name combined with `-r` (not cwd-only) should error without
-listing tasks — the `-r` signal rules out the interactive selector fallback.
+A typoed task name combined with `-r` (not cwd-only) should error without listing tasks — the `-r` signal rules out the interactive selector fallback.
 """
 steps = [["vtt", "pipe-stdin", "--", "vt", "run", "-r", "buid"]]
 
 [[e2e]]
 name = "interactive_select_task"
 comment = """
-In interactive mode, navigating down one entry and pressing Enter should
-select the second task.
+In interactive mode, navigating down one entry and pressing Enter should select the second task.
 """
 cwd = "packages/app"
 steps = [
@@ -52,8 +47,7 @@ steps = [
 [[e2e]]
 name = "interactive_select_with_typo"
 comment = """
-When a typoed task name launches the selector, the typo should be pre-filled
-as the initial search query.
+When a typoed task name launches the selector, the typo should be pre-filled as the initial search query.
 """
 cwd = "packages/app"
 steps = [
@@ -70,8 +64,7 @@ steps = [
 [[e2e]]
 name = "interactive_search_then_select"
 comment = """
-Typing characters in the selector should filter the list in real time, then
-Enter should pick the highlighted result.
+Typing characters in the selector should filter the list in real time, then Enter should pick the highlighted result.
 """
 cwd = "packages/app"
 steps = [
@@ -89,8 +82,7 @@ steps = [
 [[e2e]]
 name = "interactive_escape_clears_query"
 comment = """
-Escape in the selector should clear the current query and restore the
-unfiltered list at cursor position 0.
+Escape in the selector should clear the current query and restore the unfiltered list at cursor position 0.
 """
 cwd = "packages/app"
 steps = [
@@ -110,8 +102,7 @@ steps = [
 [[e2e]]
 name = "recursive_without_task_errors"
 comment = """
-`vt run -r` with no task argument is not treated as a bare run — it should
-error instead of opening the selector.
+`vt run -r` with no task argument is not treated as a bare run — it should error instead of opening the selector.
 """
 cwd = "packages/app"
 steps = [["vt", "run", "-r"]]
@@ -119,8 +110,7 @@ steps = [["vt", "run", "-r"]]
 [[e2e]]
 name = "transitive_typo_errors"
 comment = """
-`vt run -t <typo>` is not cwd-only, so a typo should error rather than fall
-back to the interactive selector.
+`vt run -t <typo>` is not cwd-only, so a typo should error rather than fall back to the interactive selector.
 """
 cwd = "packages/app"
 steps = [["vt", "run", "-t", "buid"]]
@@ -128,8 +118,7 @@ steps = [["vt", "run", "-t", "buid"]]
 [[e2e]]
 name = "interactive_scroll_long_list"
 comment = """
-With a list taller than the 8-row page, navigating past the viewport should
-scroll down, and navigating back should scroll the view up to index 0.
+With a list taller than the 8-row page, navigating past the viewport should scroll down, and navigating back should scroll the view up to index 0.
 """
 cwd = "packages/app"
 steps = [
@@ -163,8 +152,7 @@ steps = [
 [[e2e]]
 name = "non_interactive_list_tasks_from_lib"
 comment = """
-When listing from a subpackage's cwd, that package's tasks should appear
-first and be listed unqualified.
+When listing from a subpackage's cwd, that package's tasks should appear first and be listed unqualified.
 """
 cwd = "packages/lib"
 steps = [["vtt", "pipe-stdin", "--", "vt", "run"]]
@@ -172,8 +160,7 @@ steps = [["vtt", "pipe-stdin", "--", "vt", "run"]]
 [[e2e]]
 name = "interactive_select_task_from_lib"
 comment = """
-In the interactive selector launched from `packages/lib`, the first entry
-should be a lib-owned task.
+In the interactive selector launched from `packages/lib`, the first entry should be a lib-owned task.
 """
 cwd = "packages/lib"
 steps = [
@@ -189,8 +176,7 @@ steps = [
 [[e2e]]
 name = "interactive_search_other_package_task"
 comment = """
-A search query can match a task that lives only in another package; that
-task should become selectable.
+A search query can match a task that lives only in another package; that task should become selectable.
 """
 cwd = "packages/app"
 steps = [
@@ -208,8 +194,7 @@ steps = [
 [[e2e]]
 name = "interactive_search_with_hash_skips_reorder"
 comment = """
-Including `#` in the query means "target a specific package#task" and should
-disable the current-package reordering in the filtered list.
+Including `#` in the query means "target a specific package#task" and should disable the current-package reordering in the filtered list.
 """
 cwd = "packages/app"
 steps = [
@@ -227,8 +212,7 @@ steps = [
 [[e2e]]
 name = "interactive_search_preserves_rating_within_package"
 comment = """
-When multiple current-package tasks match, the fuzzy-rating order between
-them should be preserved (not broken by current-package grouping).
+When multiple current-package tasks match, the fuzzy-rating order between them should be preserved (not broken by current-package grouping).
 """
 cwd = "packages/lib"
 steps = [
@@ -246,8 +230,7 @@ steps = [
 [[e2e]]
 name = "interactive_enter_with_no_results_does_nothing"
 comment = """
-Pressing Enter while the filtered list is empty should be a no-op — the
-selector should remain open and accept new input.
+Pressing Enter while the filtered list is empty should be a no-op — the selector should remain open and accept new input.
 """
 cwd = "packages/app"
 steps = [
@@ -268,8 +251,7 @@ steps = [
 [[e2e]]
 name = "interactive_select_from_other_package"
 comment = """
-Navigating past the current-package group should expose tasks in other
-packages, which must also be selectable.
+Navigating past the current-package group should expose tasks in other packages, which must also be selectable.
 """
 cwd = "packages/app"
 steps = [
@@ -289,16 +271,14 @@ steps = [
 [[e2e]]
 name = "typo_in_task_script_fails_without_list"
 comment = """
-A typo inside a task's own script (i.e. a nested `vp run` command) should
-surface the real failure, not launch the task picker.
+A typo inside a task's own script (i.e. a nested `vp run` command) should surface the real failure, not launch the task picker.
 """
 steps = [["vt", "run", "run-typo-task"]]
 
 [[e2e]]
 name = "interactive_ctrl_c_cancels"
 comment = """
-Ctrl+C inside the interactive selector should cancel and exit 130 without
-running any task.
+Ctrl+C inside the interactive selector should cancel and exit 130 without running any task.
 """
 cwd = "packages/app"
 steps = [
@@ -314,8 +294,7 @@ steps = [
 [[e2e]]
 name = "verbose_without_task_errors"
 comment = """
-`vt run --verbose` with no task argument is not bare, so it should error
-with "no task specifier provided" rather than opening the selector.
+`vt run --verbose` with no task argument is not bare, so it should error with "no task specifier provided" rather than opening the selector.
 """
 cwd = "packages/app"
 steps = [["vt", "run", "--verbose"]]
@@ -323,8 +302,7 @@ steps = [["vt", "run", "--verbose"]]
 [[e2e]]
 name = "verbose_with_typo_enters_selector"
 comment = """
-`vt run --verbose <typo>` still qualifies as cwd-only, so it should fall
-back to the interactive selector pre-filled with the typo.
+`vt run --verbose <typo>` still qualifies as cwd-only, so it should fall back to the interactive selector pre-filled with the typo.
 """
 cwd = "packages/app"
 steps = [

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_ctrl_c_cancels.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_ctrl_c_cancels.md
@@ -1,7 +1,6 @@
 # interactive_ctrl_c_cancels
 
-Ctrl+C inside the interactive selector should cancel and exit 130 without
-running any task.
+Ctrl+C inside the interactive selector should cancel and exit 130 without running any task.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_enter_with_no_results_does_nothing.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_enter_with_no_results_does_nothing.md
@@ -1,7 +1,6 @@
 # interactive_enter_with_no_results_does_nothing
 
-Pressing Enter while the filtered list is empty should be a no-op — the
-selector should remain open and accept new input.
+Pressing Enter while the filtered list is empty should be a no-op — the selector should remain open and accept new input.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_escape_clears_query.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_escape_clears_query.md
@@ -1,7 +1,6 @@
 # interactive_escape_clears_query
 
-Escape in the selector should clear the current query and restore the
-unfiltered list at cursor position 0.
+Escape in the selector should clear the current query and restore the unfiltered list at cursor position 0.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_scroll_long_list.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_scroll_long_list.md
@@ -1,7 +1,6 @@
 # interactive_scroll_long_list
 
-With a list taller than the 8-row page, navigating past the viewport should
-scroll down, and navigating back should scroll the view up to index 0.
+With a list taller than the 8-row page, navigating past the viewport should scroll down, and navigating back should scroll the view up to index 0.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_search_other_package_task.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_search_other_package_task.md
@@ -1,7 +1,6 @@
 # interactive_search_other_package_task
 
-A search query can match a task that lives only in another package; that
-task should become selectable.
+A search query can match a task that lives only in another package; that task should become selectable.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_search_preserves_rating_within_package.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_search_preserves_rating_within_package.md
@@ -1,7 +1,6 @@
 # interactive_search_preserves_rating_within_package
 
-When multiple current-package tasks match, the fuzzy-rating order between
-them should be preserved (not broken by current-package grouping).
+When multiple current-package tasks match, the fuzzy-rating order between them should be preserved (not broken by current-package grouping).
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_search_then_select.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_search_then_select.md
@@ -1,7 +1,6 @@
 # interactive_search_then_select
 
-Typing characters in the selector should filter the list in real time, then
-Enter should pick the highlighted result.
+Typing characters in the selector should filter the list in real time, then Enter should pick the highlighted result.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_search_with_hash_skips_reorder.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_search_with_hash_skips_reorder.md
@@ -1,7 +1,6 @@
 # interactive_search_with_hash_skips_reorder
 
-Including `#` in the query means "target a specific package#task" and should
-disable the current-package reordering in the filtered list.
+Including `#` in the query means "target a specific package#task" and should disable the current-package reordering in the filtered list.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_select_from_other_package.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_select_from_other_package.md
@@ -1,7 +1,6 @@
 # interactive_select_from_other_package
 
-Navigating past the current-package group should expose tasks in other
-packages, which must also be selectable.
+Navigating past the current-package group should expose tasks in other packages, which must also be selectable.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_select_task.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_select_task.md
@@ -1,7 +1,6 @@
 # interactive_select_task
 
-In interactive mode, navigating down one entry and pressing Enter should
-select the second task.
+In interactive mode, navigating down one entry and pressing Enter should select the second task.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_select_task_from_lib.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_select_task_from_lib.md
@@ -1,7 +1,6 @@
 # interactive_select_task_from_lib
 
-In the interactive selector launched from `packages/lib`, the first entry
-should be a lib-owned task.
+In the interactive selector launched from `packages/lib`, the first entry should be a lib-owned task.
 
 ## `vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_select_with_typo.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/interactive_select_with_typo.md
@@ -1,7 +1,6 @@
 # interactive_select_with_typo
 
-When a typoed task name launches the selector, the typo should be pre-filled
-as the initial search query.
+When a typoed task name launches the selector, the typo should be pre-filled as the initial search query.
 
 ## `vt run buid`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_did_you_mean.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_did_you_mean.md
@@ -1,7 +1,6 @@
 # non_interactive_did_you_mean
 
-In non-interactive mode, a typo that has close fuzzy matches should produce
-"did you mean" suggestions.
+In non-interactive mode, a typo that has close fuzzy matches should produce "did you mean" suggestions.
 
 ## `vtt pipe-stdin -- vt run buid`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_list_tasks.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_list_tasks.md
@@ -1,7 +1,6 @@
 # non_interactive_list_tasks
 
-With piped stdin (non-interactive), `vt run` with no task argument should
-list all available tasks instead of launching the picker.
+With piped stdin (non-interactive), `vt run` with no task argument should list all available tasks instead of launching the picker.
 
 ## `vtt pipe-stdin -- vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_list_tasks_from_lib.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_list_tasks_from_lib.md
@@ -1,7 +1,6 @@
 # non_interactive_list_tasks_from_lib
 
-When listing from a subpackage's cwd, that package's tasks should appear
-first and be listed unqualified.
+When listing from a subpackage's cwd, that package's tasks should appear first and be listed unqualified.
 
 ## `vtt pipe-stdin -- vt run`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_no_suggestions.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_no_suggestions.md
@@ -1,7 +1,6 @@
 # non_interactive_no_suggestions
 
-In non-interactive mode, a typo with no close fuzzy matches should omit the
-"did you mean" block entirely.
+In non-interactive mode, a typo with no close fuzzy matches should omit the "did you mean" block entirely.
 
 ## `vtt pipe-stdin -- vt run zzzzz`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_recursive_typo_errors.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_recursive_typo_errors.md
@@ -1,7 +1,6 @@
 # non_interactive_recursive_typo_errors
 
-A typoed task name combined with `-r` (not cwd-only) should error without
-listing tasks — the `-r` signal rules out the interactive selector fallback.
+A typoed task name combined with `-r` (not cwd-only) should error without listing tasks — the `-r` signal rules out the interactive selector fallback.
 
 ## `vtt pipe-stdin -- vt run -r buid`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/recursive_without_task_errors.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/recursive_without_task_errors.md
@@ -1,7 +1,6 @@
 # recursive_without_task_errors
 
-`vt run -r` with no task argument is not treated as a bare run — it should
-error instead of opening the selector.
+`vt run -r` with no task argument is not treated as a bare run — it should error instead of opening the selector.
 
 ## `vt run -r`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/transitive_typo_errors.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/transitive_typo_errors.md
@@ -1,7 +1,6 @@
 # transitive_typo_errors
 
-`vt run -t <typo>` is not cwd-only, so a typo should error rather than fall
-back to the interactive selector.
+`vt run -t <typo>` is not cwd-only, so a typo should error rather than fall back to the interactive selector.
 
 ## `vt run -t buid`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/typo_in_task_script_fails_without_list.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/typo_in_task_script_fails_without_list.md
@@ -1,7 +1,6 @@
 # typo_in_task_script_fails_without_list
 
-A typo inside a task's own script (i.e. a nested `vp run` command) should
-surface the real failure, not launch the task picker.
+A typo inside a task's own script (i.e. a nested `vp run` command) should surface the real failure, not launch the task picker.
 
 ## `vt run run-typo-task`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/verbose_with_typo_enters_selector.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/verbose_with_typo_enters_selector.md
@@ -1,7 +1,6 @@
 # verbose_with_typo_enters_selector
 
-`vt run --verbose <typo>` still qualifies as cwd-only, so it should fall
-back to the interactive selector pre-filled with the typo.
+`vt run --verbose <typo>` still qualifies as cwd-only, so it should fall back to the interactive selector pre-filled with the typo.
 
 ## `vt run --verbose buid`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/verbose_without_task_errors.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/verbose_without_task_errors.md
@@ -1,7 +1,6 @@
 # verbose_without_task_errors
 
-`vt run --verbose` with no task argument is not bare, so it should error
-with "no task specifier provided" rather than opening the selector.
+`vt run --verbose` with no task argument is not bare, so it should error with "no task specifier provided" rather than opening the selector.
 
 ## `vt run --verbose`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological_execution_order/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological_execution_order/snapshots.toml
@@ -1,16 +1,14 @@
 [[e2e]]
 name = "recursive_build_runs_dependencies_before_dependents"
 comment = """
-`vt run -r build` across the workspace should execute packages in
-topological order: `@topo/core` before `@topo/lib` before `@topo/app`.
+`vt run -r build` across the workspace should execute packages in topological order: `@topo/core` before `@topo/lib` before `@topo/app`.
 """
 steps = [{ argv = ["vt", "run", "-r", "build"], comment = "core -> lib -> app" }]
 
 [[e2e]]
 name = "transitive_build_from_app_runs_all_dependencies"
 comment = """
-`vt run -t build` from the leaf package should include the full transitive
-closure of its dependencies in topological order.
+`vt run -t build` from the leaf package should include the full transitive closure of its dependencies in topological order.
 """
 cwd = "packages/app"
 steps = [{ argv = ["vt", "run", "-t", "build"], comment = "core -> lib -> app" }]
@@ -18,8 +16,7 @@ steps = [{ argv = ["vt", "run", "-t", "build"], comment = "core -> lib -> app" }
 [[e2e]]
 name = "transitive_build_from_lib_runs_only_its_dependencies"
 comment = """
-`vt run -t build` from an intermediate package should limit the run to that
-package and its own dependencies — `@topo/app` must not run.
+`vt run -t build` from an intermediate package should limit the run to that package and its own dependencies — `@topo/app` must not run.
 """
 cwd = "packages/lib"
 steps = [{ argv = ["vt", "run", "-t", "build"], comment = "core -> lib" }]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological_execution_order/snapshots/recursive_build_runs_dependencies_before_dependents.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological_execution_order/snapshots/recursive_build_runs_dependencies_before_dependents.md
@@ -1,7 +1,6 @@
 # recursive_build_runs_dependencies_before_dependents
 
-`vt run -r build` across the workspace should execute packages in
-topological order: `@topo/core` before `@topo/lib` before `@topo/app`.
+`vt run -r build` across the workspace should execute packages in topological order: `@topo/core` before `@topo/lib` before `@topo/app`.
 
 ## `vt run -r build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological_execution_order/snapshots/transitive_build_from_app_runs_all_dependencies.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological_execution_order/snapshots/transitive_build_from_app_runs_all_dependencies.md
@@ -1,7 +1,6 @@
 # transitive_build_from_app_runs_all_dependencies
 
-`vt run -t build` from the leaf package should include the full transitive
-closure of its dependencies in topological order.
+`vt run -t build` from the leaf package should include the full transitive closure of its dependencies in topological order.
 
 ## `vt run -t build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological_execution_order/snapshots/transitive_build_from_lib_runs_only_its_dependencies.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/topological_execution_order/snapshots/transitive_build_from_lib_runs_only_its_dependencies.md
@@ -1,7 +1,6 @@
 # transitive_build_from_lib_runs_only_its_dependencies
 
-`vt run -t build` from an intermediate package should limit the run to that
-package and its own dependencies — `@topo/app` must not run.
+`vt run -t build` from an intermediate package should limit the run to that package and its own dependencies — `@topo/app` must not run.
 
 ## `vt run -t build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/snapshots.toml
@@ -2,12 +2,7 @@
 name = "powershell_package_shim_keeps_pathext"
 platform = "windows"
 comment = """
-Cached Windows tasks run with a sanitized environment, and pnpm-style package
-`.cmd` shims in `node_modules/.bin` are rewritten at plan time to invoke their
-`.ps1` sibling via `powershell.exe -File`. PowerShell needs `PATHEXT` in that
-environment to launch native executables — even when the executable name is
-written out with a `.exe` extension — so `PATHEXT` must be preserved in the
-default untracked env passthrough.
+Cached Windows tasks run with a sanitized environment, and pnpm-style package `.cmd` shims in `node_modules/.bin` are rewritten at plan time to invoke their `.ps1` sibling via `powershell.exe -File`. PowerShell needs `PATHEXT` in that environment to launch native executables — even when the executable name is written out with a `.exe` extension — so `PATHEXT` must be preserved in the default untracked env passthrough.
 """
 steps = [
   { argv = [

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/snapshots/powershell_package_shim_keeps_pathext.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/snapshots/powershell_package_shim_keeps_pathext.md
@@ -1,11 +1,6 @@
 # powershell_package_shim_keeps_pathext
 
-Cached Windows tasks run with a sanitized environment, and pnpm-style package
-`.cmd` shims in `node_modules/.bin` are rewritten at plan time to invoke their
-`.ps1` sibling via `powershell.exe -File`. PowerShell needs `PATHEXT` in that
-environment to launch native executables — even when the executable name is
-written out with a `.exe` extension — so `PATHEXT` must be preserved in the
-default untracked env passthrough.
+Cached Windows tasks run with a sanitized environment, and pnpm-style package `.cmd` shims in `node_modules/.bin` are rewritten at plan time to invoke their `.ps1` sibling via `powershell.exe -File`. PowerShell needs `PATHEXT` in that environment to launch native executables — even when the executable name is written out with a `.exe` extension — so `PATHEXT` must be preserved in the default untracked env passthrough.
 
 ## `vt run probe`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/workspace_root_self_reference/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/workspace_root_self_reference/snapshots.toml
@@ -1,18 +1,13 @@
 [[e2e]]
 name = "recursive_build_skips_root_self_reference"
 comment = """
-`vt run -r build` from the workspace root, when root's own `build` script is
-itself `vt run -r build`, should hit the skip rule: the nested expansion is
-the same query, so root's step is skipped and only packages a and b run.
+`vt run -r build` from the workspace root, when root's own `build` script is itself `vt run -r build`, should hit the skip rule: the nested expansion is the same query, so root's step is skipped and only packages a and b run.
 """
 steps = [{ argv = ["vt", "run", "-r", "build"], comment = "only a and b run, root is skipped" }]
 
 [[e2e]]
 name = "build_from_root_prunes_root_from_nested_expansion"
 comment = """
-`vt run build` from root produces a `ContainingPackage` query, while root's
-script (`vt run -r build`) produces an `All` query, so the skip rule does
-not apply. The prune rule should instead remove root from the nested result,
-again leaving only a and b.
+`vt run build` from root produces a `ContainingPackage` query, while root's script (`vt run -r build`) produces an `All` query, so the skip rule does not apply. The prune rule should instead remove root from the nested result, again leaving only a and b.
 """
 steps = [{ argv = ["vt", "run", "build"], comment = "only a and b run under root, root is pruned" }]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/workspace_root_self_reference/snapshots/build_from_root_prunes_root_from_nested_expansion.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/workspace_root_self_reference/snapshots/build_from_root_prunes_root_from_nested_expansion.md
@@ -1,9 +1,6 @@
 # build_from_root_prunes_root_from_nested_expansion
 
-`vt run build` from root produces a `ContainingPackage` query, while root's
-script (`vt run -r build`) produces an `All` query, so the skip rule does
-not apply. The prune rule should instead remove root from the nested result,
-again leaving only a and b.
+`vt run build` from root produces a `ContainingPackage` query, while root's script (`vt run -r build`) produces an `All` query, so the skip rule does not apply. The prune rule should instead remove root from the nested result, again leaving only a and b.
 
 ## `vt run build`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/workspace_root_self_reference/snapshots/recursive_build_skips_root_self_reference.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/workspace_root_self_reference/snapshots/recursive_build_skips_root_self_reference.md
@@ -1,8 +1,6 @@
 # recursive_build_skips_root_self_reference
 
-`vt run -r build` from the workspace root, when root's own `build` script is
-itself `vt run -r build`, should hit the skip rule: the nested expansion is
-the same query, so root's step is skipped and only packages a and b run.
+`vt run -r build` from the workspace root, when root's own `build` script is itself `vt run -r build`, should hit the skip rule: the nested expansion is the same query, so root's step is skipped and only packages a and b run.
 
 ## `vt run -r build`
 


### PR DESCRIPTION
## Summary

- Collapse wrapped prose in E2E snapshot comments so long comment lines stay unbroken.
- Regenerate the checked-in generated markdown snapshots to match, including the ignored signal-exit case.

## Validation

- `cargo test -p vite_task_bin --test e2e_snapshots`
- `UPDATE_SNAPSHOTS=1 cargo test -p vite_task_bin --test e2e_snapshots -- --include-ignored`
