### PR TITLE
refactor(cli): improve error formatting and handling

### DIFF
--- a/crates/vite_task/src/lib.rs
+++ b/crates/vite_task/src/lib.rs
@@ -4,7 +4,7 @@ pub mod session;
 
 // Public exports for vite_task_bin
 pub use cli::{CacheSubcommand, Command, RunCommand, RunFlags};
-pub use session::{CommandHandler, ExitStatus, HandledCommand, Session, SessionConfig};
+pub use session::{CommandHandler, ExitStatus, HandledCommand, Session, SessionConfig, print_error};
 pub use vite_task_graph::{
     config::{
         self,

--- a/crates/vite_task/src/lib.rs
+++ b/crates/vite_task/src/lib.rs
@@ -4,7 +4,9 @@ pub mod session;
 
 // Public exports for vite_task_bin
 pub use cli::{CacheSubcommand, Command, RunCommand, RunFlags};
-pub use session::{CommandHandler, ExitStatus, HandledCommand, Session, SessionConfig, print_error};
+pub use session::{
+    CommandHandler, ExitStatus, HandledCommand, Session, SessionConfig, print_error,
+};
 pub use vite_task_graph::{
     config::{
         self,

--- a/crates/vite_task/src/session/mod.rs
+++ b/crates/vite_task/src/session/mod.rs
@@ -813,8 +813,7 @@ pub fn print_error(error: &anyhow::Error) {
 
     use owo_colors::{OwoColorize as _, Stream, Style};
 
-    let prefix =
-        "error:".if_supports_color(Stream::Stderr, |s| s.style(Style::new().red().bold()));
+    let prefix = "error:".if_supports_color(Stream::Stderr, |s| s.style(Style::new().red().bold()));
     let mut stderr = std::io::stderr().lock();
     let _ = write!(stderr, "{prefix} {error}");
     for source in error.chain().skip(1) {

--- a/crates/vite_task/src/session/mod.rs
+++ b/crates/vite_task/src/session/mod.rs
@@ -244,15 +244,19 @@ impl<'a> Session<'a> {
 
     /// Primary entry point for CLI usage. Plans and executes the given command.
     ///
-    /// # Errors
-    ///
-    /// Returns an error if planning or execution fails.
+    /// Any error encountered during planning or execution is printed to stderr
+    /// with a bold red `error:` prefix, with each level of the error chain on
+    /// its own `* `-prefixed line. Returns the exit status — callers exit the
+    /// process with it.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub async fn main(mut self, command: Command) -> anyhow::Result<ExitStatus> {
+    pub async fn main(mut self, command: Command) -> ExitStatus {
         match self.main_inner(command).await {
-            Ok(()) => Ok(ExitStatus::SUCCESS),
-            Err(SessionError::EarlyExit(status)) => Ok(status),
-            Err(SessionError::Anyhow(err)) => Err(err),
+            Ok(()) => ExitStatus::SUCCESS,
+            Err(SessionError::EarlyExit(status)) => status,
+            Err(SessionError::Anyhow(err)) => {
+                print_error(&err);
+                ExitStatus::FAILURE
+            }
         }
     }
 
@@ -793,6 +797,30 @@ impl<'a> Session<'a> {
         )
         .await
     }
+}
+
+/// Print `error` to stderr formatted as the `vp` CLI does:
+///
+/// ```text
+/// error: <top-level message>
+/// * <source>
+/// * <source.source()>
+/// ```
+///
+/// The `error:` prefix is bold red when stderr supports ANSI colors.
+pub fn print_error(error: &anyhow::Error) {
+    use std::io::Write as _;
+
+    use owo_colors::{OwoColorize as _, Stream, Style};
+
+    let prefix =
+        "error:".if_supports_color(Stream::Stderr, |s| s.style(Style::new().red().bold()));
+    let mut stderr = std::io::stderr().lock();
+    let _ = write!(stderr, "{prefix} {error}");
+    for source in error.chain().skip(1) {
+        let _ = write!(stderr, "\n* {source}");
+    }
+    let _ = writeln!(stderr);
 }
 
 /// Whether stdout supports ANSI color output for the current process. Honors

--- a/crates/vite_task_bin/src/main.rs
+++ b/crates/vite_task_bin/src/main.rs
@@ -3,24 +3,21 @@ use vite_task::{Command, ExitStatus, Session};
 use vite_task_bin::OwnedSessionConfig;
 
 fn main() -> ! {
-    let exit_code: i32 =
-        tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap().block_on(async {
-            match run().await {
-                Ok(status) => i32::from(status.0),
-                #[expect(clippy::print_stderr, reason = "top-level error reporting")]
-                Err(err) => {
-                    eprintln!("Error: {err:?}");
-                    1
-                }
-            }
-        });
+    let status: ExitStatus =
+        tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap().block_on(run());
 
-    std::process::exit(exit_code);
+    std::process::exit(i32::from(status.0));
 }
 
-async fn run() -> anyhow::Result<ExitStatus> {
+async fn run() -> ExitStatus {
     let args = Command::parse();
     let mut owned_config = OwnedSessionConfig::default();
-    let session = Session::init(owned_config.as_config())?;
+    let session = match Session::init(owned_config.as_config()) {
+        Ok(session) => session,
+        Err(err) => {
+            vite_task::print_error(&err);
+            return ExitStatus::FAILURE;
+        }
+    };
     session.main(args).await
 }

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/error_cycle_dependency/snapshots/cycle_dependency_error.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/error_cycle_dependency/snapshots/cycle_dependency_error.md
@@ -9,5 +9,5 @@ task-a -> task-b -> task-a cycle
 **Exit code:** 1
 
 ```
-Error: Cycle dependency detected: error-cycle-dependency-test#task-a -> error-cycle-dependency-test#task-b -> error-cycle-dependency-test#task-a
+error: Cycle dependency detected: error-cycle-dependency-test#task-a -> error-cycle-dependency-test#task-b -> error-cycle-dependency-test#task-a
 ```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_recursive_typo_errors.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/non_interactive_recursive_typo_errors.md
@@ -7,5 +7,5 @@ A typoed task name combined with `-r` (not cwd-only) should error without listin
 **Exit code:** 1
 
 ```
-Error: Task "buid" not found
+error: Task "buid" not found
 ```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/recursive_without_task_errors.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/recursive_without_task_errors.md
@@ -7,5 +7,5 @@
 **Exit code:** 1
 
 ```
-Error: No task specifier provided for 'run' command
+error: No task specifier provided for 'run' command
 ```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/transitive_typo_errors.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/transitive_typo_errors.md
@@ -7,5 +7,5 @@
 **Exit code:** 1
 
 ```
-Error: Task "buid" not found
+error: Task "buid" not found
 ```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/typo_in_task_script_fails_without_list.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/typo_in_task_script_fails_without_list.md
@@ -7,8 +7,6 @@ A typo inside a task's own script (i.e. a nested `vp run` command) should surfac
 **Exit code:** 1
 
 ```
-Error: Failed to plan tasks from `vt run nonexistent-xyz` in task task-select-test#run-typo-task
-
-Caused by:
-    Task "nonexistent-xyz" not found
+error: Failed to plan tasks from `vt run nonexistent-xyz` in task task-select-test#run-typo-task
+* Task "nonexistent-xyz" not found
 ```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/verbose_without_task_errors.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/task_select/snapshots/verbose_without_task_errors.md
@@ -7,5 +7,5 @@
 **Exit code:** 1
 
 ```
-Error: No task specifier provided for 'run' command
+error: No task specifier provided for 'run' command
 ```


### PR DESCRIPTION
## Motivation

The error-chain formatting (`error: <msg>` + `* <source>` lines, bold-red prefix) used to live in vite-plus at the napi boundary (voidzero-dev/vite-plus#784). That meant any tweak to error output — or any test that asserts on it — required building the whole vite-plus napi binding and running through the JS CLI.

Moving the formatter into vite-task lets us iterate on and snapshot-test the exact user-visible error output directly with `cargo test`, no vite-plus build needed. vite-plus can then drop its napi-side formatter since `Session::main` no longer surfaces errors across the boundary — it prints them itself and returns only an exit status.

## Changes

- New `vite_task::print_error(&anyhow::Error)` — writes `error: <top-level>` (bold red on TTY) plus `\n* <source>` for each link in the chain, mirroring the format vite-plus#784 introduced.
- `Session::main` signature: `anyhow::Result<ExitStatus>` → `ExitStatus`. It prints errors itself via `print_error` and returns `FAILURE`; the caller just exits with the status.
- `vt` binary uses `print_error` for `Session::init` errors too, so any error escaping the CLI uses the same format.
- e2e snapshots updated for the new format (`Error:` → `error:`, anyhow's `Caused by:\n    ...` block → `* ...` lines).

vite-plus is pinned to a vite-task revision and will be updated separately to drop its napi-layer formatter.

https://claude.ai/code/session_012BLuM9bhiDFBfc8U1CMst8