### PR TITLE
refactor: replace allocator-api2 with bumpalo collections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,9 +350,6 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
-dependencies = [
- "allocator-api2",
-]
 
 [[package]]
 name = "bytemuck"
@@ -1232,7 +1229,6 @@ dependencies = [
 name = "fspy"
 version = "0.1.0"
 dependencies = [
- "allocator-api2",
  "anyhow",
  "bstr",
  "bumpalo",
@@ -1342,10 +1338,10 @@ dependencies = [
 name = "fspy_shared"
 version = "0.0.0"
 dependencies = [
- "allocator-api2",
  "assert2",
  "bitflags 2.10.0",
  "bstr",
+ "bumpalo",
  "bytemuck",
  "ctor",
  "native_str",
@@ -2040,7 +2036,7 @@ dependencies = [
 name = "native_str"
 version = "0.0.0"
 dependencies = [
- "allocator-api2",
+ "bumpalo",
  "bytemuck",
  "wincode",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ multiple_crate_versions = "allow"
 future_not_send = "allow"
 
 [workspace.dependencies]
-allocator-api2 = { version = "0.2.21", default-features = false, features = ["alloc", "std"] }
 anstream = "1.0.0"
 anyhow = "1.0.98"
 assert2 = "0.4.0"
@@ -51,7 +50,7 @@ bindgen = "0.72.1"
 bitflags = "2.10.0"
 brush-parser = "0.4.0"
 bstr = { version = "1.12.0", default-features = false, features = ["alloc", "std"] }
-bumpalo = { version = "3.17.0", features = ["allocator-api2"] }
+bumpalo = { version = "3.17.0", features = ["collections"] }
 bytemuck = { version = "1.23.0", features = ["extern_crate_alloc", "must_cast"] }
 cc = "1.2.39"
 clap = "4.5.53"

--- a/crates/fspy/Cargo.toml
+++ b/crates/fspy/Cargo.toml
@@ -6,7 +6,6 @@ license.workspace = true
 publish = false
 
 [dependencies]
-allocator-api2 = { workspace = true, features = ["alloc"] }
 wincode = { workspace = true }
 bstr = { workspace = true, default-features = false }
 bumpalo = { workspace = true }

--- a/crates/fspy/src/arena.rs
+++ b/crates/fspy/src/arena.rs
@@ -1,5 +1,4 @@
-use allocator_api2::vec::Vec;
-use bumpalo::Bump;
+use bumpalo::{Bump, collections::Vec};
 
 use crate::PathAccess;
 
@@ -10,7 +9,7 @@ pub struct PathAccessArena {
     #[borrows(bump)]
     #[covariant]
     // TODO(pref): use linked list to avoid realloc & copy. We don't need random access.
-    pub accesses: Vec<PathAccess<'this>, &'this Bump>,
+    pub accesses: Vec<'this, PathAccess<'this>>,
 }
 
 impl Default for PathAccessArena {

--- a/crates/fspy_shared/Cargo.toml
+++ b/crates/fspy_shared/Cargo.toml
@@ -6,9 +6,9 @@ license.workspace = true
 publish = false
 
 [dependencies]
-allocator-api2 = { workspace = true }
 wincode = { workspace = true, features = ["derive"] }
 bitflags = { workspace = true }
+bumpalo = { workspace = true }
 bstr = { workspace = true }
 bytemuck = { workspace = true, features = ["must_cast", "derive"] }
 native_str = { workspace = true }

--- a/crates/fspy_shared/src/ipc/native_path.rs
+++ b/crates/fspy_shared/src/ipc/native_path.rs
@@ -7,7 +7,7 @@ use std::{
     path::{Path, StripPrefixError},
 };
 
-use allocator_api2::alloc::Allocator;
+use bumpalo::Bump;
 use bytemuck::TransparentWrapper;
 use native_str::NativeStr;
 use wincode::{
@@ -61,11 +61,8 @@ impl NativePath {
         Self::wrap_ref(NativeStr::from_wide(wide))
     }
 
-    pub fn clone_in<'new_alloc, A>(&self, alloc: &'new_alloc A) -> &'new_alloc Self
-    where
-        &'new_alloc A: Allocator,
-    {
-        Self::wrap_ref(self.inner.clone_in(alloc))
+    pub fn clone_in<'bump>(&self, bump: &'bump Bump) -> &'bump Self {
+        Self::wrap_ref(self.inner.clone_in(bump))
     }
 
     pub fn strip_path_prefix<P: AsRef<Path>, R, F: FnOnce(Result<&Path, StripPrefixError>) -> R>(

--- a/crates/native_str/Cargo.toml
+++ b/crates/native_str/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 rust-version.workspace = true
 
 [dependencies]
-allocator-api2 = { workspace = true }
+bumpalo = { workspace = true }
 bytemuck = { workspace = true, features = ["must_cast", "derive"] }
 wincode = { workspace = true }
 

--- a/crates/native_str/src/lib.rs
+++ b/crates/native_str/src/lib.rs
@@ -8,7 +8,7 @@ use std::os::windows::ffi::OsStrExt as _;
 use std::os::windows::ffi::OsStringExt as _;
 use std::{borrow::Cow, ffi::OsStr, fmt::Debug, mem::MaybeUninit};
 
-use allocator_api2::alloc::Allocator;
+use bumpalo::Bump;
 #[cfg(windows)]
 use bytemuck::must_cast_slice;
 use bytemuck::{TransparentWrapper, TransparentWrapperAlloc};
@@ -87,15 +87,8 @@ impl NativeStr {
         return Cow::Borrowed(self.as_os_str());
     }
 
-    pub fn clone_in<'new_alloc, A>(&self, alloc: &'new_alloc A) -> &'new_alloc Self
-    where
-        &'new_alloc A: Allocator,
-    {
-        use allocator_api2::vec::Vec;
-        let mut data = Vec::<u8, _>::with_capacity_in(self.data.len(), alloc);
-        data.extend_from_slice(&self.data);
-        let data = data.leak::<'new_alloc>();
-        Self::wrap_ref(data)
+    pub fn clone_in<'bump>(&self, bump: &'bump Bump) -> &'bump Self {
+        Self::wrap_ref(bump.alloc_slice_copy(&self.data))
     }
 }
 


### PR DESCRIPTION
Replace the generic `allocator-api2` dependency with `bumpalo`'s built-in collections API for simpler, more direct arena allocation.

## Motivation

`bumpalo` pins its optional `allocator-api2` dependency at `^0.2.8`, which means `bumpalo::Bump` only implements `allocator_api2::alloc::Allocator` from the 0.2.x line. When Renovate proposes upgrading our direct `allocator-api2` dependency past 0.2.x (e.g. PR #384 tried to bump it to 0.4.0), the workspace ends up with two incompatible versions of the `Allocator` trait in the dependency graph, and `&Bump` no longer satisfies the trait bound used by `NativePath::clone_in` / `NativeStr::clone_in`. The result is a compile error that can only be resolved by reverting the Renovate upgrade — until upstream `bumpalo` decides to bump its own `allocator-api2` requirement.

Dropping `allocator-api2` as a direct workspace dependency removes the pin we have no control over, eliminates the recurring Renovate noise, and lets `bumpalo` upgrades land independently. `allocator-api2 0.2.x` remains in the graph transitively (via `hashbrown`), but that's an internal concern of `hashbrown` and no longer ours to manage.

## Summary

This refactor removes the `allocator-api2` crate dependency across the codebase and consolidates on `bumpalo` for all arena-based allocations. The change simplifies the generic allocator abstraction to a concrete `Bump` allocator, reducing complexity while maintaining the same functionality.

## Key Changes

- **`native_str` and `fspy_shared`**: Simplified `clone_in()` methods to accept `&Bump` directly instead of generic `Allocator` trait bounds
  - `NativeStr::clone_in()` now uses `bump.alloc_slice_copy()` instead of manual `Vec` allocation and leak
  - `NativePath::clone_in()` delegates to the simplified `NativeStr` method

- **`fspy` arena**: Updated to use `bumpalo::collections::Vec` instead of `allocator_api2::vec::Vec`
  - Changed `Vec<PathAccess<'this>, &'this Bump>` to `Vec<'this, PathAccess<'this>>` (bumpalo's syntax)

- **Dependencies**:
  - Removed `allocator-api2` from workspace and all crate dependencies
  - Updated `bumpalo` feature from `allocator-api2` to `collections`
  - Added explicit `bumpalo` dependency to `fspy_shared` (was implicit before)

## Implementation Details

The change leverages `bumpalo`'s native collection types which are simpler and more ergonomic than the generic allocator abstraction. This reduces trait bounds and makes the code more readable while maintaining the same arena allocation semantics.

https://claude.ai/code/session_01PbgnWekFEAwysNrpigCzCJ