### PR TITLE
refactor: remove unused `and_item_index` field from ExecutionItemDisplay

### DIFF
--- a/crates/vite_task/src/session/reporter/mod.rs
+++ b/crates/vite_task/src/session/reporter/mod.rs
@@ -465,7 +465,6 @@ pub mod test_fixtures {
         ExecutionItemDisplay {
             task_display: test_task_display(name),
             command: name.into(),
-            and_item_index: None,
             cwd: test_path(),
         }
     }

--- a/crates/vite_task_plan/src/lib.rs
+++ b/crates/vite_task_plan/src/lib.rs
@@ -103,10 +103,6 @@ pub struct ExecutionItemDisplay {
     /// `SpawnExecution` contains the actual args for execution.
     pub command: Str,
 
-    /// The index of this execution item among all items in the task's command split by `&&`.
-    /// If the task's command doesn't have `&&`, this will be `None`.
-    pub and_item_index: Option<usize>,
-
     /// The cwd when this execution item is planned.
     /// This is for displaying purpose only.
     ///

--- a/crates/vite_task_plan/src/plan.rs
+++ b/crates/vite_task_plan/src/plan.rs
@@ -175,7 +175,6 @@ async fn plan_task_as_execution_node(
                     }
                     command
                 },
-                and_item_index: if and_item_count > 1 { Some(index) } else { None },
                 cwd: Arc::clone(&cwd),
                 task_display: task_node.task_display.clone(),
             };
@@ -345,7 +344,6 @@ async fn plan_task_as_execution_node(
 
         let execution_item_display = ExecutionItemDisplay {
             command: command_str.into(),
-            and_item_index: None,
             cwd,
             task_display: task_node.task_display.clone(),
         };

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/additional_env/snapshots/query_tool_synthetic_task_in_user_task.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/additional_env/snapshots/query_tool_synthetic_task_in_user_task.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "TEST_VAR=hello_world vt tool print-env TEST_VAR",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_does_not_override_per_task_cache_false.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_does_not_override_per_task_cache_false.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vtt print-file vite-task.json",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_enables_script_caching.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_enables_script_caching.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vtt print-file package.json",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_enables_task_caching_even_when_cache_tasks_is_false.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_enables_task_caching_even_when_cache_tasks_is_false.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vtt print-file package.json",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_on_task_with_per_task_cache_true_enables_caching.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_on_task_with_per_task_cache_true_enables_caching.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vtt print-file package.json",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___no_cache_disables_task_caching.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___no_cache_disables_task_caching.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vtt print-file package.json",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___no_cache_overrides_per_task_cache_true.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___no_cache_overrides_per_task_cache_true.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vtt print-file package.json",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query_baseline___tasks_not_cached_when_cache_tasks_is_false.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query_baseline___tasks_not_cached_when_cache_tasks_is_false.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vtt print-file package.json",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_echo_and_lint_with_extra_args.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_echo_and_lint_with_extra_args.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "echo Linting",
-              "and_item_index": 0,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -47,7 +46,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt tool print lint --fix",
-              "and_item_index": 1,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_lint_and_echo_with_extra_args.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_lint_and_echo_with_extra_args.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt tool print lint",
-              "and_item_index": 0,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -89,7 +88,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "echo 'Linting complete'",
-              "and_item_index": 1,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_normal_task_with_extra_args.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_normal_task_with_extra_args.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vtt print-file a.txt",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_synthetic_task_in_user_task.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_synthetic_task_in_user_task.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt tool print lint",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_synthetic_task_in_user_task_with_cwd.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_synthetic_task_in_user_task_with_cwd.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt tool print lint",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_synthetic_task_with_extra_args_in_user_task.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_synthetic_task_with_extra_args_in_user_task.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt tool print lint --fix",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_default/snapshots/query_script_not_cached_by_default.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_default/snapshots/query_script_not_cached_by_default.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vtt print-file package.json",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_task_override/snapshots/query_another_task_cached_by_default.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_task_override/snapshots/query_another_task_cached_by_default.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vtt print-file package.json",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_task_override/snapshots/query_script_not_cached_by_default.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_task_override/snapshots/query_script_not_cached_by_default.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vtt print-file package.json",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_task_override/snapshots/query_task_cached_by_default.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_task_override/snapshots/query_task_cached_by_default.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vtt print-file package.json",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_subcommand/snapshots/query_cache_clean_in_script.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_subcommand/snapshots/query_cache_clean_in_script.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt cache clean",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_tasks_disabled/snapshots/query_per_task_cache_true_still_disabled_by_cache_tasks_false.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_tasks_disabled/snapshots/query_per_task_cache_true_still_disabled_by_cache_tasks_false.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vtt print-file package.json",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_tasks_disabled/snapshots/query_script_not_cached.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_tasks_disabled/snapshots/query_script_not_cached.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vtt print-file package.json",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_tasks_disabled/snapshots/query_task_not_cached_when_cache_tasks_is_false.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_tasks_disabled/snapshots/query_task_not_cached_when_cache_tasks_is_false.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vtt print-file package.json",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_true_no_force_enable/snapshots/query_script_cached_when_global_cache_true.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_true_no_force_enable/snapshots/query_script_cached_when_global_cache_true.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vtt print-file package.json",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_true_no_force_enable/snapshots/query_task_cached_when_global_cache_true.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_true_no_force_enable/snapshots/query_task_cached_when_global_cache_true.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vtt print-file package.json",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_true_no_force_enable/snapshots/query_task_with_cache_false_not_cached_despite_global_cache_true.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_true_no_force_enable/snapshots/query_task_with_cache_false_not_cached_despite_global_cache_true.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vtt print-file package.json",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cd_in_scripts/snapshots/query_cd_before_vt_lint_should_put_synthetic_task_under_cwd.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cd_in_scripts/snapshots/query_cd_before_vt_lint_should_put_synthetic_task_under_cwd.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt tool print lint",
-              "and_item_index": 1,
               "cwd": "<workspace>/src"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cd_in_scripts/snapshots/query_cd_before_vt_run_should_not_affect_expanded_task_cwd.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cd_in_scripts/snapshots/query_cd_before_vt_run_should_not_affect_expanded_task_cwd.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt run build",
-              "and_item_index": 1,
               "cwd": "<workspace>/src"
             },
             "kind": {
@@ -47,7 +46,6 @@
                               "package_path": "<workspace>/"
                             },
                             "command": "vtt print-file package.json",
-                            "and_item_index": null,
                             "cwd": "<workspace>/"
                           },
                           "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/extra_args_not_forwarded_to_depends_on/snapshots/query_extra_args_only_reach_requested_task.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/extra_args_not_forwarded_to_depends_on/snapshots/query_extra_args_only_reach_requested_task.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt tool print build",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -105,7 +104,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt tool print test some-filter",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_nested___cache_enables_inner_task_caching.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_nested___cache_enables_inner_task_caching.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt run --cache inner",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -47,7 +46,6 @@
                               "package_path": "<workspace>/"
                             },
                             "command": "vtt print-file package.json",
-                            "and_item_index": null,
                             "cwd": "<workspace>/"
                           },
                           "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_nested___no_cache_disables_inner_task_caching.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_nested___no_cache_disables_inner_task_caching.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt run --no-cache inner",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -47,7 +46,6 @@
                               "package_path": "<workspace>/"
                             },
                             "command": "vtt print-file package.json",
-                            "and_item_index": null,
                             "cwd": "<workspace>/"
                           },
                           "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_nested_run_without_flags_inherits_parent_cache.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_nested_run_without_flags_inherits_parent_cache.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt run inner",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -47,7 +46,6 @@
                               "package_path": "<workspace>/"
                             },
                             "command": "vtt print-file package.json",
-                            "and_item_index": null,
                             "cwd": "<workspace>/"
                           },
                           "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_outer___cache_propagates_to_nested_run_without_flags.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_outer___cache_propagates_to_nested_run_without_flags.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt run inner",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -47,7 +46,6 @@
                               "package_path": "<workspace>/"
                             },
                             "command": "vtt print-file package.json",
-                            "and_item_index": null,
                             "cwd": "<workspace>/"
                           },
                           "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_outer___no_cache_does_not_propagate_into_nested___cache.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_outer___no_cache_does_not_propagate_into_nested___cache.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt run --cache inner",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -47,7 +46,6 @@
                               "package_path": "<workspace>/"
                             },
                             "command": "vtt print-file package.json",
-                            "and_item_index": null,
                             "cwd": "<workspace>/"
                           },
                           "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_outer___no_cache_propagates_to_nested_run_without_flags.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_outer___no_cache_propagates_to_nested_run_without_flags.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt run inner",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -47,7 +46,6 @@
                               "package_path": "<workspace>/"
                             },
                             "command": "vtt print-file package.json",
-                            "and_item_index": null,
                             "cwd": "<workspace>/"
                           },
                           "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/parallel_and_concurrency/snapshots/query_cli_flag_overrides_env_var.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/parallel_and_concurrency/snapshots/query_cli_flag_overrides_env_var.jsonc
@@ -36,7 +36,6 @@
                 "package_path": "<workspace>/packages/a"
               },
               "command": "echo building a",
-              "and_item_index": null,
               "cwd": "<workspace>/packages/a"
             },
             "kind": {
@@ -84,7 +83,6 @@
                 "package_path": "<workspace>/packages/b"
               },
               "command": "echo building b",
-              "and_item_index": null,
               "cwd": "<workspace>/packages/b"
             },
             "kind": {
@@ -132,7 +130,6 @@
                 "package_path": "<workspace>/packages/c"
               },
               "command": "echo building c",
-              "and_item_index": null,
               "cwd": "<workspace>/packages/c"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/parallel_and_concurrency/snapshots/query_concurrency_limit_with_explicit_value.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/parallel_and_concurrency/snapshots/query_concurrency_limit_with_explicit_value.jsonc
@@ -36,7 +36,6 @@
                 "package_path": "<workspace>/packages/a"
               },
               "command": "echo building a",
-              "and_item_index": null,
               "cwd": "<workspace>/packages/a"
             },
             "kind": {
@@ -84,7 +83,6 @@
                 "package_path": "<workspace>/packages/b"
               },
               "command": "echo building b",
-              "and_item_index": null,
               "cwd": "<workspace>/packages/b"
             },
             "kind": {
@@ -132,7 +130,6 @@
                 "package_path": "<workspace>/packages/c"
               },
               "command": "echo building c",
-              "and_item_index": null,
               "cwd": "<workspace>/packages/c"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/parallel_and_concurrency/snapshots/query_env_var_sets_concurrency.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/parallel_and_concurrency/snapshots/query_env_var_sets_concurrency.jsonc
@@ -36,7 +36,6 @@
                 "package_path": "<workspace>/packages/a"
               },
               "command": "echo building a",
-              "and_item_index": null,
               "cwd": "<workspace>/packages/a"
             },
             "kind": {
@@ -84,7 +83,6 @@
                 "package_path": "<workspace>/packages/b"
               },
               "command": "echo building b",
-              "and_item_index": null,
               "cwd": "<workspace>/packages/b"
             },
             "kind": {
@@ -132,7 +130,6 @@
                 "package_path": "<workspace>/packages/c"
               },
               "command": "echo building c",
-              "and_item_index": null,
               "cwd": "<workspace>/packages/c"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/parallel_and_concurrency/snapshots/query_nested_with_explicit_concurrency_limit.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/parallel_and_concurrency/snapshots/query_nested_with_explicit_concurrency_limit.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt run -r --concurrency-limit 5 build",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -62,7 +61,6 @@
                               "package_path": "<workspace>/packages/a"
                             },
                             "command": "echo building a",
-                            "and_item_index": null,
                             "cwd": "<workspace>/packages/a"
                           },
                           "kind": {
@@ -110,7 +108,6 @@
                               "package_path": "<workspace>/packages/b"
                             },
                             "command": "echo building b",
-                            "and_item_index": null,
                             "cwd": "<workspace>/packages/b"
                           },
                           "kind": {
@@ -158,7 +155,6 @@
                               "package_path": "<workspace>/packages/c"
                             },
                             "command": "echo building c",
-                            "and_item_index": null,
                             "cwd": "<workspace>/packages/c"
                           },
                           "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/parallel_and_concurrency/snapshots/query_parallel_with_concurrency_limit.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/parallel_and_concurrency/snapshots/query_parallel_with_concurrency_limit.jsonc
@@ -36,7 +36,6 @@
                 "package_path": "<workspace>/packages/a"
               },
               "command": "echo building a",
-              "and_item_index": null,
               "cwd": "<workspace>/packages/a"
             },
             "kind": {
@@ -79,7 +78,6 @@
                 "package_path": "<workspace>/packages/b"
               },
               "command": "echo building b",
-              "and_item_index": null,
               "cwd": "<workspace>/packages/b"
             },
             "kind": {
@@ -122,7 +120,6 @@
                 "package_path": "<workspace>/packages/c"
               },
               "command": "echo building c",
-              "and_item_index": null,
               "cwd": "<workspace>/packages/c"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/parallel_and_concurrency/snapshots/query_parallel_without_concurrency_limit.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/parallel_and_concurrency/snapshots/query_parallel_without_concurrency_limit.jsonc
@@ -36,7 +36,6 @@
                 "package_path": "<workspace>/packages/a"
               },
               "command": "echo building a",
-              "and_item_index": null,
               "cwd": "<workspace>/packages/a"
             },
             "kind": {
@@ -79,7 +78,6 @@
                 "package_path": "<workspace>/packages/b"
               },
               "command": "echo building b",
-              "and_item_index": null,
               "cwd": "<workspace>/packages/b"
             },
             "kind": {
@@ -122,7 +120,6 @@
                 "package_path": "<workspace>/packages/c"
               },
               "command": "echo building c",
-              "and_item_index": null,
               "cwd": "<workspace>/packages/c"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks/snapshots/query_build_runs_with_pre_hook_only.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks/snapshots/query_build_runs_with_pre_hook_only.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "echo prebuild",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -47,7 +46,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "echo build",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks/snapshots/query_extra_args_not_passed_to_hooks.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks/snapshots/query_extra_args_not_passed_to_hooks.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "echo pretest",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -47,7 +46,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "echo test --coverage",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -74,7 +72,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "echo posttest",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks/snapshots/query_pretest_directly_expands_prepretest_but_not_when_called_as_hook.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks/snapshots/query_pretest_directly_expands_prepretest_but_not_when_called_as_hook.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "echo prepretest",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -47,7 +46,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "echo pretest",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks/snapshots/query_test_runs_with_pre_and_post_hooks.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks/snapshots/query_test_runs_with_pre_and_post_hooks.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "echo pretest",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -47,7 +46,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "echo test",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -73,7 +71,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "echo posttest",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks_disabled/snapshots/query_test_runs_without_hooks_when_disabled.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks_disabled/snapshots/query_test_runs_without_hooks_when_disabled.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "echo test",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks_nested_run/snapshots/query_prescriptInHook_runs_when_scriptInHook_is_called_from_a_hook.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks_nested_run/snapshots/query_prescriptInHook_runs_when_scriptInHook_is_called_from_a_hook.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt run scriptInHook",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -47,7 +46,6 @@
                               "package_path": "<workspace>/"
                             },
                             "command": "echo prescriptInHook",
-                            "and_item_index": null,
                             "cwd": "<workspace>/"
                           },
                           "kind": {
@@ -73,7 +71,6 @@
                               "package_path": "<workspace>/"
                             },
                             "command": "echo scriptInHook",
-                            "and_item_index": null,
                             "cwd": "<workspace>/"
                           },
                           "kind": {
@@ -108,7 +105,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "echo test",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks_task_no_hook/snapshots/query_task_config_test_does_not_expand_pretest_hook.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks_task_no_hook/snapshots/query_task_config_test_does_not_expand_pretest_hook.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "echo test-task",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/shell_fallback/snapshots/query_shell_fallback_for_pipe_command.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/shell_fallback/snapshots/query_shell_fallback_for_pipe_command.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "echo hello | node -e \"process.stdin.pipe(process.stdout)\"",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_parent_cache_false_does_not_affect_expanded_query_tasks.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_parent_cache_false_does_not_affect_expanded_query_tasks.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt run build",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -47,7 +46,6 @@
                               "package_path": "<workspace>/"
                             },
                             "command": "vt tool print lint",
-                            "and_item_index": null,
                             "cwd": "<workspace>/"
                           },
                           "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_script_cache_false_does_not_affect_expanded_synthetic_cache.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_script_cache_false_does_not_affect_expanded_synthetic_cache.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt run build",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -47,7 +46,6 @@
                               "package_path": "<workspace>/"
                             },
                             "command": "vt tool print lint",
-                            "and_item_index": null,
                             "cwd": "<workspace>/"
                           },
                           "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_script_without_cache_scripts_defaults_to_no_cache.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_script_without_cache_scripts_defaults_to_no_cache.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt tool print lint",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_task_untrackedEnv_inherited_by_synthetic.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_task_untrackedEnv_inherited_by_synthetic.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt tool print lint",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_task_with_cache_false_disables_synthetic_cache.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_task_with_cache_false_disables_synthetic_cache.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt tool print lint",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_task_with_cache_true_enables_synthetic_cache.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_task_with_cache_true_enables_synthetic_cache.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt tool print lint",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_in_subpackage/snapshots/query_synthetic_in_subpackage.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_in_subpackage/snapshots/query_synthetic_in_subpackage.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/"
               },
               "command": "vt run a#lint",
-              "and_item_index": null,
               "cwd": "<workspace>/"
             },
             "kind": {
@@ -47,7 +46,6 @@
                               "package_path": "<workspace>/packages/a"
                             },
                             "command": "vt tool print lint",
-                            "and_item_index": null,
                             "cwd": "<workspace>/packages/a"
                           },
                           "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/windows_cmd_shim_rewrite/snapshots/query_dev_filter_from_root.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/windows_cmd_shim_rewrite/snapshots/query_dev_filter_from_root.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/packages/foo"
               },
               "command": "vite --port 3000",
-              "and_item_index": null,
               "cwd": "<workspace>/packages/foo"
             },
             "kind": {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/windows_cmd_shim_rewrite/snapshots/query_dev_in_subpackage.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/windows_cmd_shim_rewrite/snapshots/query_dev_in_subpackage.jsonc
@@ -21,7 +21,6 @@
                 "package_path": "<workspace>/packages/foo"
               },
               "command": "vite --port 3000",
-              "and_item_index": null,
               "cwd": "<workspace>/packages/foo"
             },
             "kind": {


### PR DESCRIPTION
Removes the `and_item_index` field from the `ExecutionItemDisplay` struct, which tracked the index of execution items split by `&&` in task commands. This field was populated during task planning but never used downstream.

## Changes

- **Struct definition**: Removed `and_item_index: Option<usize>` field from `ExecutionItemDisplay` in `crates/vite_task_plan/src/lib.rs`
- **Planning logic**: Removed the assignment of `and_item_index` in `crates/vite_task_plan/src/plan.rs` (both for split commands and single commands)
- **Test fixtures**: Updated all snapshot files to remove the `and_item_index` field from serialized output
- **Test utilities**: Removed the field initialization in test fixture helpers in `crates/vite_task/src/session/reporter/mod.rs`

## Rationale

The `and_item_index` field was computed during task planning to indicate which part of a `&&`-separated command sequence an execution item represented, but this information was never consumed by any downstream code. Removing it simplifies the data structure and reduces unnecessary computation.

https://claude.ai/code/session_01LXLpjxLchyX5FyD8Fzmxqp