### PR TITLE
chore(cache): bump database schema version to 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- **Changed** `vp run --filter <expr>` now exits 0 with a warning when the filter matches no packages, matching pnpm. Use `--fail-if-no-match` to restore the previous strict behavior ([#393](https://github.com/voidzero-dev/vite-task/pull/393))
 - **Added** task command shorthands for defining tasks as command strings or command string arrays ([#391](https://github.com/voidzero-dev/vite-task/pull/391))
 - **Changed** Cached logs are stored with colors intact (`FORCE_COLOR=1` is auto-injected into spawned tasks). Colors are then stripped at display time when the terminal does not support them. Other color-related env vars (`NO_COLOR`, `COLORTERM`, `TERM`, `TERM_PROGRAM`) are no longer passed through by default. Opt in via a task's `env`/`untrackedEnv` ([#378](https://github.com/voidzero-dev/vite-task/pull/378))
 - **Added** `output` field for cached tasks: archives matching files after a successful run and restores them on cache hit ([#375](https://github.com/voidzero-dev/vite-task/pull/375))

--- a/crates/vite_task/src/session/cache/mod.rs
+++ b/crates/vite_task/src/session/cache/mod.rs
@@ -215,16 +215,16 @@ impl ExecutionCache {
                         "CREATE TABLE task_fingerprints (key BLOB PRIMARY KEY, value BLOB);",
                         (),
                     )?;
-                    conn.execute("PRAGMA user_version = 12", ())?;
+                    conn.execute("PRAGMA user_version = 13", ())?;
                 }
-                1..=11 => {
+                1..=12 => {
                     // old internal db version. reset
                     conn.set_db_config(DbConfig::SQLITE_DBCONFIG_RESET_DATABASE, true)?;
                     conn.execute("VACUUM", ())?;
                     conn.set_db_config(DbConfig::SQLITE_DBCONFIG_RESET_DATABASE, false)?;
                 }
-                12 => break, // current version
-                13.. => {
+                13 => break, // current version
+                14.. => {
                     return Err(anyhow::anyhow!(
                         "Unrecognized database version: {user_version}. \
                          The cache may have been created by a newer version of Vite Task. \


### PR DESCRIPTION
Increments the SQLite database schema version from 12 to 13 to invalidate existing caches. This ensures that any cached data from previous versions is discarded and regenerated with the current schema.

## Changes

- Updated `PRAGMA user_version` from 12 to 13 in the database initialization path
- Adjusted version range checks: versions 1-12 now trigger a reset, and version 13 is the current version
- Versions 14+ are treated as from a newer/incompatible version

This is a routine cache invalidation bump, likely accompanying other changes documented in the changelog entry about filter behavior and task command shorthands.

https://claude.ai/code/session_014GJcPFA2riNUVobvPFKs7s