### PR TITLE
chore: bump pnpm to 11.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,5 @@
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@11.1.2"
 }


### PR DESCRIPTION
Bumps the repo-root `packageManager` pin to `pnpm@11.1.2`.

Only the root `package.json` `packageManager` field is changed.