### PR TITLE
feat: exit 0 on `--filter` no-match, add `--fail-if-no-match`

### DIFF
--- a/crates/vite_task/src/cli/mod.rs
+++ b/crates/vite_task/src/cli/mod.rs
@@ -217,6 +217,8 @@ impl ResolvedRunCommand {
         let include_explicit_deps = !self.flags.ignore_depends_on;
         let concurrency_limit = self.flags.concurrency_limit.map(|n| n.max(1));
         let parallel = self.flags.parallel;
+        // Read before `into_package_query` consumes the args.
+        let fail_if_no_match = self.flags.package_query.fail_if_no_match;
 
         let (package_query, is_cwd_only) =
             self.flags.package_query.into_package_query(task_specifier.package_name, cwd)?;
@@ -233,6 +235,7 @@ impl ResolvedRunCommand {
                     cache_override,
                     concurrency_limit,
                     parallel,
+                    fail_if_no_match,
                 },
             },
             is_cwd_only,

--- a/crates/vite_task/src/session/mod.rs
+++ b/crates/vite_task/src/session/mod.rs
@@ -274,14 +274,22 @@ impl<'a> Session<'a> {
                 let graph = if let Some(ref task_specifier) = run_command.task_specifier {
                     // Task specifier provided — plan it.
                     let cwd = Arc::clone(&self.cwd);
-                    let (graph, is_cwd_only) =
+                    let (plan_result, is_cwd_only) =
                         self.plan_from_cli_run_resolved(cwd, run_command.clone()).await?;
 
-                    if graph.graph.node_count() == 0 {
-                        // No tasks matched. Show the interactive selector only when
-                        // the command has no scope flags and no execution flags
-                        // (concurrency-limit, parallel) — otherwise the user intended
-                        // a specific execution mode and a typo should be an error.
+                    if plan_result.graph.graph.node_count() == 0 {
+                        // Three empty-graph outcomes, in order of precedence:
+                        //   1. `--filter` selected zero packages — the planner has
+                        //      already warned per filter; exit 0 silently. This is the
+                        //      pnpm-compatible default; `--fail-if-no-match` opts in
+                        //      to strict behaviour and is raised inside the planner.
+                        //   2. Bare `vp run` (cwd-only, no execution flags) — fall
+                        //      through to the interactive task selector.
+                        //   3. Otherwise (e.g. typoed task, `-r` with no matching
+                        //      package) — surface NoTasksMatched.
+                        if plan_result.no_packages_matched {
+                            return Ok(());
+                        }
                         let has_execution_flags = run_command.flags.concurrency_limit.is_some()
                             || run_command.flags.parallel;
                         if is_cwd_only && !has_execution_flags {
@@ -294,7 +302,7 @@ impl<'a> Session<'a> {
                             .into());
                         }
                     } else {
-                        graph
+                        plan_result.graph
                     }
                 } else {
                     // No task specifier (e.g. `vp run` or `vp run --verbose`).
@@ -563,6 +571,9 @@ impl<'a> Session<'a> {
                 cache_override: run_command.flags.cache_override(),
                 concurrency_limit: None,
                 parallel: false,
+                // The selector path runs whatever the user picked interactively;
+                // there is no `--filter` in play, so strict-mode does not apply.
+                fail_if_no_match: false,
             },
         })
     }
@@ -741,8 +752,9 @@ impl<'a> Session<'a> {
         cwd: Arc<AbsolutePath>,
         command: RunCommand,
     ) -> Result<ExecutionGraph, vite_task_plan::Error> {
-        let (graph, _) = self.plan_from_cli_run_resolved(cwd, command.into_resolved()).await?;
-        Ok(graph)
+        let (plan_result, _) =
+            self.plan_from_cli_run_resolved(cwd, command.into_resolved()).await?;
+        Ok(plan_result.graph)
     }
 
     /// Internal: plans execution from a resolved run command.
@@ -751,7 +763,7 @@ impl<'a> Session<'a> {
         &mut self,
         cwd: Arc<AbsolutePath>,
         command: crate::cli::ResolvedRunCommand,
-    ) -> Result<(ExecutionGraph, bool), vite_task_plan::Error> {
+    ) -> Result<(vite_task_plan::PlanResult, bool), vite_task_plan::Error> {
         let (query_plan_request, is_cwd_only) = match command.into_query_plan_request(&cwd) {
             Ok(result) => result,
             Err(crate::cli::CLITaskQueryError::MissingTaskSpecifier) => {
@@ -766,7 +778,7 @@ impl<'a> Session<'a> {
                 });
             }
         };
-        let graph = vite_task_plan::plan_query(
+        let plan_result = vite_task_plan::plan_query(
             query_plan_request,
             &self.workspace_path,
             &cwd,
@@ -775,7 +787,7 @@ impl<'a> Session<'a> {
             &mut self.lazy_task_graph,
         )
         .await?;
-        Ok((graph, is_cwd_only))
+        Ok((plan_result, is_cwd_only))
     }
 
     /// Plan execution from a pre-built [`QueryPlanRequest`].
@@ -787,7 +799,7 @@ impl<'a> Session<'a> {
         request: QueryPlanRequest,
     ) -> Result<ExecutionGraph, vite_task_plan::Error> {
         let cwd = Arc::clone(&self.cwd);
-        vite_task_plan::plan_query(
+        let plan_result = vite_task_plan::plan_query(
             request,
             &self.workspace_path,
             &cwd,
@@ -795,7 +807,8 @@ impl<'a> Session<'a> {
             &mut self.plan_request_parser,
             &mut self.lazy_task_graph,
         )
-        .await
+        .await?;
+        Ok(plan_result.graph)
     }
 }
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots.toml
@@ -86,3 +86,17 @@ comment = """
 With `--fail-if-no-match` and only matching filters, the run proceeds normally — strict mode does not change the success path.
 """
 steps = [["vt", "run", "--filter", "@test/app", "--fail-if-no-match", "build"]]
+
+[[e2e]]
+name = "nested_filter_no_match_succeeds_by_default"
+comment = """
+The default-success rule must apply to nested `vt run --filter ...` invocations too: a task whose command is `vt run --filter nonexistent build` should exit 0 with the warning, not fail the outer task. Guards the script wrapping that pnpm users typically write.
+"""
+steps = [["vt", "run", "filter-nonexistent"]]
+
+[[e2e]]
+name = "nested_filter_no_match_with_fail_if_no_match_errors"
+comment = """
+Strict mode also propagates through nesting: a task command that adds `--fail-if-no-match` aborts the outer task when the nested filter selects nothing. The error chain identifies both the nested command and the unmatched filter source.
+"""
+steps = [["vt", "run", "filter-nonexistent-strict"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots.toml
@@ -39,3 +39,50 @@ comment = """
 A directory-style `--filter` (`./packages/...`) that points nowhere should warn just like an unmatched name filter.
 """
 steps = [["vt", "run", "--filter", "@test/app", "--filter", "./packages/nope", "build"]]
+
+[[e2e]]
+name = "filter_with_zero_results_exits_zero_by_default"
+comment = """
+A `--filter` whose entire result is empty (typo, glob with no match, …) prints the warning and exits 0 — pnpm's default. Previously this errored with `Task "build" not found`.
+"""
+steps = [["vt", "run", "--filter", "nonexistent", "build"]]
+
+[[e2e]]
+name = "traversal_collapsed_to_empty_exits_zero_by_default"
+comment = """
+`{.}^...` selects the dependencies of the current package, excluding itself. On a leaf with no workspace deps the expression collapses to zero matches — a legitimate no-op rather than a typo — so the run warns and exits 0.
+"""
+cwd = "packages/lib"
+steps = [["vt", "run", "--filter", "{.}^...", "build"]]
+
+[[e2e]]
+name = "fail_if_no_match_errors_on_unmatched_filter"
+comment = """
+With `--fail-if-no-match`, an unmatched `--filter` aborts the run with a non-zero exit code instead of warning. Mirrors pnpm's `--fail-if-no-match`.
+"""
+steps = [["vt", "run", "--filter", "nonexistent", "--fail-if-no-match", "build"]]
+
+[[e2e]]
+name = "fail_if_no_match_errors_even_when_other_filters_match"
+comment = """
+Strict mode errors on **any** unmatched filter, even when other filters did match packages — this catches typos in CI scripts that combine an exact name with a glob.
+"""
+steps = [
+  [
+    "vt",
+    "run",
+    "--filter",
+    "@test/app",
+    "--filter",
+    "nonexistent",
+    "--fail-if-no-match",
+    "build",
+  ],
+]
+
+[[e2e]]
+name = "fail_if_no_match_succeeds_when_all_filters_match"
+comment = """
+With `--fail-if-no-match` and only matching filters, the run proceeds normally — strict mode does not change the success path.
+"""
+steps = [["vt", "run", "--filter", "@test/app", "--fail-if-no-match", "build"]]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/fail_if_no_match_errors_even_when_other_filters_match.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/fail_if_no_match_errors_even_when_other_filters_match.md
@@ -1,0 +1,11 @@
+# fail_if_no_match_errors_even_when_other_filters_match
+
+Strict mode errors on **any** unmatched filter, even when other filters did match packages — this catches typos in CI scripts that combine an exact name with a glob.
+
+## `vt run --filter @test/app --filter nonexistent --fail-if-no-match build`
+
+**Exit code:** 1
+
+```
+error: No packages matched the filter: nonexistent
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/fail_if_no_match_errors_on_unmatched_filter.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/fail_if_no_match_errors_on_unmatched_filter.md
@@ -1,0 +1,11 @@
+# fail_if_no_match_errors_on_unmatched_filter
+
+With `--fail-if-no-match`, an unmatched `--filter` aborts the run with a non-zero exit code instead of warning. Mirrors pnpm's `--fail-if-no-match`.
+
+## `vt run --filter nonexistent --fail-if-no-match build`
+
+**Exit code:** 1
+
+```
+error: No packages matched the filter: nonexistent
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/fail_if_no_match_succeeds_when_all_filters_match.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/fail_if_no_match_succeeds_when_all_filters_match.md
@@ -1,0 +1,10 @@
+# fail_if_no_match_succeeds_when_all_filters_match
+
+With `--fail-if-no-match` and only matching filters, the run proceeds normally — strict mode does not change the success path.
+
+## `vt run --filter @test/app --fail-if-no-match build`
+
+```
+~/packages/app$ vtt print built-app
+built-app
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/filter_with_zero_results_exits_zero_by_default.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/filter_with_zero_results_exits_zero_by_default.md
@@ -1,0 +1,9 @@
+# filter_with_zero_results_exits_zero_by_default
+
+A `--filter` whose entire result is empty (typo, glob with no match, …) prints the warning and exits 0 — pnpm's default. Previously this errored with `Task "build" not found`.
+
+## `vt run --filter nonexistent build`
+
+```
+No packages matched the filter: nonexistent
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/nested_filter_no_match_succeeds_by_default.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/nested_filter_no_match_succeeds_by_default.md
@@ -1,0 +1,11 @@
+# nested_filter_no_match_succeeds_by_default
+
+The default-success rule must apply to nested `vt run --filter ...` invocations too: a task whose command is `vt run --filter nonexistent build` should exit 0 with the warning, not fail the outer task. Guards the script wrapping that pnpm users typically write.
+
+## `vt run filter-nonexistent`
+
+```
+No packages matched the filter: nonexistent
+---
+vt run: 0/0 cache hit (0%). (Run `vt run --last-details` for full details)
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/nested_filter_no_match_with_fail_if_no_match_errors.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/nested_filter_no_match_with_fail_if_no_match_errors.md
@@ -1,0 +1,12 @@
+# nested_filter_no_match_with_fail_if_no_match_errors
+
+Strict mode also propagates through nesting: a task command that adds `--fail-if-no-match` aborts the outer task when the nested filter selects nothing. The error chain identifies both the nested command and the unmatched filter source.
+
+## `vt run filter-nonexistent-strict`
+
+**Exit code:** 1
+
+```
+error: Failed to plan tasks from `vt run --filter nonexistent --fail-if-no-match build` in task filter-unmatched-test#filter-nonexistent-strict
+* No packages matched the filter: nonexistent
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/traversal_collapsed_to_empty_exits_zero_by_default.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/snapshots/traversal_collapsed_to_empty_exits_zero_by_default.md
@@ -1,0 +1,9 @@
+# traversal_collapsed_to_empty_exits_zero_by_default
+
+`{.}^...` selects the dependencies of the current package, excluding itself. On a leaf with no workspace deps the expression collapses to zero matches — a legitimate no-op rather than a typo — so the run warns and exits 0.
+
+## `vt run --filter {.}^... build`
+
+```
+No packages matched the filter: {.}^...
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/vite-task.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/filter_unmatched/vite-task.json
@@ -1,3 +1,13 @@
 {
-  "cache": true
+  "cache": true,
+  "tasks": {
+    "filter-nonexistent": {
+      "command": "vt run --filter nonexistent build",
+      "cache": false
+    },
+    "filter-nonexistent-strict": {
+      "command": "vt run --filter nonexistent --fail-if-no-match build",
+      "cache": false
+    }
+  }
 }

--- a/crates/vite_task_graph/src/query/mod.rs
+++ b/crates/vite_task_graph/src/query/mod.rs
@@ -79,15 +79,26 @@ pub struct TaskQueryResult {
     /// The final execution graph for the selected tasks.
     ///
     /// May be empty if no selected packages have the requested task, or if no
-    /// packages matched the filters. The caller uses `node_count() == 0` to
-    /// decide whether to show task-not-found UI.
+    /// packages matched the filters. The caller distinguishes the two cases
+    /// with [`Self::selected_package_count`].
     pub execution_graph: TaskExecutionGraph,
 
-    /// Original `--filter` strings for inclusion selectors that matched no packages.
+    /// Original `--filter` strings for inclusion filters that contributed no
+    /// packages to the final selected set — either the core selector matched
+    /// nothing, or the traversal (e.g. `^...`) collapsed an otherwise-matching
+    /// seed down to zero.
     ///
     /// Omits synthetic filters (implicit cwd, `-w`) since the user didn't type them.
     /// Always empty when `PackageQuery::All` was used.
     pub unmatched_selectors: Vec<Str>,
+
+    /// Number of packages in the resolved package subgraph (Stage 1 result),
+    /// before any task mapping.
+    ///
+    /// `0` means the filter expression(s) selected no packages at all — this
+    /// is what tells the caller "no packages matched the filter" rather than
+    /// "packages were selected but none have the requested task".
+    pub selected_package_count: usize,
 }
 
 impl IndexedTaskGraph {
@@ -116,6 +127,7 @@ impl IndexedTaskGraph {
 
         // Stage 1: resolve package selection.
         let resolution = self.indexed_package_graph.resolve_query(&query.package_query)?;
+        let selected_package_count = resolution.package_subgraph.node_count();
 
         // Stage 2: map each selected package to its task node (with reconnection).
         self.map_subgraph_to_tasks(
@@ -129,7 +141,11 @@ impl IndexedTaskGraph {
             self.add_dependencies(&mut execution_graph, |_| TaskDependencyType::is_explicit());
         }
 
-        Ok(TaskQueryResult { execution_graph, unmatched_selectors: resolution.unmatched_selectors })
+        Ok(TaskQueryResult {
+            execution_graph,
+            unmatched_selectors: resolution.unmatched_selectors,
+            selected_package_count,
+        })
     }
 
     /// Map a package subgraph to a task execution graph.

--- a/crates/vite_task_plan/src/error.rs
+++ b/crates/vite_task_plan/src/error.rs
@@ -154,6 +154,17 @@ pub enum Error {
     #[error("Task \"{0}\" not found")]
     NoTasksMatched(Str),
 
+    /// One or more `--filter` expressions matched no packages and the user
+    /// opted into strict mode with `--fail-if-no-match`. The message echoes
+    /// the warning phrasing ("No packages matched the filter: ...") and joins
+    /// multiple unmatched sources with `, ` so the chain renderer keeps it on
+    /// a single line.
+    #[error(
+        "No packages matched the filter: {}",
+        sources.iter().map(vite_str::Str::as_str).collect::<Vec<_>>().join(", ")
+    )]
+    NoPackagesMatched { sources: Vec<Str> },
+
     #[error("Invalid value for VP_RUN_CONCURRENCY_LIMIT: {0:?}")]
     InvalidConcurrencyLimitEnv(Arc<OsStr>),
 

--- a/crates/vite_task_plan/src/lib.rs
+++ b/crates/vite_task_plan/src/lib.rs
@@ -180,6 +180,20 @@ pub trait TaskGraphLoader {
     ) -> Result<&vite_task_graph::IndexedTaskGraph, TaskGraphLoadError>;
 }
 
+/// Output of [`plan_query`] (and the internal `plan_query_request`).
+///
+/// Wraps the [`ExecutionGraph`] together with a diagnostic flag that lets the
+/// CLI distinguish a Stage-1 zero-package result (a `--filter` that selected
+/// nothing — succeed silently) from a Stage-2 zero-task result (packages were
+/// selected but none have the requested task — surface `NoTasksMatched`).
+#[derive(Debug)]
+pub struct PlanResult {
+    pub graph: ExecutionGraph,
+    /// `true` when the package filter selected zero packages (Stage 1 was
+    /// empty). The warnings printed inside the planner already explain why.
+    pub no_packages_matched: bool,
+}
+
 /// Plan a query execution: load the task graph, query it, and build the execution graph.
 ///
 /// # Errors
@@ -193,7 +207,7 @@ pub async fn plan_query(
     envs: &FxHashMap<Arc<OsStr>, Arc<OsStr>>,
     plan_request_parser: &mut (dyn PlanRequestParser + '_),
     task_graph_loader: &mut (dyn TaskGraphLoader + '_),
-) -> Result<ExecutionGraph, Error> {
+) -> Result<PlanResult, Error> {
     let indexed_task_graph = task_graph_loader.load_task_graph().await?;
 
     let resolved_global_cache = resolve_cache_with_override(

--- a/crates/vite_task_plan/src/plan.rs
+++ b/crates/vite_task_plan/src/plan.rs
@@ -244,25 +244,29 @@ async fn plan_task_as_execution_node(
                     context.add_envs(and_item.envs.iter());
                     let QueryPlanRequest { query, plan_options } = query_plan_request;
                     let query = Arc::new(query);
-                    let execution_graph =
-                        plan_query_request(Arc::clone(&query), plan_options, context)
-                            .await
-                            .map_err(|error| Error::NestPlan {
-                                task_display: task_node.task_display.clone(),
-                                command: Str::from(&command_str[add_item_span.clone()]),
-                                error: Box::new(error),
-                            })?;
-                    // An empty execution graph means no tasks matched the query.
-                    // At the top level the session shows the task selector UI,
-                    // but in a nested context there is no UI — propagate as an error.
-                    if execution_graph.graph.node_count() == 0 {
+                    let nested_plan = plan_query_request(Arc::clone(&query), plan_options, context)
+                        .await
+                        .map_err(|error| Error::NestPlan {
+                            task_display: task_node.task_display.clone(),
+                            command: Str::from(&command_str[add_item_span.clone()]),
+                            error: Box::new(error),
+                        })?;
+                    // Two empty-graph cases:
+                    //   1. The nested filter selected no packages (`no_packages_matched`):
+                    //      treat as a no-op so a script's `vp run --filter X build` does
+                    //      not break when X happens to match nothing. The planner has
+                    //      already printed any per-filter warnings.
+                    //   2. Packages were selected but none have the task: there is no
+                    //      task selector in a nested context, so surface NoTasksMatched.
+                    if nested_plan.graph.graph.node_count() == 0 && !nested_plan.no_packages_matched
+                    {
                         return Err(Error::NestPlan {
                             task_display: task_node.task_display.clone(),
                             command: Str::from(&command_str[add_item_span]),
                             error: Box::new(Error::NoTasksMatched(task_name)),
                         });
                     }
-                    ExecutionItemKind::Expanded(execution_graph)
+                    ExecutionItemKind::Expanded(nested_plan.graph)
                 }
                 // Synthetic task (from CommandHandler)
                 Some(PlanRequest::Synthetic(synthetic_plan_request)) => {
@@ -685,7 +689,7 @@ pub async fn plan_query_request(
     query: Arc<TaskQuery>,
     plan_options: PlanOptions,
     mut context: PlanContext<'_>,
-) -> Result<ExecutionGraph, Error> {
+) -> Result<crate::PlanResult, Error> {
     // Apply cache override from `--cache` / `--no-cache` flags on this request.
     //
     // When `None`, we skip the update so the context keeps whatever the parent
@@ -736,15 +740,25 @@ pub async fn plan_query_request(
     context.set_parent_query(Arc::clone(&query));
 
     // Query matching tasks from the task graph.
-    // An empty graph means no tasks matched; the caller (session) handles
-    // empty graphs by showing the task selector.
+    // An empty graph means either no packages matched the filter (caller
+    // should succeed silently) or no selected package has the task (caller
+    // should error or show the task selector). `selected_package_count`
+    // tells the caller which case applies.
     let task_query_result = context.indexed_task_graph().query_tasks(&query)?;
+
+    // Strict mode (`--fail-if-no-match`): any user-provided `--filter` that
+    // contributed zero packages is an error. Skip the per-filter warnings
+    // below since the error already names every unmatched source.
+    if plan_options.fail_if_no_match && !task_query_result.unmatched_selectors.is_empty() {
+        return Err(Error::NoPackagesMatched { sources: task_query_result.unmatched_selectors });
+    }
 
     #[expect(clippy::print_stderr, reason = "user-facing warning for typos in --filter")]
     for selector in &task_query_result.unmatched_selectors {
         eprintln!("No packages matched the filter: {selector}");
     }
 
+    let no_packages_matched = task_query_result.selected_package_count == 0;
     let task_node_index_graph = task_query_result.execution_graph;
 
     // Prune rule: if the expanding task appears in the expansion, prune it.
@@ -824,28 +838,31 @@ pub async fn plan_query_request(
     // Validate the graph is acyclic.
     // `try_from_graph` performs a DFS; if a cycle is found, it returns
     // `CycleError` containing the full cycle path as node indices.
-    ExecutionGraph::try_from_graph(inner_graph, effective_concurrency).map_err(|cycle| {
-        // Map each execution node index in the cycle path to its human-readable TaskDisplay.
-        // Every node in the cycle was added via `inner_graph.add_node()` above,
-        // with a corresponding entry in `execution_node_indices_by_task_index`.
-        let displays = cycle
-            .cycle_path()
-            .iter()
-            .map(|&exec_idx| {
-                execution_node_indices_by_task_index
-                    .iter()
-                    .find_map(|(task_idx, &mapped_exec_idx)| {
-                        if mapped_exec_idx == exec_idx {
-                            Some(context.indexed_task_graph().display_task(*task_idx))
-                        } else {
-                            None
-                        }
-                    })
-                    .expect("cycle node must exist in execution_node_indices_by_task_index")
-            })
-            .collect();
-        Error::CycleDependencyDetected(displays)
-    })
+    let graph =
+        ExecutionGraph::try_from_graph(inner_graph, effective_concurrency).map_err(|cycle| {
+            // Map each execution node index in the cycle path to its human-readable TaskDisplay.
+            // Every node in the cycle was added via `inner_graph.add_node()` above,
+            // with a corresponding entry in `execution_node_indices_by_task_index`.
+            let displays = cycle
+                .cycle_path()
+                .iter()
+                .map(|&exec_idx| {
+                    execution_node_indices_by_task_index
+                        .iter()
+                        .find_map(|(task_idx, &mapped_exec_idx)| {
+                            if mapped_exec_idx == exec_idx {
+                                Some(context.indexed_task_graph().display_task(*task_idx))
+                            } else {
+                                None
+                            }
+                        })
+                        .expect("cycle node must exist in execution_node_indices_by_task_index")
+                })
+                .collect();
+            Error::CycleDependencyDetected(displays)
+        })?;
+
+    Ok(crate::PlanResult { graph, no_packages_matched })
 }
 
 /// Parse `VP_RUN_CONCURRENCY_LIMIT` from the environment variables.

--- a/crates/vite_task_plan/src/plan_request.rs
+++ b/crates/vite_task_plan/src/plan_request.rs
@@ -56,6 +56,10 @@ pub struct PlanOptions {
     /// running all tasks as independent. If `concurrency` is also `None`,
     /// this sets the effective concurrency to `usize::MAX`.
     pub parallel: bool,
+    /// When `true`, an unmatched `--filter` expression turns the warning into
+    /// an [`crate::Error::NoPackagesMatched`] error and the run exits non-zero.
+    /// Mirrors pnpm's `--fail-if-no-match`.
+    pub fail_if_no_match: bool,
 }
 
 #[derive(Debug)]

--- a/crates/vite_workspace/src/package_filter.rs
+++ b/crates/vite_workspace/src/package_filter.rs
@@ -245,6 +245,7 @@ pub enum PackageQueryError {
 /// Use `#[clap(flatten)]` to embed these in a parent clap struct.
 /// Call [`into_package_query`](Self::into_package_query) to convert into an opaque [`PackageQuery`].
 #[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
+#[expect(clippy::struct_excessive_bools, reason = "CLI flags are naturally boolean")]
 pub struct PackageQueryArgs {
     /// Select all packages in the workspace.
     #[clap(default_value = "false", short, long)]
@@ -275,6 +276,14 @@ Match packages by name, directory, or glob pattern.
   --filter !<pattern>       Exclude packages matching the pattern"
     )]
     filters: Vec<Str>,
+
+    /// Exit with a non-zero status if a `--filter` expression matches no packages.
+    ///
+    /// Without this flag, an unmatched filter (a typo, an empty glob, or a
+    /// traversal like `{.}^...` that collapses to zero on a leaf package) only
+    /// produces a warning and the command exits successfully.
+    #[clap(long = "fail-if-no-match", default_value = "false")]
+    pub fail_if_no_match: bool,
 }
 
 impl PackageQueryArgs {
@@ -297,7 +306,9 @@ impl PackageQueryArgs {
         package_name: Option<Str>,
         cwd: &Arc<AbsolutePath>,
     ) -> Result<(PackageQuery, bool), PackageQueryError> {
-        let Self { recursive, transitive, workspace_root, filters } = self;
+        // `fail_if_no_match` is read directly from the field before this
+        // method consumes `self`; it does not affect query construction.
+        let Self { recursive, transitive, workspace_root, filters, fail_if_no_match: _ } = self;
 
         // Collect filter tokens from all `--filter` arguments, splitting on whitespace.
         let mut filter_tokens = Vec::<Str>::with_capacity(filters.len());
@@ -1118,6 +1129,7 @@ mod tests {
             transitive: false,
             workspace_root: true,
             filters: Vec::new(),
+            fail_if_no_match: false,
         };
         let (query, _) = args.into_package_query(None, &cwd).unwrap();
         match &query.0 {
@@ -1144,6 +1156,7 @@ mod tests {
             transitive: false,
             workspace_root: true,
             filters: Vec::new(),
+            fail_if_no_match: false,
         };
         let (query, _) = args.into_package_query(None, &cwd).unwrap();
         assert!(
@@ -1162,6 +1175,7 @@ mod tests {
             transitive: true,
             workspace_root: true,
             filters: Vec::new(),
+            fail_if_no_match: false,
         };
         let (query, _) = args.into_package_query(None, &cwd).unwrap();
         match &query.0 {
@@ -1187,6 +1201,7 @@ mod tests {
             transitive: false,
             workspace_root: true,
             filters: vec![Str::from("foo")],
+            fail_if_no_match: false,
         };
         let (query, _) = args.into_package_query(None, &cwd).unwrap();
         match &query.0 {
@@ -1211,6 +1226,7 @@ mod tests {
             transitive: false,
             workspace_root: true,
             filters: Vec::new(),
+            fail_if_no_match: false,
         };
         assert!(matches!(
             args.into_package_query(Some(Str::from("app")), &cwd),
@@ -1235,6 +1251,7 @@ mod tests {
             transitive: false,
             workspace_root: false,
             filters: vec![Str::from("a b")],
+            fail_if_no_match: false,
         };
         let (query, _) = args.into_package_query(None, &cwd).unwrap();
         match &query.0 {
@@ -1255,6 +1272,7 @@ mod tests {
             transitive: false,
             workspace_root: true,
             filters: vec![Str::from("foo")],
+            fail_if_no_match: false,
         };
         let (query, _) = args.into_package_query(None, &cwd).unwrap();
         match &query.0 {
@@ -1275,6 +1293,7 @@ mod tests {
             transitive: false,
             workspace_root: false,
             filters: Vec::new(),
+            fail_if_no_match: false,
         };
         let (query, _) = args.into_package_query(None, &cwd).unwrap();
         match &query.0 {
@@ -1296,6 +1315,7 @@ mod tests {
             transitive: false,
             workspace_root: false,
             filters: vec![Str::from("")],
+            fail_if_no_match: false,
         };
         assert!(matches!(args.into_package_query(None, &cwd), Err(PackageQueryError::EmptyFilter)));
     }
@@ -1308,6 +1328,7 @@ mod tests {
             transitive: false,
             workspace_root: false,
             filters: vec![Str::from("   ")],
+            fail_if_no_match: false,
         };
         assert!(matches!(args.into_package_query(None, &cwd), Err(PackageQueryError::EmptyFilter)));
     }
@@ -1320,6 +1341,7 @@ mod tests {
             transitive: false,
             workspace_root: false,
             filters: vec![Str::from("foo"), Str::from("")],
+            fail_if_no_match: false,
         };
         assert!(matches!(args.into_package_query(None, &cwd), Err(PackageQueryError::EmptyFilter)));
     }
@@ -1332,6 +1354,7 @@ mod tests {
             transitive: false,
             workspace_root: false,
             filters: vec![Str::from(""), Str::from("foo")],
+            fail_if_no_match: false,
         };
         assert!(matches!(args.into_package_query(None, &cwd), Err(PackageQueryError::EmptyFilter)));
     }
@@ -1344,6 +1367,7 @@ mod tests {
             transitive: false,
             workspace_root: false,
             filters: vec![Str::from("foo"), Str::from("  \t  ")],
+            fail_if_no_match: false,
         };
         assert!(matches!(args.into_package_query(None, &cwd), Err(PackageQueryError::EmptyFilter)));
     }
@@ -1358,6 +1382,7 @@ mod tests {
             transitive: false,
             workspace_root: false,
             filters: Vec::new(),
+            fail_if_no_match: false,
         };
         let (_, is_cwd_only) = args.into_package_query(None, &cwd).unwrap();
         assert!(is_cwd_only);
@@ -1371,6 +1396,7 @@ mod tests {
             transitive: false,
             workspace_root: false,
             filters: Vec::new(),
+            fail_if_no_match: false,
         };
         let (_, is_cwd_only) = args.into_package_query(Some(Str::from("app")), &cwd).unwrap();
         assert!(!is_cwd_only);
@@ -1384,6 +1410,7 @@ mod tests {
             transitive: true,
             workspace_root: false,
             filters: Vec::new(),
+            fail_if_no_match: false,
         };
         let (_, is_cwd_only) = args.into_package_query(None, &cwd).unwrap();
         assert!(!is_cwd_only);
@@ -1397,6 +1424,7 @@ mod tests {
             transitive: false,
             workspace_root: false,
             filters: Vec::new(),
+            fail_if_no_match: false,
         };
         let (_, is_cwd_only) = args.into_package_query(None, &cwd).unwrap();
         assert!(!is_cwd_only);
@@ -1410,6 +1438,7 @@ mod tests {
             transitive: false,
             workspace_root: false,
             filters: vec![Str::from("foo")],
+            fail_if_no_match: false,
         };
         let (_, is_cwd_only) = args.into_package_query(None, &cwd).unwrap();
         assert!(!is_cwd_only);
@@ -1423,6 +1452,7 @@ mod tests {
             transitive: false,
             workspace_root: true,
             filters: Vec::new(),
+            fail_if_no_match: false,
         };
         let (_, is_cwd_only) = args.into_package_query(None, &cwd).unwrap();
         assert!(!is_cwd_only);

--- a/crates/vite_workspace/src/package_graph.rs
+++ b/crates/vite_workspace/src/package_graph.rs
@@ -100,7 +100,9 @@ pub struct FilterResolution {
     /// stage (construction time), keeping all downstream code edge-type-agnostic.
     pub package_subgraph: DiGraphMap<PackageNodeIndex, ()>,
 
-    /// Original `--filter` strings for inclusion selectors that matched no packages.
+    /// Original `--filter` strings for inclusion filters that contributed no packages
+    /// to the final selected set (either the core selector matched nothing, or the
+    /// selector matched but the graph traversal — e.g. `^...` — collapsed it to empty).
     ///
     /// Omits synthetic filters (implicit cwd, `-w`) since the user didn't type them.
     /// Empty when `PackageQuery::All` is used.
@@ -263,12 +265,16 @@ impl IndexedPackageGraph {
         // Apply inclusions: union each filter's resolved set into `selected`.
         for filter in &inclusions {
             let matched = self.resolve_selector_entries(&filter.selector)?;
-            if matched.is_empty()
+            let expanded = self.expand_traversal(matched, filter.traversal.as_ref());
+            // Track filters that contribute nothing (typo, no-match glob, or a
+            // traversal like `^...` that collapsed an otherwise-matching seed
+            // down to zero). Synthetic filters (implicit cwd, `-w`) have no
+            // user-typed source and are skipped — they aren't typos.
+            if expanded.is_empty()
                 && let Some(source) = &filter.source
             {
                 unmatched_selectors.push(source.clone());
             }
-            let expanded = self.expand_traversal(matched, filter.traversal.as_ref());
             selected.extend(expanded);
         }
 


### PR DESCRIPTION
## Summary

- Match pnpm: `vp run --filter <expr>` now exits **0** with a warning when the expression matches no packages, instead of failing with `Task "X" not found`.
- This also covers `--filter {.}^...` on a leaf package: the seed matches but the traversal collapses to zero, a legitimate no-op rather than a typo.
- Add `--fail-if-no-match` for callers (CI scripts) that want the previous strict behaviour. In strict mode, any unmatched `--filter` aborts the run, even when other filters did match.

## Implementation notes

- `unmatched_selectors` now tracks filters whose expanded set is empty (was: whose core selector matched nothing), so traversal collapses are reported too.
- `TaskQueryResult` exposes `selected_package_count` and `plan_query` returns a `PlanResult { graph, no_packages_matched }` so the CLI can distinguish "no packages matched filter" (succeed) from "packages matched but task missing" (still errors as `NoTasksMatched`).
- Nested `vp run --filter X build` inside a task script gets the same default-success treatment.

Closes #380
