### PR TITLE
feat(ipc): protocol + Rust transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4216,6 +4216,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "vite_task_client"
+version = "0.0.0"
+dependencies = [
+ "native_str",
+ "rustc-hash",
+ "vite_path",
+ "vite_task_ipc_shared",
+ "winapi",
+ "wincode",
+]
+
+[[package]]
 name = "vite_task_graph"
 version = "0.1.0"
 dependencies = [
@@ -4235,6 +4247,15 @@ dependencies = [
  "vite_str",
  "vite_workspace",
  "wax",
+ "wincode",
+]
+
+[[package]]
+name = "vite_task_ipc_shared"
+version = "0.0.0"
+dependencies = [
+ "native_str",
+ "rustc-hash",
  "wincode",
 ]
 
@@ -4273,6 +4294,26 @@ dependencies = [
  "vite_task_graph",
  "vite_workspace",
  "which",
+ "wincode",
+]
+
+[[package]]
+name = "vite_task_server"
+version = "0.0.0"
+dependencies = [
+ "futures",
+ "native_str",
+ "rustc-hash",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+ "vite_glob",
+ "vite_path",
+ "vite_task_client",
+ "vite_task_ipc_shared",
  "wincode",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,8 +149,11 @@ vite_shell = { path = "crates/vite_shell" }
 vite_str = { path = "crates/vite_str" }
 vite_task = { path = "crates/vite_task" }
 vite_task_bin = { path = "crates/vite_task_bin" }
+vite_task_client = { path = "crates/vite_task_client" }
 vite_task_graph = { path = "crates/vite_task_graph" }
+vite_task_ipc_shared = { path = "crates/vite_task_ipc_shared" }
 vite_task_plan = { path = "crates/vite_task_plan" }
+vite_task_server = { path = "crates/vite_task_server" }
 vite_workspace = { path = "crates/vite_workspace" }
 vt100 = "0.16.2"
 wax = "0.7.0"
@@ -168,6 +171,10 @@ ignored = [
   # These are artifact dependencies. They are not directly `use`d in Rust code.
   "fspy_preload_unix",
   "fspy_preload_windows",
+  # Registered in the workspace dependency table so downstream PRs in the
+  # runner-aware-tools stack can pick it up via `workspace = true` without
+  # touching this file. No in-tree consumer in this PR.
+  "vite_task_server",
 ]
 
 [profile.dev]

--- a/crates/native_str/src/lib.rs
+++ b/crates/native_str/src/lib.rs
@@ -37,7 +37,7 @@ use wincode::{
 /// **Not portable across platforms.** The binary representation is platform-specific.
 /// Deserializing a `NativeStr` serialized on a different platform leads to unspecified
 /// behavior (garbage data), but is not unsafe. Designed for same-platform IPC only.
-#[derive(TransparentWrapper, PartialEq, Eq)]
+#[derive(TransparentWrapper, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct NativeStr {
     // On unix, this is the raw bytes of the OsStr.

--- a/crates/vite_task_client/Cargo.toml
+++ b/crates/vite_task_client/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "vite_task_client"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+publish = false
+rust-version.workspace = true
+
+[dependencies]
+native_str = { workspace = true }
+rustc-hash = { workspace = true }
+vite_path = { workspace = true }
+vite_task_ipc_shared = { workspace = true }
+wincode = { workspace = true, features = ["derive"] }
+
+[target.'cfg(windows)'.dependencies]
+winapi = { workspace = true, features = ["namedpipeapi"] }
+
+[lints]
+workspace = true
+
+[lib]
+doctest = false
+test = false

--- a/crates/vite_task_client/README.md
+++ b/crates/vite_task_client/README.md
@@ -1,0 +1,3 @@
+# vite_task_client
+
+IPC client that connects from tool processes to the task runner to report inputs/outputs, request env values, and disable caching.

--- a/crates/vite_task_client/src/lib.rs
+++ b/crates/vite_task_client/src/lib.rs
@@ -1,0 +1,264 @@
+use std::{
+    cell::RefCell,
+    ffi::OsStr,
+    io::{self, Read, Write},
+    sync::Arc,
+};
+
+use native_str::NativeStr;
+use rustc_hash::FxHashMap;
+use vite_path::{self, AbsolutePath};
+use vite_task_ipc_shared::{GetEnvResponse, GetEnvsResponse, IPC_ENV_NAME, Request};
+
+#[cfg(unix)]
+type Stream = std::os::unix::net::UnixStream;
+#[cfg(windows)]
+type Stream = std::fs::File;
+
+pub struct Client {
+    stream: RefCell<Stream>,
+    scratch: RefCell<Vec<u8>>,
+}
+
+impl Client {
+    /// Scans `envs` for the runner's IPC connection info and connects if
+    /// present. Typical callers pass `std::env::vars_os()`.
+    ///
+    /// Returns `Ok(None)` if the IPC env is absent (running outside the runner).
+    /// `Err(..)` if the env is set but connecting fails.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the env var is set but the server cannot be reached.
+    pub fn from_envs(
+        envs: impl Iterator<Item = (impl AsRef<OsStr>, impl AsRef<OsStr>)>,
+    ) -> io::Result<Option<Self>> {
+        for (name, value) in envs {
+            if name.as_ref() == IPC_ENV_NAME {
+                let stream = connect(value.as_ref())?;
+                return Ok(Some(Self::from_stream(stream)));
+            }
+        }
+        Ok(None)
+    }
+
+    const fn from_stream(stream: Stream) -> Self {
+        Self { stream: RefCell::new(stream), scratch: RefCell::new(Vec::new()) }
+    }
+
+    /// `path` can be a file or a directory; for a directory, all files inside
+    /// it are ignored. Relative paths are resolved against the current working
+    /// directory before being sent to the runner.
+    ///
+    /// Fire-and-forget: the call returns once the request is flushed to the
+    /// kernel pipe buffer; the runner processes it during its drain phase
+    /// after this process exits. See the `Request` type in the IPC protocol
+    /// crate for why this is safe.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails to send, or (for a relative
+    /// `path`) if the current working directory cannot be read.
+    pub fn ignore_input(&self, path: &OsStr) -> io::Result<()> {
+        let ns = resolve_path(path)?;
+        self.send(&Request::IgnoreInput(&ns))
+    }
+
+    /// `path` can be a file or a directory; for a directory, all files inside
+    /// it are ignored. Relative paths are resolved against the current working
+    /// directory before being sent to the runner.
+    ///
+    /// Fire-and-forget — see [`Self::ignore_input`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails to send, or (for a relative
+    /// `path`) if the current working directory cannot be read.
+    pub fn ignore_output(&self, path: &OsStr) -> io::Result<()> {
+        let ns = resolve_path(path)?;
+        self.send(&Request::IgnoreOutput(&ns))
+    }
+
+    /// Fire-and-forget — see [`Self::ignore_input`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails to send.
+    pub fn disable_cache(&self) -> io::Result<()> {
+        self.send(&Request::DisableCache)
+    }
+
+    /// Requests an env value from the runner. Returns `None` if the runner reports
+    /// the env is not available.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request or response fails.
+    pub fn get_env(&self, name: &OsStr, tracked: bool) -> io::Result<Option<Arc<OsStr>>> {
+        let name = Box::<NativeStr>::from(name);
+
+        self.send(&Request::GetEnv { name: &name, tracked })?;
+        self.recv_with(|bytes| {
+            let response: GetEnvResponse<'_> = wincode::deserialize_exact(bytes)
+                .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+            Ok(response
+                .env_value
+                .map(|env_value| Arc::<OsStr>::from(env_value.to_cow_os_str().as_ref())))
+        })
+    }
+
+    /// Requests every env whose name matches `pattern` from the runner. The
+    /// returned map is keyed by env name with its value.
+    ///
+    /// Unlike [`Self::get_env`], this always round-trips to the server — the
+    /// client has no way to know in advance which names the pattern matches.
+    /// Env names that aren't valid UTF-8 are silently dropped at the server.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request or response fails, or if the server
+    /// rejected the pattern as an invalid glob.
+    pub fn get_envs(
+        &self,
+        pattern: &str,
+        tracked: bool,
+    ) -> io::Result<FxHashMap<Arc<OsStr>, Arc<OsStr>>> {
+        self.send(&Request::GetEnvs { pattern, tracked })?;
+        self.recv_with(|bytes| {
+            let response: GetEnvsResponse<'_> = wincode::deserialize_exact(bytes)
+                .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+            Ok(response
+                .entries
+                .iter()
+                .map(|(name, value)| {
+                    (
+                        Arc::<OsStr>::from(name.to_cow_os_str().as_ref()),
+                        Arc::<OsStr>::from(value.to_cow_os_str().as_ref()),
+                    )
+                })
+                .collect())
+        })
+    }
+
+    fn send(&self, request: &Request<'_>) -> io::Result<()> {
+        let bytes = wincode::serialize(request)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        let len = u32::try_from(bytes.len())
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "request too large"))?;
+        let mut stream = self.stream.borrow_mut();
+        stream.write_all(&len.to_le_bytes())?;
+        stream.write_all(&bytes)?;
+        stream.flush()?;
+        Ok(())
+    }
+
+    fn recv_with<T>(&self, extract: impl FnOnce(&[u8]) -> io::Result<T>) -> io::Result<T> {
+        let mut stream = self.stream.borrow_mut();
+        let mut scratch = self.scratch.borrow_mut();
+        let mut len_bytes = [0u8; 4];
+        stream.read_exact(&mut len_bytes)?;
+        let len = u32::from_le_bytes(len_bytes) as usize;
+        scratch.clear();
+        scratch.resize(len, 0);
+        stream.read_exact(&mut scratch)?;
+        extract(&scratch)
+    }
+}
+
+#[cfg(unix)]
+fn connect(name: &OsStr) -> io::Result<Stream> {
+    std::os::unix::net::UnixStream::connect(name)
+}
+
+/// Open a Windows named pipe as a client.
+///
+/// `OpenOptions::open` on a named-pipe path fails with `ERROR_PIPE_BUSY` when
+/// the server's only pending instance has just been claimed by another client
+/// — the brief window between the server accepting one connection and creating
+/// the next instance. On `ERROR_PIPE_BUSY` we hand off to the kernel via
+/// `WaitNamedPipeW`, which blocks until an instance becomes available (or
+/// fails if the named pipe is gone). No polling and no arbitrary timeouts.
+///
+/// This matches what the `interprocess` crate does internally.
+#[cfg(windows)]
+fn connect(name: &OsStr) -> io::Result<Stream> {
+    use std::{fs::OpenOptions, os::windows::ffi::OsStrExt};
+
+    use winapi::um::namedpipeapi::WaitNamedPipeW;
+
+    // ERROR_PIPE_BUSY — see WinError.h. `std::io::Error` does not expose a
+    // typed constant for this, so the raw OS code is the cleanest test.
+    const ERROR_PIPE_BUSY: i32 = 231;
+    // NMPWAIT_WAIT_FOREVER — see WinBase.h. winapi 0.3 doesn't define the
+    // NMPWAIT_* constants yet (only the comment placeholder).
+    const NMPWAIT_WAIT_FOREVER: u32 = 0xFFFF_FFFF;
+
+    // `WaitNamedPipeW` needs a NUL-terminated UTF-16 path.
+    let mut wide: Vec<u16> = name.encode_wide().collect();
+    wide.push(0);
+
+    loop {
+        match OpenOptions::new().read(true).write(true).open(name) {
+            Ok(file) => return Ok(file),
+            Err(err) if err.raw_os_error() == Some(ERROR_PIPE_BUSY) => {
+                // SAFETY: `wide` is NUL-terminated; pointer stays valid for
+                // the call's duration. `NMPWAIT_WAIT_FOREVER` makes this a
+                // bounded kernel wait (server's pipe wait-timeout is the
+                // upper bound on each retry; default ~50ms, then we loop).
+                let ok = unsafe { WaitNamedPipeW(wide.as_ptr(), NMPWAIT_WAIT_FOREVER) };
+                if ok == 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                // Loop and re-open — another client may have raced us to the
+                // newly-available instance.
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+#[expect(
+    clippy::disallowed_types,
+    reason = "std::path::PathBuf is needed to round-trip through std::fs::canonicalize on Windows below"
+)]
+fn resolve_path(path: &OsStr) -> io::Result<Box<NativeStr>> {
+    let absolute: std::path::PathBuf = if let Some(abs) = AbsolutePath::new(path) {
+        abs.as_path().to_path_buf()
+    } else {
+        let mut buf = vite_path::current_dir()?;
+        buf.push(path);
+        buf.as_path().to_path_buf()
+    };
+
+    // On Windows, canonicalize so the path uses the exact on-disk casing
+    // and resolves substitute drives / junctions the same way `fspy`'s
+    // `GetFinalPathNameByHandleW`-reported paths do. Without this, an
+    // `ignoreInput("cache_like")` whose `current_dir()` prefix differs in
+    // case or symlink shape from the fspy-reported reads won't filter
+    // them out, and the runner sees a read/write overlap. Strip the
+    // `\\?\` namespace prefix because `fspy_shared::NativePath::
+    // strip_path_prefix` does the same on the runner side; if the
+    // canonical form starts with `\\?\UNC\`, fall back to the
+    // non-canonical form so we don't accidentally rewrite a UNC path
+    // (where dropping `\\?\` would change meaning).
+    #[cfg(windows)]
+    let absolute = std::fs::canonicalize(&absolute).map_or(absolute, |canonical| {
+        use std::{
+            ffi::OsString,
+            os::windows::ffi::{OsStrExt, OsStringExt},
+        };
+        let wide: Vec<u16> = canonical.as_os_str().encode_wide().collect();
+        let unc_prefix: Vec<u16> = r"\\?\UNC\".encode_utf16().collect();
+        let nt_prefix: Vec<u16> = r"\\?\".encode_utf16().collect();
+        if wide.starts_with(&unc_prefix) {
+            // UNC path — keep canonical form (still has \\?\UNC\ for fspy parity).
+            canonical
+        } else if let Some(rest) = wide.strip_prefix(nt_prefix.as_slice()) {
+            std::path::PathBuf::from(OsString::from_wide(rest))
+        } else {
+            canonical
+        }
+    });
+
+    Ok(Box::<NativeStr>::from(absolute.as_os_str()))
+}

--- a/crates/vite_task_ipc_shared/.clippy.toml
+++ b/crates/vite_task_ipc_shared/.clippy.toml
@@ -1,0 +1,1 @@
+../../.non-vite.clippy.toml

--- a/crates/vite_task_ipc_shared/Cargo.toml
+++ b/crates/vite_task_ipc_shared/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "vite_task_ipc_shared"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+publish = false
+rust-version.workspace = true
+
+[dependencies]
+native_str = { workspace = true }
+rustc-hash = { workspace = true }
+wincode = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true
+
+[lib]
+doctest = false
+test = false

--- a/crates/vite_task_ipc_shared/README.md
+++ b/crates/vite_task_ipc_shared/README.md
@@ -1,0 +1,3 @@
+# vite_task_ipc_shared
+
+Shared IPC message types for communication between the task runner and tools.

--- a/crates/vite_task_ipc_shared/src/lib.rs
+++ b/crates/vite_task_ipc_shared/src/lib.rs
@@ -1,0 +1,50 @@
+use native_str::NativeStr;
+use rustc_hash::FxHashMap;
+use wincode::{SchemaRead, SchemaWrite};
+
+pub const IPC_ENV_NAME: &str = "VP_RUN_IPC_NAME";
+
+/// Path to the Node client module that JS/TS tools `require()` to talk to
+/// the runner.
+///
+/// Implementation-detail leakage (`napi`, `.node`, `addon`) is intentionally
+/// kept out of the name: from the consumer's point of view this is just a
+/// path they can `require()`. The `NODE_` scope reserves room for a future
+/// C-ABI client library advertised via its own env var for non-Node
+/// consumers.
+pub const NODE_CLIENT_PATH_ENV_NAME: &str = "VP_RUN_NODE_CLIENT_PATH";
+
+/// IPC request frame sent by tools to the runner.
+///
+/// `IgnoreInput`, `IgnoreOutput`, and `DisableCache` are fire-and-forget:
+/// the runner processes them when they arrive and never writes a response.
+/// `GetEnv` and `GetEnvs` are round-trips and pair with the matching response
+/// types below.
+///
+/// Fire-and-forget is safe because nothing in the runner observes individual
+/// IPC events live — the recorded set is only consumed *after* the per-task
+/// IPC driver has drained the connection, which happens after the child
+/// process exits. So a tool can `flush + exit` and the server's drain phase
+/// will still consume every buffered frame.
+#[derive(Debug, SchemaWrite, SchemaRead)]
+pub enum Request<'a> {
+    IgnoreInput(&'a NativeStr),
+    IgnoreOutput(&'a NativeStr),
+    GetEnv { name: &'a NativeStr, tracked: bool },
+    GetEnvs { pattern: &'a str, tracked: bool },
+    DisableCache,
+}
+
+#[derive(Debug, SchemaWrite, SchemaRead)]
+pub struct GetEnvResponse<'a> {
+    pub env_value: Option<&'a NativeStr>,
+}
+
+#[derive(Debug, SchemaWrite, SchemaRead)]
+pub struct GetEnvsResponse<'a> {
+    /// Match snapshot for the glob pattern. Keys/values are byte-faithful
+    /// (`NativeStr`) — non-UTF-8 env values are preserved over the wire so the
+    /// runner can record them unchanged. Conversion to `str` happens later,
+    /// at the cache-fingerprinting boundary, not here.
+    pub entries: FxHashMap<&'a NativeStr, &'a NativeStr>,
+}

--- a/crates/vite_task_server/Cargo.toml
+++ b/crates/vite_task_server/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "vite_task_server"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+publish = false
+rust-version.workspace = true
+
+[dependencies]
+futures = { workspace = true }
+native_str = { workspace = true }
+rustc-hash = { workspace = true }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["io-util", "net", "rt", "macros"] }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+vite_glob = { workspace = true }
+vite_path = { workspace = true }
+vite_task_ipc_shared = { workspace = true }
+wincode = { workspace = true, features = ["derive"] }
+
+[target.'cfg(windows)'.dependencies]
+uuid = { workspace = true, features = ["v4"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["io-util", "net", "rt", "macros", "time"] }
+vite_task_client = { workspace = true }
+
+[lints]
+workspace = true
+
+[lib]
+doctest = false
+test = false

--- a/crates/vite_task_server/README.md
+++ b/crates/vite_task_server/README.md
@@ -1,0 +1,3 @@
+# vite_task_server
+
+IPC server that runs per task execution, receiving messages from tools (runner-aware tools) and dispatching them to a user-provided handler.

--- a/crates/vite_task_server/src/lib.rs
+++ b/crates/vite_task_server/src/lib.rs
@@ -1,0 +1,478 @@
+use std::{
+    cell::RefCell,
+    ffi::{OsStr, OsString},
+    io,
+    sync::Arc,
+};
+
+use futures::{FutureExt, StreamExt, future::LocalBoxFuture, stream::FuturesUnordered};
+use native_str::NativeStr;
+use rustc_hash::{FxHashMap, FxHashSet};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_util::sync::CancellationToken;
+use vite_path::AbsolutePath;
+use vite_task_ipc_shared::{GetEnvResponse, GetEnvsResponse, IPC_ENV_NAME, Request};
+use wincode::{SchemaWrite, config::DefaultConfig};
+
+pub trait Handler {
+    fn ignore_input(&mut self, path: &Arc<AbsolutePath>);
+    fn ignore_output(&mut self, path: &Arc<AbsolutePath>);
+    fn disable_cache(&mut self);
+    fn get_env(&mut self, name: &OsStr, tracked: bool) -> Option<Arc<OsStr>>;
+    /// Returns the subset of the env map whose names match `pattern` as a
+    /// wax/glob pattern, recording the match-set for the post-run fingerprint.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `pattern` fails to parse as a glob.
+    fn get_envs(
+        &mut self,
+        pattern: &str,
+        tracked: bool,
+    ) -> Result<FxHashMap<Arc<OsStr>, Arc<OsStr>>, vite_glob::Error>;
+}
+
+/// A protocol-level failure observed while servicing a client.
+///
+/// The driver retains only the first such error across all clients, then
+/// completes gracefully (existing clients drain, new connections are rejected).
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("failed to read request frame from client")]
+    ReadFrame(#[source] io::Error),
+
+    #[error("failed to deserialize request from client")]
+    InvalidRequest(#[source] wincode::ReadError),
+
+    #[error("non-absolute path from client: {path:?}")]
+    NonAbsolutePath { path: OsString },
+
+    #[error("invalid glob pattern from client: {:?}", .0.pattern)]
+    InvalidGlob(Box<InvalidGlob>),
+
+    #[error("failed to write response to client")]
+    WriteResponse(#[source] io::Error),
+}
+
+/// Payload for [`Error::InvalidGlob`]. Boxed so the `Error` enum stays small
+/// — `vite_glob::Error` wraps `wax::BuildError` which is over 100 bytes on
+/// its own.
+#[derive(Debug)]
+pub struct InvalidGlob {
+    pub pattern: Box<str>,
+    pub source: vite_glob::Error,
+}
+
+/// A [`Handler`] that records every report and resolves `get_env` against
+/// a provided env map.
+///
+/// Call [`Recorder::into_reports`] after the driver future completes to
+/// recover the collected [`Reports`].
+pub struct Recorder {
+    ignored_inputs: FxHashSet<Arc<AbsolutePath>>,
+    ignored_outputs: FxHashSet<Arc<AbsolutePath>>,
+    cache_disabled: bool,
+    env_records: FxHashMap<Arc<OsStr>, EnvRecord>,
+    env_glob_records: FxHashMap<Arc<str>, EnvGlobRecord>,
+    env_map: FxHashMap<Arc<OsStr>, Arc<OsStr>>,
+}
+
+/// A record of an env value requested via `get_env`.
+///
+/// `tracked` is the monotonic OR of every `tracked` flag sent for this name
+/// — once `true`, it stays `true`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnvRecord {
+    pub tracked: bool,
+    pub value: Option<Arc<OsStr>>,
+}
+
+/// A record of a glob-pattern env query made via `get_envs`.
+///
+/// `matches` is captured on the first call and reused on repeat queries —
+/// the server's `env_map` is immutable for the task's lifetime, so the set
+/// is stable. `tracked` is monotonic like `EnvRecord::tracked`.
+///
+/// Names and values are stored as `OsStr` here — the in-memory recording
+/// layer is byte-faithful. Conversion to `str` happens at the fingerprint
+/// boundary downstream; conversion to `NativeStr` happens at the wire
+/// boundary inside the per-client request handler.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnvGlobRecord {
+    pub tracked: bool,
+    pub matches: FxHashMap<Arc<OsStr>, Arc<OsStr>>,
+}
+
+/// The data collected by a [`Recorder`] over the server's lifetime.
+#[derive(Debug, Default)]
+pub struct Reports {
+    pub ignored_inputs: FxHashSet<Arc<AbsolutePath>>,
+    pub ignored_outputs: FxHashSet<Arc<AbsolutePath>>,
+    pub cache_disabled: bool,
+    pub env_records: FxHashMap<Arc<OsStr>, EnvRecord>,
+    pub env_glob_records: FxHashMap<Arc<str>, EnvGlobRecord>,
+}
+
+impl Recorder {
+    #[must_use]
+    pub fn new(env_map: FxHashMap<Arc<OsStr>, Arc<OsStr>>) -> Self {
+        Self {
+            ignored_inputs: FxHashSet::default(),
+            ignored_outputs: FxHashSet::default(),
+            cache_disabled: false,
+            env_records: FxHashMap::default(),
+            env_glob_records: FxHashMap::default(),
+            env_map,
+        }
+    }
+
+    #[must_use]
+    pub fn into_reports(self) -> Reports {
+        Reports {
+            ignored_inputs: self.ignored_inputs,
+            ignored_outputs: self.ignored_outputs,
+            cache_disabled: self.cache_disabled,
+            env_records: self.env_records,
+            env_glob_records: self.env_glob_records,
+        }
+    }
+}
+
+impl Handler for Recorder {
+    fn ignore_input(&mut self, path: &Arc<AbsolutePath>) {
+        self.ignored_inputs.insert(Arc::clone(path));
+    }
+
+    fn ignore_output(&mut self, path: &Arc<AbsolutePath>) {
+        self.ignored_outputs.insert(Arc::clone(path));
+    }
+
+    fn disable_cache(&mut self) {
+        self.cache_disabled = true;
+    }
+
+    fn get_env(&mut self, name: &OsStr, tracked: bool) -> Option<Arc<OsStr>> {
+        if let Some(existing) = self.env_records.get_mut(name) {
+            existing.tracked |= tracked;
+            return existing.value.clone();
+        }
+        let value = self.env_map.get(name).cloned();
+        self.env_records.insert(name.into(), EnvRecord { tracked, value: value.clone() });
+        value
+    }
+
+    fn get_envs(
+        &mut self,
+        pattern: &str,
+        tracked: bool,
+    ) -> Result<FxHashMap<Arc<OsStr>, Arc<OsStr>>, vite_glob::Error> {
+        if let Some(existing) = self.env_glob_records.get_mut(pattern) {
+            existing.tracked |= tracked;
+            return Ok(existing.matches.clone());
+        }
+        let set = vite_glob::GlobPatternSet::new(std::iter::once(pattern))?;
+        let matches: FxHashMap<Arc<OsStr>, Arc<OsStr>> = self
+            .env_map
+            .iter()
+            .filter_map(|(name, value)| {
+                // Env names that aren't valid UTF-8 can't be matched against a
+                // glob (wax patterns are UTF-8), so they're silently dropped.
+                // Values can still be non-UTF-8 — that conversion happens at
+                // the wire-encoding / fingerprinting boundary, not here.
+                let name_str = name.to_str()?;
+                if set.is_match(name_str) {
+                    Some((Arc::clone(name), Arc::clone(value)))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        self.env_glob_records
+            .insert(Arc::from(pattern), EnvGlobRecord { tracked, matches: matches.clone() });
+        Ok(matches)
+    }
+}
+
+/// Handle to a running IPC server.
+///
+/// `driver` must be polled to accept clients and handle messages. It resolves
+/// only after [`StopAccepting::signal`] has been called AND all in-flight
+/// per-client tasks have drained, returning the owned handler.
+///
+/// The driver resolves to `Err(Error)` if any client triggered a protocol
+/// violation (see [`Error`]). The first such error is retained; subsequent
+/// errors during drain are discarded. On `Err`, the handler is not returned.
+///
+/// Dropping `driver` before it resolves tears everything down immediately —
+/// listener closed, per-client tasks cancelled, handler discarded.
+pub struct ServerHandle<'h, H> {
+    pub driver: LocalBoxFuture<'h, Result<H, Error>>,
+    pub stop_accepting: StopAccepting,
+}
+
+/// Signal that tells the server to stop accepting new clients. Existing
+/// clients continue until they naturally close the connection; the driver
+/// future resolves once that drain completes.
+///
+/// [`signal`](Self::signal) takes `&self` and the underlying cancellation
+/// is idempotent, so calling it twice or from a shared borrow is safe.
+pub struct StopAccepting {
+    token: CancellationToken,
+}
+
+impl StopAccepting {
+    pub fn signal(&self) {
+        self.token.cancel();
+    }
+}
+
+/// Starts an IPC server.
+///
+/// Returns the env entries that a child process must inherit to find and
+/// connect to this server, plus a handle bundling the driver future and the
+/// `StopAccepting` signal. See [`ServerHandle`] for driver semantics.
+///
+/// # Errors
+///
+/// Returns an error if creating the listener fails (on Unix, this includes
+/// creating the temp socket path).
+pub fn serve<'h, H: Handler + 'h>(
+    handler: H,
+) -> io::Result<(impl Iterator<Item = (&'static OsStr, OsString)>, ServerHandle<'h, H>)> {
+    let stop_token = CancellationToken::new();
+    let (name, bound) = bind_listener()?;
+
+    let run_stop = stop_token.clone();
+    let driver = async move {
+        // Multiple per-client futures coexist inside `FuturesUnordered` and each
+        // calls `&mut self` handler methods. `RefCell` provides the interior
+        // mutability that makes these shared-access method calls compile; at
+        // runtime the `borrow_mut()` never conflicts because we're on a
+        // single-threaded runtime and handler methods are synchronous (no
+        // awaits, so no borrow spans a yield point).
+        let handler = RefCell::new(handler);
+        let first_err = run(bound, &handler, run_stop).await;
+        first_err.map_or_else(|| Ok(handler.into_inner()), Err)
+    }
+    .boxed_local();
+
+    Ok((
+        std::iter::once((OsStr::new(IPC_ENV_NAME), name)),
+        ServerHandle { driver, stop_accepting: StopAccepting { token: stop_token } },
+    ))
+}
+
+#[cfg(unix)]
+type Stream = tokio::net::UnixStream;
+#[cfg(windows)]
+type Stream = tokio::net::windows::named_pipe::NamedPipeServer;
+
+/// The bound listener for the IPC server.
+///
+/// Unix: a Tokio [`UnixListener`](tokio::net::UnixListener) bound inside a
+/// [`NamedTempFile`](tempfile::NamedTempFile) so its socket file is unlinked
+/// on `Drop`. Windows: a single named-pipe instance that is created up front
+/// and replaced on each `accept` (a new pipe instance must be created before
+/// the previous one is handed to the client, otherwise concurrent connect
+/// attempts race for it).
+#[cfg(unix)]
+struct Bound {
+    file: tempfile::NamedTempFile<tokio::net::UnixListener>,
+}
+
+#[cfg(windows)]
+struct Bound {
+    pipe_name: OsString,
+    pending: tokio::net::windows::named_pipe::NamedPipeServer,
+}
+
+#[cfg(unix)]
+fn bind_listener() -> io::Result<(OsString, Bound)> {
+    // `make` lets us bind the socket directly to the path tempfile picks; the
+    // closure is responsible for creating the file (`UnixListener::bind` does).
+    // The `NamedTempFile` wrapper unlinks the socket path on `Drop`.
+    let file = tempfile::Builder::new()
+        .prefix("vite_task_ipc_")
+        .make(|path| tokio::net::UnixListener::bind(path))?;
+    let name = file.path().as_os_str().to_owned();
+    Ok((name, Bound { file }))
+}
+
+#[cfg(windows)]
+fn bind_listener() -> io::Result<(OsString, Bound)> {
+    use tokio::net::windows::named_pipe::ServerOptions;
+
+    #[expect(
+        clippy::disallowed_macros,
+        reason = "pipe name always exceeds Str inline capacity; format! is the simplest construction"
+    )]
+    let pipe_name = OsString::from(format!(r"\\.\pipe\vite_task_ipc_{}", uuid::Uuid::new_v4()));
+    let pending = ServerOptions::new().first_pipe_instance(true).create(&pipe_name)?;
+    Ok((pipe_name.clone(), Bound { pipe_name, pending }))
+}
+
+impl Bound {
+    #[cfg(unix)]
+    #[expect(
+        clippy::needless_pass_by_ref_mut,
+        reason = "Windows variant requires &mut self to swap pending instance; keep the signature uniform across cfgs so `run` can call it identically."
+    )]
+    async fn accept(&mut self) -> io::Result<Stream> {
+        let (stream, _addr) = self.file.as_file().accept().await?;
+        Ok(stream)
+    }
+
+    #[cfg(windows)]
+    async fn accept(&mut self) -> io::Result<Stream> {
+        use tokio::net::windows::named_pipe::ServerOptions;
+
+        // Wait for the next client to connect to the currently-pending
+        // instance, then immediately create a fresh instance to listen for the
+        // connection after that. Creating the next instance before yielding the
+        // accepted one ensures no client gets `ERROR_PIPE_BUSY` during the
+        // handoff.
+        self.pending.connect().await?;
+        let next = ServerOptions::new().create(&self.pipe_name)?;
+        Ok(std::mem::replace(&mut self.pending, next))
+    }
+}
+
+async fn run<H: Handler>(
+    mut bound: Bound,
+    handler: &RefCell<H>,
+    shutdown: CancellationToken,
+) -> Option<Error> {
+    let mut clients = FuturesUnordered::new();
+    let mut first_err: Option<Error> = None;
+
+    // Accept phase: accept new clients until shutdown fires.
+    loop {
+        tokio::select! {
+            () = shutdown.cancelled() => break,
+            accept_result = bound.accept() => {
+                match accept_result {
+                    Ok(stream) => {
+                        clients.push(handle_client(stream, handler).boxed_local());
+                    }
+                    Err(err) => {
+                        tracing::warn!(?err, "vite_task_server: accept failed");
+                    }
+                }
+            }
+            Some(result) = clients.next(), if !clients.is_empty() => {
+                if let Err(err) = result
+                    && first_err.is_none()
+                {
+                    first_err = Some(err);
+                    shutdown.cancel();
+                }
+            }
+        }
+    }
+
+    // Stop accepting: drop the listener (and on Unix unlink the socket file).
+    // Existing client streams continue to work.
+    drop(bound);
+
+    // Drain phase: wait for all in-flight per-client tasks to finish.
+    while let Some(result) = clients.next().await {
+        if let Err(err) = result
+            && first_err.is_none()
+        {
+            first_err = Some(err);
+        }
+    }
+
+    first_err
+}
+
+async fn handle_client<H: Handler>(mut stream: Stream, handler: &RefCell<H>) -> Result<(), Error> {
+    let mut buf = Vec::new();
+    loop {
+        match read_frame(&mut stream, &mut buf).await {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => return Ok(()),
+            Err(err) => return Err(Error::ReadFrame(err)),
+        }
+
+        let request: Request<'_> =
+            wincode::deserialize_exact(&buf).map_err(Error::InvalidRequest)?;
+
+        // Fire-and-forget branches (`IgnoreInput`, `IgnoreOutput`,
+        // `DisableCache`) intentionally write no response. Nothing in the
+        // runner observes individual IPC events live; the recorded set is
+        // collected after this driver drains. See `Request` in
+        // `vite_task_ipc_shared` for the rationale.
+        match request {
+            Request::IgnoreInput(ns) => {
+                let path = native_str_to_abs_path(ns)?;
+                handler.borrow_mut().ignore_input(&path);
+            }
+            Request::IgnoreOutput(ns) => {
+                let path = native_str_to_abs_path(ns)?;
+                handler.borrow_mut().ignore_output(&path);
+            }
+            Request::DisableCache => {
+                handler.borrow_mut().disable_cache();
+            }
+            Request::GetEnv { name, tracked } => {
+                let value = handler.borrow_mut().get_env(name.to_cow_os_str().as_ref(), tracked);
+                let boxed: Option<Box<NativeStr>> = value.as_deref().map(Into::into);
+                let response = GetEnvResponse { env_value: boxed.as_deref() };
+                write_response(&mut stream, &response).await.map_err(Error::WriteResponse)?;
+            }
+            Request::GetEnvs { pattern, tracked } => {
+                let matches =
+                    handler.borrow_mut().get_envs(pattern, tracked).map_err(|source| {
+                        Error::InvalidGlob(Box::new(InvalidGlob {
+                            pattern: Box::<str>::from(pattern),
+                            source,
+                        }))
+                    })?;
+                // Wire boundary: convert the handler's `OsStr` map into the
+                // byte-faithful `NativeStr` form. `boxed_entries` owns the
+                // `NativeStr` boxes so their borrowed refs stay valid while
+                // `response` is serialized.
+                let boxed_entries: Vec<(Box<NativeStr>, Box<NativeStr>)> = matches
+                    .iter()
+                    .map(|(k, v)| (Box::<NativeStr>::from(&**k), Box::<NativeStr>::from(&**v)))
+                    .collect();
+                let entries: FxHashMap<&NativeStr, &NativeStr> =
+                    boxed_entries.iter().map(|(k, v)| (&**k, &**v)).collect();
+                let response = GetEnvsResponse { entries };
+                write_response(&mut stream, &response).await.map_err(Error::WriteResponse)?;
+            }
+        }
+    }
+}
+
+fn native_str_to_abs_path(ns: &NativeStr) -> Result<Arc<AbsolutePath>, Error> {
+    let os_str = ns.to_cow_os_str();
+    AbsolutePath::new(&*os_str)
+        .map(Arc::from)
+        .ok_or_else(|| Error::NonAbsolutePath { path: os_str.into_owned() })
+}
+
+async fn read_frame(stream: &mut Stream, buf: &mut Vec<u8>) -> io::Result<()> {
+    let mut len_bytes = [0u8; 4];
+    stream.read_exact(&mut len_bytes).await?;
+    let len = u32::from_le_bytes(len_bytes) as usize;
+    buf.clear();
+    buf.resize(len, 0);
+    stream.read_exact(buf).await?;
+    Ok(())
+}
+
+async fn write_response<T>(stream: &mut Stream, response: &T) -> io::Result<()>
+where
+    T: SchemaWrite<DefaultConfig, Src = T> + ?Sized,
+{
+    let bytes = wincode::serialize(response)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    let len = u32::try_from(bytes.len())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "response too large"))?;
+    stream.write_all(&len.to_le_bytes()).await?;
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+    Ok(())
+}

--- a/crates/vite_task_server/tests/integration.rs
+++ b/crates/vite_task_server/tests/integration.rs
@@ -1,0 +1,294 @@
+use std::{
+    ffi::{OsStr, OsString},
+    io::{self, Read, Write},
+    sync::Arc,
+    thread,
+};
+
+use native_str::NativeStr;
+
+#[cfg(unix)]
+type RawStream = std::os::unix::net::UnixStream;
+#[cfg(windows)]
+type RawStream = std::fs::File;
+use rustc_hash::FxHashMap;
+use tokio::runtime::Builder;
+use vite_task_client::Client;
+use vite_task_ipc_shared::Request;
+use vite_task_server::{Error, Recorder, Reports, ServerHandle, serve};
+
+fn env_map(pairs: &[(&str, &str)]) -> FxHashMap<Arc<OsStr>, Arc<OsStr>> {
+    pairs
+        .iter()
+        .map(|(k, v)| (Arc::<OsStr>::from(OsStr::new(k)), Arc::<OsStr>::from(OsStr::new(v))))
+        .collect()
+}
+
+fn run_with_server<F>(
+    envs: FxHashMap<Arc<OsStr>, Arc<OsStr>>,
+    client_work: F,
+) -> Result<Reports, Error>
+where
+    F: FnOnce(Vec<(&'static OsStr, OsString)>) + Send + 'static,
+{
+    let recorder = Recorder::new(envs);
+
+    let rt = Builder::new_current_thread().enable_all().build().unwrap();
+    rt.block_on(async move {
+        let (envs, ServerHandle { driver, stop_accepting }) = serve(recorder).expect("bind server");
+        let envs: Vec<_> = envs.collect();
+
+        let client = async move {
+            tokio::task::spawn_blocking(move || client_work(envs))
+                .await
+                .expect("client work panicked");
+            stop_accepting.signal();
+        };
+
+        let (result, ()) = tokio::join!(driver, client);
+        result.map(Recorder::into_reports)
+    })
+}
+
+fn connect(envs: &[(&'static OsStr, OsString)]) -> Client {
+    Client::from_envs(envs.iter().map(|(k, v)| (k, v)))
+        .expect("connect")
+        .expect("serve should yield an IPC env")
+}
+
+/// Force a round-trip so the server has definitely processed every prior
+/// fire-and-forget frame on this connection: frames on a single stream are
+/// read sequentially, so once the server answers a `get_env` everything
+/// before it must already have been dispatched to the handler.
+fn flush(client: &Client) {
+    let _ = client.get_env(OsStr::new("__VP_TEST_FLUSH__"), false).unwrap();
+}
+
+#[cfg(unix)]
+fn connect_raw(name: &OsStr) -> RawStream {
+    std::os::unix::net::UnixStream::connect(name).expect("connect raw")
+}
+
+#[cfg(windows)]
+fn connect_raw(name: &OsStr) -> RawStream {
+    std::fs::OpenOptions::new().read(true).write(true).open(name).expect("connect raw")
+}
+
+fn send_frame(stream: &mut RawStream, request: &Request<'_>) {
+    let bytes = wincode::serialize(request).expect("serialize");
+    let len = u32::try_from(bytes.len()).expect("frame length fits u32");
+    stream.write_all(&len.to_le_bytes()).expect("write len");
+    stream.write_all(&bytes).expect("write body");
+    stream.flush().expect("flush");
+}
+
+#[test]
+fn single_client_fire_and_forget() {
+    // Absolute paths look different on each platform; bare forward-slash
+    // paths are relative on Windows (no drive letter) and would be rewritten
+    // by the client before the server sees them.
+    #[cfg(unix)]
+    let (in_path, out_path) = ("/tmp/in.txt", "/tmp/out.txt");
+    #[cfg(windows)]
+    let (in_path, out_path) = (r"C:\tmp\in.txt", r"C:\tmp\out.txt");
+
+    let reports = run_with_server(env_map(&[]), |envs| {
+        let client = connect(&envs);
+        client.ignore_input(OsStr::new(in_path)).unwrap();
+        client.ignore_output(OsStr::new(out_path)).unwrap();
+        client.disable_cache().unwrap();
+        flush(&client);
+    })
+    .expect("driver returned error");
+
+    let inputs: Vec<_> = reports.ignored_inputs.iter().map(|p| p.as_path().as_os_str()).collect();
+    let outputs: Vec<_> = reports.ignored_outputs.iter().map(|p| p.as_path().as_os_str()).collect();
+    assert_eq!(inputs, vec![OsStr::new(in_path)]);
+    assert_eq!(outputs, vec![OsStr::new(out_path)]);
+    assert!(reports.cache_disabled);
+}
+
+#[test]
+fn get_env_found_and_not_found() {
+    let reports = run_with_server(env_map(&[("NODE_ENV", "production")]), |envs| {
+        let client = connect(&envs);
+        let present = client.get_env(OsStr::new("NODE_ENV"), true).unwrap();
+        assert_eq!(present.as_deref(), Some(OsStr::new("production")));
+        let missing = client.get_env(OsStr::new("MISSING"), false).unwrap();
+        assert!(missing.is_none());
+    })
+    .expect("driver returned error");
+
+    let node = reports.env_records.get(OsStr::new("NODE_ENV")).expect("NODE_ENV recorded");
+    assert!(node.tracked);
+    assert_eq!(node.value.as_deref(), Some(OsStr::new("production")));
+
+    let missing = reports.env_records.get(OsStr::new("MISSING")).expect("MISSING recorded");
+    assert!(!missing.tracked);
+    assert!(missing.value.is_none());
+}
+
+#[test]
+fn get_env_tracked_upgrade_is_monotonic() {
+    let reports = run_with_server(env_map(&[("NODE_ENV", "production")]), |envs| {
+        let client = connect(&envs);
+        let a = client.get_env(OsStr::new("NODE_ENV"), false).unwrap();
+        let b = client.get_env(OsStr::new("NODE_ENV"), true).unwrap();
+        let c = client.get_env(OsStr::new("NODE_ENV"), false).unwrap();
+        for v in [a, b, c] {
+            assert_eq!(v.as_deref(), Some(OsStr::new("production")));
+        }
+    })
+    .expect("driver returned error");
+
+    let node = reports.env_records.get(OsStr::new("NODE_ENV")).expect("recorded");
+    assert!(node.tracked, "tracked must remain true once set");
+}
+
+#[test]
+fn concurrent_clients() {
+    #[cfg(unix)]
+    let paths = ["/tmp/worker_0", "/tmp/worker_1", "/tmp/worker_2", "/tmp/worker_3"];
+    #[cfg(windows)]
+    let paths = [r"C:\tmp\worker_0", r"C:\tmp\worker_1", r"C:\tmp\worker_2", r"C:\tmp\worker_3"];
+    let reports = run_with_server(env_map(&[("SHARED", "value")]), move |envs| {
+        let threads: Vec<_> = paths
+            .iter()
+            .map(|path| {
+                let envs = envs.clone();
+                let path = *path;
+                thread::spawn(move || {
+                    let client = connect(&envs);
+                    client.ignore_input(OsStr::new(path)).unwrap();
+                    let value = client.get_env(OsStr::new("SHARED"), true).unwrap();
+                    assert_eq!(value.as_deref(), Some(OsStr::new("value")));
+                })
+            })
+            .collect();
+        for t in threads {
+            t.join().unwrap();
+        }
+    })
+    .expect("driver returned error");
+
+    assert_eq!(reports.ignored_inputs.len(), 4);
+    let shared = reports.env_records.get(OsStr::new("SHARED")).expect("recorded");
+    assert!(shared.tracked);
+    assert_eq!(shared.value.as_deref(), Some(OsStr::new("value")));
+}
+
+#[test]
+fn relative_input_joined_with_cwd() {
+    let cwd = vite_path::current_dir().expect("cwd");
+    let expected = cwd.as_path().join("sub/file.txt");
+
+    let reports = run_with_server(env_map(&[]), |envs| {
+        let client = connect(&envs);
+        client.ignore_input(OsStr::new("sub/file.txt")).unwrap();
+        flush(&client);
+    })
+    .expect("driver returned error");
+
+    let inputs: Vec<_> = reports.ignored_inputs.iter().map(|p| p.as_path().as_os_str()).collect();
+    assert_eq!(inputs, vec![expected.as_os_str()]);
+}
+
+#[test]
+fn server_returns_error_on_non_absolute_path() {
+    let err = run_with_server(env_map(&[]), |envs| {
+        let name = &envs[0].1;
+        let mut stream = connect_raw(name);
+
+        let ns: Box<NativeStr> = OsStr::new("relative/path").into();
+        send_frame(&mut stream, &Request::IgnoreInput(&ns));
+
+        let mut buf = [0u8; 1];
+        let read_err = stream.read_exact(&mut buf).expect_err("server should close connection");
+        assert_eq!(read_err.kind(), io::ErrorKind::UnexpectedEof);
+    })
+    .expect_err("driver should surface the protocol error");
+
+    match err {
+        Error::NonAbsolutePath { path } => {
+            assert_eq!(path, OsStr::new("relative/path"));
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+}
+
+#[test]
+fn get_envs_returns_matching_entries() {
+    let reports = run_with_server(
+        env_map(&[("PROBE_A", "alpha"), ("PROBE_B", "beta"), ("UNRELATED", "noise")]),
+        |envs| {
+            let client = connect(&envs);
+            let matches = client.get_envs("PROBE_*", true).unwrap();
+            assert_eq!(matches.len(), 2);
+            assert_eq!(
+                matches.get(OsStr::new("PROBE_A")).map(AsRef::as_ref),
+                Some(OsStr::new("alpha"))
+            );
+            assert_eq!(
+                matches.get(OsStr::new("PROBE_B")).map(AsRef::as_ref),
+                Some(OsStr::new("beta"))
+            );
+            assert!(!matches.contains_key(OsStr::new("UNRELATED")));
+        },
+    )
+    .expect("driver returned error");
+
+    let glob = reports.env_glob_records.get("PROBE_*").expect("glob recorded");
+    assert!(glob.tracked);
+    assert_eq!(glob.matches.len(), 2);
+}
+
+#[test]
+fn get_envs_empty_match_set_is_recorded() {
+    let reports = run_with_server(env_map(&[("FOO", "x"), ("BAR", "y")]), |envs| {
+        let client = connect(&envs);
+        let matches = client.get_envs("PROBE_*", true).unwrap();
+        assert!(matches.is_empty());
+    })
+    .expect("driver returned error");
+
+    let glob = reports.env_glob_records.get("PROBE_*").expect("glob recorded");
+    assert!(glob.tracked);
+    assert!(glob.matches.is_empty());
+}
+
+#[test]
+fn get_envs_tracked_upgrade_is_monotonic() {
+    let reports = run_with_server(env_map(&[("PROBE_A", "alpha")]), |envs| {
+        let client = connect(&envs);
+        let first = client.get_envs("PROBE_*", false).unwrap();
+        let second = client.get_envs("PROBE_*", true).unwrap();
+        let third = client.get_envs("PROBE_*", false).unwrap();
+        // Same snapshot returned on every call.
+        assert_eq!(first, second);
+        assert_eq!(second, third);
+    })
+    .expect("driver returned error");
+
+    let glob = reports.env_glob_records.get("PROBE_*").expect("glob recorded");
+    assert!(glob.tracked, "tracked must stay true once set");
+    assert_eq!(glob.matches.len(), 1);
+}
+
+#[test]
+fn get_envs_invalid_pattern_surfaces_error() {
+    let err = run_with_server(env_map(&[]), |envs| {
+        let client = connect(&envs);
+        // Unbalanced alternation — wax rejects this as a build error.
+        let send_err = client.get_envs("{unclosed", true).expect_err("server should reject");
+        // The server closes the stream after sending the error; reads return EOF.
+        assert_eq!(send_err.kind(), io::ErrorKind::UnexpectedEof);
+    })
+    .expect_err("driver should surface the protocol error");
+
+    match err {
+        Error::InvalidGlob(inner) => {
+            assert_eq!(inner.pattern.as_ref(), "{unclosed");
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+}

--- a/docs/runner-task-ipc/design-decisions.md
+++ b/docs/runner-task-ipc/design-decisions.md
@@ -1,0 +1,15 @@
+## Why change code in tools instead of configuring in vite-plus
+
+- logic locality
+- dynamic decision at runtime
+- provide api to tools' plugins.
+
+## Why implement client in rust (instead of pure js)
+
+- Consumable by both rust and js (via napi)
+- Easier to implement sync api
+
+## Why provide client at runtime (instead of bundling in the tools)
+
+- Makes IPC protocol a implementation detail. Allows us to evolve IPC implementation or data schema without breaking clients (as long as we maintain the client API contract)
+- Easier for 3rd party client implementation in other languages (for example, esbuild can create a golang wrapper over the client ffi)

--- a/docs/runner-task-ipc/index.md
+++ b/docs/runner-task-ipc/index.md
@@ -1,0 +1,38 @@
+# runner-aware tools
+
+## Motivation
+
+Report information from the tools to the runner, to help runner cache results without needing user's manual configs.
+
+### What information vite-task knows without runner-awareness of tools?
+
+- All files that are read/written by the tools
+- All directory that are read/written by the tools
+
+### What information vite-task doesn't know without runner-awareness of tools?
+
+- **Why** did the tool read/write the file/directory? (e.g. files in cache should not be considered as inputs even when they are read by the tool, and should not be considered as outputs even when they are written by the tool)
+- **What** env variables are the tool interested in? (they are not available to the tool's process env if the user doesn't explicitly define them in `env` in the config)
+- **Whether** the tool needs be cached at all? (e.g. dev server doesn't need to be cached, but build does)
+
+## Implementation
+
+Workflow:
+
+1. For each spawn execution, `vite_task` starts an IPC server via `vite_task_server::serve` and passes the server's connection info plus the path to a materialized node addon into the child's env.
+2. The task process loads the addon through `@voidzero-dev/vite-task-client` and reports back over IPC: which reads/writes to ignore, which envs it needs (returned by the runner from the spawn's resolved env map), and whether to disable caching.
+3. When the task exits, the server drains and hands its collected reports back to `vite_task`, which feeds them into the cache layer.
+
+Crate / package responsibilities:
+
+- `vite_task_ipc_shared` — wincode-encoded request/response types and the env-var names used to hand connection info to children.
+- `vite_task_server` — `Handler` trait, `serve` entry point, and a built-in `Recorder` handler that stores what the cache layer consumes.
+- `vite_task_client` — sync blocking Rust client; `Client::from_envs` no-ops when the IPC env is absent.
+- `vite_task_client_napi` — NAPI cdylib exposing the client's methods to Node.
+- `materialized_artifact` — shared machinery for embedding the cdylib into `vp` and writing it to a temp file on first use (extracted from `fspy`).
+- `@voidzero-dev/vite-task-client` — npm package with JSDoc-typed wrappers (`ignoreInput`, `ignoreOutput`, `disableCache`, `getEnv`, `getEnvs`). Lazy-loads the addon and silently no-ops when it can't connect, so tools don't break when run outside `vp`.
+
+Notes:
+
+- ignored input/output files reported from the runner are considered as part of `{ auto: true }`, which means if the user defines `input`/`output` without `auto: true`, in the config, the runner will only consider the files defined in the config as inputs/outputs, and ignore what's reported from the tools.
+- envs requested from the tools are additional to the envs defined in the config. User config always wins: if an env is already defined in the config (e.g. as `untrackedEnv`), the tool cannot override it (e.g. upgrade it to tracked).

--- a/docs/runner-task-ipc/plan.md
+++ b/docs/runner-task-ipc/plan.md
@@ -1,0 +1,8 @@
+# Implementation Plan
+
+1. **Protocol** — `vite_task_ipc_shared`. Define message types and serialization. Everything else depends on this. ✅
+2. **Transport** — `vite_task_server` + `vite_task_client`. Build both sides, test them against each other directly in Rust. ✅
+3. **Extract artifact** — Pull `artifact.rs` out of fspy into a shared crate. Prerequisite for dylib embedding. ✅
+4. **JS bridge** — `vite_task_client_napi` (real impl) + `@voidzero-dev/vite-task-client` (JS wrapper with `getEnvs` logic). ✅
+5. **Runner integration** — Wire into `vite_task` spawn: start server per execution, embed/extract dylib, inject the IPC envs via `serve()`'s returned iterator. ✅
+6. **Cache integration** — Runner consumes the reported data (ignored inputs/outputs, requested envs, disable cache) and adjusts caching behavior. ✅

--- a/docs/runner-task-ipc/server-design.md
+++ b/docs/runner-task-ipc/server-design.md
@@ -1,0 +1,147 @@
+# Server API & Lifecycle
+
+## Goal
+
+The IPC server runs per spawn execution **only when fspy is enabled**, letting tools report runtime-only facts to the runner (`ignoreInputs`, `ignoreOutputs`, `disableCache`, `getEnv`). The runner uses these reports alongside fspy's tracked accesses for cache correctness.
+
+## Key principles
+
+1. **Server doesn't take a cancellation token.** The caller signals "stop accepting" via `StopAccepting::signal()`. The server has no awareness of external cancellation.
+2. **Handler is moved in, returned out.** The caller doesn't keep a reference. The driver owns the handler; on drain completion it returns it by value. No self-reference, no `&H` lifetime.
+3. **`CancellationToken` is internal** — hidden from the public API (exposed only via `StopAccepting`).
+4. **Driver is `!Send`**, lifetime bounded by `H`'s lifetime — if `H: 'static`, the driver is `'static`; if `H` borrows, the driver respects that.
+
+## Server API
+
+```rust
+pub trait Handler {
+    fn ignore_input(&self, path: &Arc<AbsolutePath>);
+    fn ignore_output(&self, path: &Arc<AbsolutePath>);
+    fn disable_cache(&self);
+    fn get_env(&self, name: &str, tracked: bool) -> Option<Arc<OsStr>>;
+}
+
+pub fn serve<'h, H: Handler + 'h>(
+    handler: H,
+) -> io::Result<(impl Iterator<Item = (&'static OsStr, OsString)>, ServerHandle<'h, H>)>;
+
+pub struct ServerHandle<'h, H> {
+    pub driver: LocalBoxFuture<'h, H>,
+    pub stop_accepting: StopAccepting,
+}
+
+pub struct StopAccepting { /* opaque */ }
+impl StopAccepting {
+    pub fn signal(self);
+}
+```
+
+## Driver semantics
+
+The driver future, when polled:
+
+1. **Accept phase** — accepts new clients and pumps per-client futures (`FuturesUnordered`) until `StopAccepting::signal()` fires.
+2. **Listener teardown** — drops listener; Unix socket file auto-cleaned via `tempfile::NamedTempFile`.
+3. **Drain phase** — waits for in-flight per-client futures to complete naturally (each ends on client EOF).
+4. **Returns `H`** — the owned handler that was moved in at `serve()`.
+
+Dropping the driver before it resolves tears everything down immediately. Handler is dropped without being returned.
+
+## Lifecycle in `execute_spawn`
+
+### When to start
+
+Only when fspy is enabled (`cache_metadata.input_config.includes_auto`). No fspy → no IPC server.
+
+### Construction (at `ExecutionMode` build time)
+
+`serve()` yields an env-pair iterator that the caller chains directly into the spawn's envs. The specific env var(s) used for IPC handoff are an implementation detail between the server and client crates — the runner never has to know their names.
+
+```rust
+let (ipc_envs, server) = serve(IpcRecorder::new(env_config))?;
+let envs = cmd.all_envs.iter().map(|(k, v)| (&**k, &**v)).chain(ipc_envs);
+let child = spawn(&cmd, envs, true, SpawnStdio::Piped, token).await?;
+// After the child is spawned, nothing else needs the IPC envs.
+
+let fspy = FspyState {
+    negatives,
+    server,  // ServerHandle<'h, IpcRecorder>
+};
+```
+
+### `FspyState` shape
+
+```rust
+struct FspyState {
+    negatives: Vec<wax::Glob<'static>>,
+    server: ServerHandle<IpcRecorder>,
+}
+```
+
+**Not stored:**
+
+- IPC env name/value — consumed once to build the spawn envs, dropped immediately.
+- `handler` — lives inside `server.driver`'s async state; recovered by value when the driver resolves.
+
+### Driving the server during `pipe_stdio` / `child.wait`
+
+The driver is polled as an extra arm in the existing `tokio::select!` blocks. `LocalBoxFuture<'static, H>` is `Unpin`, so `&mut driver` is a valid select arm:
+
+```rust
+tokio::select! {
+    r = &mut pipe_fut => r,
+    _recorder = &mut fspy_state.server.driver => {
+        unreachable!("driver resolved before stop_accepting.signal()")
+    }
+}
+```
+
+The driver only resolves after `stop_accepting.signal()` + drain — neither happens during these phases, so the branch is unreachable.
+
+### Completion paths
+
+```rust
+// Normal exit:
+if !fast_fail_token.is_cancelled() && !interrupt_token.is_cancelled() {
+    if let Some(fspy_state) = fspy.take() {
+        fspy_state.server.stop_accepting.signal();
+        let recorder = fspy_state.server.driver.await;
+        // recorder.into_reports() flows into cache-update
+    }
+}
+
+// Cancellation: fspy dropped at scope end → driver dropped → teardown.
+```
+
+## Design-decision log
+
+### Why no `'static` bound on `H`?
+
+The driver future _owns_ the handler (via `Rc<H>` internally). It doesn't need to outlive `H` — it just needs `H` to outlive the future. So the signature is `serve<'h, H: Handler + 'h>` and the returned `ServerHandle<'h, H>` carries the lifetime. If the caller's `H` is `'static`, the driver is `'static`; if `H` borrows, the driver respects that.
+
+If the caller wants to store `ServerHandle` in a struct without a lifetime parameter, they can use a `'static` handler (naturally satisfied by handlers that own all their state via `RefCell<...>` + cloned data).
+
+### Handler is owned by the driver, not shared via `Rc`
+
+The driver's async function owns `handler: H` as a local. Per-client futures borrow `&handler` from that same async state; Rust's async-fn state machine makes this self-borrow sound (the state is pinned and never moves). All per-client futures live inside `FuturesUnordered` which is also part of the same state — borrow scopes are contained.
+
+When drain completes and all per-client futures have been dropped, the outer async returns `handler` by move. No `Rc`, no `try_unwrap`, no panic possible.
+
+### Why return `H` from the driver?
+
+Caller doesn't keep the handler around separately. Avoids `Rc::try_unwrap` at the call site. Makes it impossible to forget recovering the state.
+
+### Why `StopAccepting::signal(self)` instead of exposing `CancellationToken`?
+
+- Hides the implementation (could swap `CancellationToken` for `oneshot` or `Notify` later).
+- Reads as intent: "stop accepting" vs. "cancel".
+- `self`-consuming method signals one-shot semantics.
+- Keeps the public API free of `tokio_util` types.
+
+### Why not pass `shutdown: impl Future` or `CancellationToken`?
+
+Earlier direction: "server doesn't care about cancellation token; it simply stops accepting when the process exits." The caller doesn't have a token to pass — they have a moment (child exit) when they want to stop accepting. `StopAccepting::signal()` is that moment.
+
+### On `spawn()` changes (deferred)
+
+`spawn()` will need to accept extra envs (e.g. `envs: impl IntoIterator<Item = (impl AsRef<OsStr>, impl AsRef<OsStr>)>`) so the caller can inject the IPC envs without cloning `Arc<BTreeMap>`. Not part of this step.

--- a/docs/runner-task-ipc/todo.md
+++ b/docs/runner-task-ipc/todo.md
@@ -1,0 +1,30 @@
+# TODO
+
+## Native addon should return `null` on connect failure
+
+**Status**: not started.
+
+**Decision**: when `Client::from_envs` returns `Ok(None)` (env missing) or `Err` (connect failed), the `.node` addon's `require()` must resolve to `null` instead of throwing.
+
+### Why
+
+- **Impossible to misuse** — a caller writes `const addon = require(path); if (!addon) return;` once. You can't call a method on `null`, so there's no silent-no-op trap.
+- **Smallest API surface** — one null-check at load time replaces per-call `try/catch` or per-call readiness checks everywhere.
+- **Reserves room to upgrade** — we can later promote truly unexpected errors (bugs, misconfiguration) to throw while keeping the expected "no runner / no socket" cases as `null`, without changing tools or the JS wrapper. Committing to "throw on failure" today closes that door forever.
+
+### Why not the alternatives
+
+- **Throw (today)** — forces every third-party consumer into `try/catch` forever. Forgetting it crashes the tool in non-runner contexts.
+- **Readiness flag on an always-returned object** — pushes the no-op decision into the methods. Every call site either needs a guard or relies on silent no-op (the tool thinks it's reporting, but isn't).
+
+### How
+
+napi-rs 3.x has no hook to change what its `napi_register_module_v1` returns ([napi-3.8.5/src/bindgen_runtime/module_register.rs:487-545](https://) hard-codes `Ok(exports)`), so we have to bypass it:
+
+- Enable napi's `noop` feature on [crates/vite_task_client_napi/Cargo.toml](../../crates/vite_task_client_napi/Cargo.toml) — disables napi-rs's own `napi_register_module_v1` and avoids a duplicate-symbol linker error.
+- Drop `napi-derive` and the `#[napi]` decorators. Rewrite [crates/vite_task_client_napi/src/lib.rs](../../crates/vite_task_client_napi/src/lib.rs) using raw `napi::sys::*`: one `#[unsafe(no_mangle)] extern "C" fn napi_register_module_v1`, four `extern "C"` callbacks, properties registered via `sys::napi_define_properties`.
+- On `Ok(Some(client))`: store client in a `thread_local! { static CLIENT: OnceCell<Client> }` and populate `exports`. On any other outcome: return `sys::napi_get_null(env)`.
+- Update [packages/vite-task-client/index.js](../../packages/vite-task-client/index.js) — drop the `try/catch` in `load()`; `require()`'s result is already `null` or an object.
+- Add an e2e test that spawns Node without `VP_RUN_IPC_NAME` and asserts `require(addonPath) === null`.
+
+Estimated size: ~200 lines. We only depend on `sys::*`, which is the stable Node ABI, so napi-rs internal churn can't break us.

--- a/docs/runner-task-ipc/transport.md
+++ b/docs/runner-task-ipc/transport.md
@@ -1,0 +1,20 @@
+# IPC Transport
+
+Cross-platform IPC straight on top of OS primitives — no `interprocess` or other transport-abstraction crate in between:
+
+| Platform           | Server                                                               | Client                                                     |
+| ------------------ | -------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Unix (macOS/Linux) | `tokio::net::UnixListener` (path inside a `tempfile::NamedTempFile`) | `std::os::unix::net::UnixStream`                           |
+| Windows            | `tokio::net::windows::named_pipe::NamedPipeServer` (per-instance)    | `std::fs::OpenOptions::open` on the `\\.\pipe\<name>` path |
+
+The socket path or pipe name is passed to the task process via an env var shared between `vite_task_server` and `vite_task_client` (the specific name is an implementation detail). Clients check for its presence and skip IPC gracefully if absent.
+
+## Server Model
+
+One listener per task execution. The runner creates a new socket just before spawning the task and tears it down after the task exits.
+
+The listener runs an accept loop and handles multiple concurrent clients — build tools may spawn worker processes or threads that each connect independently.
+
+On Windows, each accepted connection consumes the pending `NamedPipeServer` instance, and the accept loop immediately creates a fresh instance for the next client. There is a brief window during the swap where a client can see `ERROR_PIPE_BUSY`; the client retries (bounded) until the new instance is ready.
+
+Platform differences are handled via `#[cfg(unix)]` / `#[cfg(windows)]`.

--- a/docs/runner-task-ipc/vite-proposal.md
+++ b/docs/runner-task-ipc/vite-proposal.md
@@ -1,0 +1,224 @@
+# Proposal: Let Vite Talk to Vite Task
+
+We'd like `vite build` to be cached by Vite Task **correctly** and **with zero user configuration**. This proposal adds a small dependency and a few calls in Vite's codebase to make that possible.
+
+## Background
+
+Vite Task (`vp run` in Vite+) caches a task by tracking three things:
+
+- the files it reads (**inputs**)
+- the files it writes (**outputs**)
+- the env vars it depends on (**envs**)
+
+Inputs and envs are **fingerprints** of the cache: any change in them triggers a cache miss and a re-run.
+
+Outputs are the main content of the cache: they are **restored on cache hits**.
+
+Vite Task discovers inputs and outputs automatically by **tracking reads and writes at the syscall level**. But envs have to be declared in the task config; Vite Task only passes declared envs through to the child process, so **undeclared envs are invisible to the task** and don't affect caching.
+
+A typical task config looks like this:
+
+```json
+{
+  "tasks": {
+    "build": {
+      "command": "build-script",
+      "cache": true,
+      // The user doesn't have to declare inputs and outputs.
+      // But they does have to declare envs. Vite Task can't track what envs a task reads.
+      "env": ["APP_*"]
+    }
+  }
+}
+```
+
+## Motivation
+
+The goal of this proposal is to cache `vite build` **correctly**, and with **zero manual cache config**.
+
+Vite Task needs the Vite process to communicate two things:
+
+- Which file reads and writes are **internal** (the task's own cache) rather than real inputs or outputs;
+- Which envs the task **actually needs** at runtime.
+
+## Cases && Proposed Changes
+
+We want to add a small dependency `@voidzero-dev/vite-task-client` to Vite that lets it talk to Vite Task at runtime. Vite calls into the client at the relevant code paths to declare "ignore this path as an input/output" or "fetch these envs from Vite Task". The calls **are no-ops when Vite runs outside Vite Task**.
+
+### 1. Reading envs according to `envPrefix`
+
+Vite's [`envPrefix`](https://vite.dev/config/shared-options#envprefix) exposes any env matching the prefix (`VITE_*` by default) to the client bundle via `import.meta.env`.
+
+**Current State**: For Vite Task to forward these envs to the build and fingerprint them, the user has to declare them in Vite Task config:
+
+```jsonc
+// Vite Task config
+{ "tasks": { "build": { "command": "vite build", "env": ["VITE_*"] } } }
+```
+
+This task config duplicates `envPrefix`. The two configs currently have to be maintained in sync by the user. Forgetting to do so silently produces incorrect bundles (because the `VITE_*` envs won't be passed to Vite).
+
+**Proposed Changes**:
+
+Add a call to `vite-task-client`'s `getEnvs` **before reading the envs matching `envPrefix`**. If Vite is running outside Vite Task, this calls is a no-op. If Vite is running inside Vite Task, it does two things:
+
+- It tells Vite Task which envs are relevant to the build, so they **become part of the cache fingerprint**.
+- It **populates `process.env`** with those envs, so Vite can see them.
+
+```diff
+--- a/packages/vite/src/node/env.ts
++++ b/packages/vite/src/node/env.ts
+@@ loadEnv(mode, envDir, prefixes = 'VITE_') {
+   const parsed = Object.fromEntries(...);
+   for (const [key, value] of Object.entries(parsed))
+     if (prefixes.some(p => key.startsWith(p))) env[key] = value;
++  for (const prefix of prefixes) getEnvs(`${prefix}*`, { tracked: true });
+   for (const key in process.env)
+     if (prefixes.some(p => key.startsWith(p))) env[key] = process.env[key];
+```
+
+### 2. Pre-bundling deps in `cacheDir`
+
+Vite's dep optimizer reads metadata from and writes pre-bundled deps into [`cacheDir`](https://vite.dev/config/shared-options#cachedir) (default `node_modules/.vite/`).
+
+**Current State**: Vite Task sees these reads and writes, and **treats them as the task's inputs and outputs**. But they're in fact neither: `cacheDir` is the dep optimizer's internal state. The user has to exclude the directory out of both lists manually:
+
+```jsonc
+// Vite task config
+{
+  "input": [{ "auto": true }, { "pattern": "!node_modules/.vite/**", "base": "workspace" }],
+  "output": [{ "auto": true }, { "pattern": "!node_modules/.vite/**", "base": "workspace" }],
+}
+```
+
+And `cacheDir` is user-configurable, so the path in this config has to match whatever the user set.
+
+**Proposed Changes**:
+
+Add two calls **right after resolving `depsCacheDir`**. If Vite is running outside Vite Task, these calls are no-ops. If Vite is running inside Vite Task, they do two things:
+
+- They tell Vite Task to **not treat reads in this directory as inputs**.
+- They tell Vite Task to **not treat writes in this directory as outputs**.
+
+```diff
+--- a/packages/vite/src/node/optimizer/index.ts
++++ b/packages/vite/src/node/optimizer/index.ts
+@@ loadCachedDepOptimizationMetadata(environment, force) {
+   const depsCacheDir = getDepsCacheDir(environment);
++  ignoreInput(depsCacheDir);
++  ignoreOutput(depsCacheDir);
+```
+
+### 3. Cleaning `outDir` before writing the bundle
+
+Before writing the bundle, Vite calls [`emptyDir(outDir)`](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/plugins/prepareOutDir.ts#L69), which `readdirSync`s the directory to list entries for deletion. Then the bundler writes new files to the same directory.
+
+**Current State**: Vite Task sees `dist/` as both an input (the cleanup read) and an output (the bundle write). The user has to exclude `dist/**` from inputs while keeping it declared as an output. And [`build.outDir`](https://vite.dev/config/build-options#build-outdir) is user-configurable, so the path in this config has to match whatever the user set.
+
+**Proposed Changes**:
+
+Add a call **before `emptyDir`**. If Vite is running outside Vite Task, this call is a no-op. If Vite is running inside Vite Task, it tells Vite Task to **not treat reads in this directory as inputs**.
+
+```diff
+--- a/packages/vite/src/node/plugins/prepareOutDir.ts
++++ b/packages/vite/src/node/plugins/prepareOutDir.ts
+@@ prepareOutDir(outDirs, emptyOutDir, environment) {
+   for (const outDir of outDirs) {
++    ignoreInput(outDir);
+     if (emptyOutDir !== false && fs.existsSync(outDir)) emptyDir(outDir, ...);
+```
+
+### 4. Globbing files in `import.meta.glob`
+
+`import.meta.glob('src/**/*.ts')` lets users import every file matching a pattern. Vite expands the pattern with `tinyglobby`, which reads directory entries under `src/` and filters down to files matching `*.ts`.
+
+**Current State**: Vite Task sees the directory entry reads but not the filter. For `src/**/*.ts`, it knows that the entries of every directory under `src/` are read, but doesn't know that only `.ts` files matter to Vite. Adding or removing any file under `src/` (say a `.md` file the build wouldn't have picked up) invalidates the cache.
+
+**Proposed Changes**:
+
+Add a `glob` function to `@voidzero-dev/vite-task-client`. The first two arguments are the same patterns and options as `tinyglobby`'s `glob`; the third is the original `tinyglobby.glob` itself, used as the fallback when called outside Vite Task. Passing the fallback in keeps `tinyglobby` out of `@voidzero-dev/vite-task-client`'s dependencies.
+
+When called inside Vite Task, Vite Task does the globbing itself and returns the matching paths; the patterns and the matched paths become the fingerprint input, so only changes that would have affected the match-set invalidate the cache. When called outside Vite Task, it just calls the fallback, so behaviour is unchanged for direct `vite build` invocations.
+
+```diff
+--- a/packages/vite/src/node/plugins/importMetaGlob.ts
++++ b/packages/vite/src/node/plugins/importMetaGlob.ts
+-import { glob } from 'tinyglobby'
++import { glob as tinyglobbyGlob } from 'tinyglobby'
++import { glob } from '@voidzero-dev/vite-task-client'
+
+   const files = (
+-    await glob(globsResolved, { /* tinyglobby options */ })
++    await glob(globsResolved, { /* tinyglobby options */ }, tinyglobbyGlob)
+   ).filter(...).sort()
+```
+
+## Details of `@voidzero-dev/vite-task-client` package
+
+`@voidzero-dev/vite-task-client` is a [small ESM package](https://github.com/voidzero-dev/vite-task/blob/runner-aware-tools/packages/vite-task-client/index.js) (~80 lines, no native code, no transitive deps). Its API is five functions:
+
+```ts
+declare module '@voidzero-dev/vite-task-client' {
+  export function ignoreInput(path: string): void;
+  export function ignoreOutput(path: string): void;
+  export function disableCache(): void;
+  export function getEnv(name: string, opts?: { tracked?: boolean }): void;
+  export function getEnvs(pattern: string, opts?: { tracked?: boolean }): Record<string, string>;
+  // Same patterns and options as `tinyglobby`'s `glob`. The third
+  // argument is the fallback used when called outside Vite Task; passing
+  // it in keeps `tinyglobby` out of this package's dependencies.
+  export function glob(
+    patterns: string | string[],
+    options: GlobOptions,
+    fallback: (patterns: string | string[], options: GlobOptions) => Promise<string[]>,
+  ): Promise<string[]>;
+}
+```
+
+`getEnv` / `getEnvs` populate `process.env` for names Vite Task knows about and that aren't already set, so callers read values back via `process.env[...]` as usual.
+
+### Runtime mechanics
+
+The package is a thin wrapper. The wire protocol and IPC transport live in a node module **shipped with Vite Task**. At task start, Vite Task exports that module's path to tasks via an env var; the `@voidzero-dev/vite-task-client` wrapper lazy-requires it on first call.
+
+```mermaid
+sequenceDiagram
+    participant T as Vite Task
+    participant V as Vite
+    participant W as @voidzero-dev/vite-task-client (thin wrapper)
+    participant N as client implementation bundled in Vite Task
+    T->>V: spawn with $VP_RUN_NODE_CLIENT_PATH
+    V->>W: import
+    W->>N: require($VP_RUN_NODE_CLIENT_PATH) on first call
+    N->>T: IPC
+```
+
+The thin-wrapper design has two benefits:
+
+- **Light logic bundled in Vite.** Only the lazy-load shim ships with Vite. The wire protocol and `node_client` ship with Vite Task.
+- **Vite Task can evolve the IPC freely.** The wire protocol and `node_client`'s APIs can change in Vite Task without requiring a new Vite release. Old Vite versions keep working as long as the wrapper's public surface stays stable.
+
+If the env var is absent (e.g. `vite build` run directly, without Vite Task) or the addon fails to load, every exported function silently no-ops. Vite's behaviour is unchanged outside Vite Task.
+
+## Future additions
+
+This proposal covers the cases that demonstrate the high-level approach. The exact shape of the client APIs and any additional call sites can be discussed and added progressively once the high-level approach is agreed on.
+
+Two examples of what could come next:
+
+- **Call `disableCache()` in dev.** `vite dev` could opt the task out of caching completely.
+- **Plugin-owned cache dirs.** Any plugin with its own read/write cache could declare it with `ignoreInput`/`ignoreOutput` instead of asking every user to declare them in Vite Task config.
+
+## Alternatives considered
+
+- **Detect `vite build` and configure its cache in Vite+.**
+  - `envPrefix`, `cacheDir`, and `outDir` can be dynamically computed in `vite.config.ts`. Vite+ would have to execute the config to know their values.
+  - Other similar cases may exist or appear in future Vite versions. Vite+ would have to learn each one's semantics and handle them case by case. It'd be easier to maintain them alongside the related code in Vite itself.
+
+- **Patch the Vite bundled in Vite+.**
+  - **Logic locality.** Each call belongs next to the Vite code that owns its path; patching from outside puts them somewhere else.
+  - Users with a self-installed Vite (not the Vite+ bundled one) would get no benefit.
+
+- **Implement this in a Vite plugin**
+  - The plugin doesn't have the enough hooks to cover all cases (fetch envs for `envPrefix`).
+  - Enhancing the plugin API to cover all cases would be a much bigger impact on Vite.

--- a/docs/runner-task-ipc/vite-rolldown-env-operations.md
+++ b/docs/runner-task-ipc/vite-rolldown-env-operations.md
@@ -1,0 +1,83 @@
+# Vite & Rolldown Environment Variable Operations
+
+## Vite
+
+### Reads that affect build output (must be tracked for cache correctness)
+
+| File                                                                                                                             | Line | Variable                       | Effect on output                                  |
+| -------------------------------------------------------------------------------------------------------------------------------- | ---- | ------------------------------ | ------------------------------------------------- |
+| [config.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/config.ts#L1383)                                   | 1383 | `NODE_ENV`                     | Build mode, affects dead-code elimination         |
+| [config.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/config.ts#L1661)                                   | 1661 | `VITE_USER_NODE_ENV`           | User-set NODE_ENV from `.env` file                |
+| [build.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/build.ts#L644)                                      | 644  | `NODE_ENV`                     | Preserved for bundler                             |
+| [plugins/clientInjections.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/plugins/clientInjections.ts#L52) | 52   | `NODE_ENV`                     | Injected into client bundle                       |
+| [plugins/define.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/plugins/define.ts#L20)                     | 20   | `NODE_ENV`                     | Define replacement in output                      |
+| [optimizer/index.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/optimizer/index.ts#L1281)                 | 1281 | `NODE_ENV`                     | Dep pre-bundling config                           |
+| [env.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/env.ts#L86)                                           | 86   | `VITE_*` (all matching prefix) | Injected into client bundle via `import.meta.env` |
+
+### Reads that do not affect output (untracked)
+
+| File                                                                                                             | Line | Variable                | Effect                         |
+| ---------------------------------------------------------------------------------------------------------------- | ---- | ----------------------- | ------------------------------ |
+| [logger.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/logger.ts#L84)                     | 84   | `CI`                    | Disables color output only     |
+| [build.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/build.ts#L1067)                     | 1067 | `CI`                    | Disables TTY progress only     |
+| [utils.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/utils.ts#L176)                      | 176  | `DEBUG`                 | Debug logging only             |
+| [optimizer/index.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/optimizer/index.ts#L1269) | 1269 | `npm_config_user_agent` | Package manager detection only |
+
+### Writes to `process.env`
+
+| File                                                                                           | Line | Variable             | Reason                                                |
+| ---------------------------------------------------------------------------------------------- | ---- | -------------------- | ----------------------------------------------------- |
+| [config.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/config.ts#L1389) | 1389 | `NODE_ENV`           | Sets default if unset                                 |
+| [config.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/config.ts#L1664) | 1664 | `NODE_ENV`           | Overrides to `'development'` if user set it in `.env` |
+| [env.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/env.ts#L62)         | 62   | `VITE_USER_NODE_ENV` | Stores NODE_ENV read from `.env`                      |
+
+### `.env` file loading
+
+Handled by `loadEnv()` at [env.ts:27](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/env.ts#L27). Reads `.env`, `.env.local`, `.env.{mode}`, `.env.{mode}.local` from `envDir`. All `VITE_*` vars become `import.meta.env.*` in the client bundle.
+
+This is **file input fingerprinting**, not an env var concern — fspy automatically tracks the `readFileSync` calls on `.env` files as inferred inputs.
+
+---
+
+## Rolldown
+
+### Rust — reads
+
+| File                                                                                                                         | Line | Variable                        | Effect                      |
+| ---------------------------------------------------------------------------------------------------------------------------- | ---- | ------------------------------- | --------------------------- |
+| [rolldown_binding/src/lib.rs](https://github.com/rolldown/rolldown/blob/v1.0.0-rc.15/crates/rolldown_binding/src/lib.rs#L88) | 88   | `ROLLDOWN_MAX_BLOCKING_THREADS` | Tokio blocking thread count |
+| [rolldown_binding/src/lib.rs](https://github.com/rolldown/rolldown/blob/v1.0.0-rc.15/crates/rolldown_binding/src/lib.rs#L95) | 95   | `ROLLDOWN_WORKER_THREADS`       | Tokio worker thread count   |
+| [rolldown_tracing/src/lib.rs](https://github.com/rolldown/rolldown/blob/v1.0.0-rc.15/crates/rolldown_tracing/src/lib.rs#L25) | 25   | `RD_LOG`                        | Tracing log levels          |
+| [rolldown_tracing/src/lib.rs](https://github.com/rolldown/rolldown/blob/v1.0.0-rc.15/crates/rolldown_tracing/src/lib.rs#L33) | 33   | `RD_LOG_OUTPUT`                 | Log output mode             |
+
+None of these affect build output.
+
+### JS (NAPI binding loader) — reads
+
+| File                                                                                                                              | Line | Variable                        | Effect                                             |
+| --------------------------------------------------------------------------------------------------------------------------------- | ---- | ------------------------------- | -------------------------------------------------- |
+| [packages/rolldown/src/binding.cjs](https://github.com/rolldown/rolldown/blob/v1.0.0-rc.15/packages/rolldown/src/binding.cjs#L64) | 64   | `NAPI_RS_NATIVE_LIBRARY_PATH`   | Custom native lib path for loading `.node` binding |
+| [packages/rolldown/src/binding.cjs](https://github.com/rolldown/rolldown/blob/v1.0.0-rc.15/packages/rolldown/src/binding.cjs#L80) | 80   | `NAPI_RS_ENFORCE_VERSION_CHECK` | Version mismatch behavior                          |
+
+---
+
+## Implications for `getEnv` IPC
+
+Today, env vars read from `process.env` inside the task process are invisible to
+the runner — no file read happens, so fspy cannot track them. The runner's current
+`env`/`untrackedEnv` config requires the user to declare them manually.
+
+With `getEnv` IPC, a Vite plugin could request vars at runtime and have them
+automatically fingerprinted:
+
+```ts
+buildStart() {
+  await getEnv('NODE_ENV', { tracked: true })   // affects output — fingerprint it
+  await getEnv('CI', { tracked: false })         // affects behavior only — pass through
+}
+```
+
+The key vars for Vite cache correctness via `getEnv`:
+
+- **`NODE_ENV`** — affects dead-code elimination, define replacements, and `import.meta.env.MODE`
+- **`VITE_*`** — any matching var is injected into the client bundle; all must be tracked

--- a/docs/runner-task-ipc/vite-rolldown-fs-operations.md
+++ b/docs/runner-task-ipc/vite-rolldown-fs-operations.md
@@ -1,0 +1,109 @@
+# Vite & Rolldown Filesystem Operations
+
+File reads and writes relevant to output restoration and cache fingerprinting.
+All paths are relative to the package root unless noted.
+
+## Who writes output files
+
+When Vite uses Rolldown as its bundler, the actual chunk/asset writes happen in
+Rolldown's Rust core (`bundle.rs`). Vite calls `bundle.write(output)` on the
+`RolldownBuild` object; it does not write chunks itself. Rolldown's TypeScript
+`build.ts` is only the standalone public API and is bypassed when called from
+Vite.
+
+Vite owns only the surrounding operations: emptying the output dir and copying
+public assets.
+
+---
+
+## Vite — Output Directory (`build.outDir`, default `dist/`)
+
+| File                                                                                                                    | Line | Operation                        | Description                                                         |
+| ----------------------------------------------------------------------------------------------------------------------- | ---- | -------------------------------- | ------------------------------------------------------------------- |
+| [prepareOutDir.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/plugins/prepareOutDir.ts#L69)      | 69   | read (`readdirSync`)             | `emptyDir(outDir)` — lists then deletes all contents before build   |
+| [utils.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/utils.ts#L591)                             | 591  | read (`readdirSync`, `statSync`) | `emptyDir()` and `copyDir()` implementations                        |
+| [prepareOutDir.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/plugins/prepareOutDir.ts#L89)      | 89   | write                            | `copyDir(publicDir, outDir)` — copies public assets into output dir |
+| [build.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/build.ts#L874)                             | 874  | write (delegates)                | `bundle.write(output)` — hands off to Rolldown Rust core            |
+| [license.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/plugins/license.ts#L97)                  | 97   | write                            | emits `dist/.vite/license.json` via `emitFile()`                    |
+| [license.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/plugins/license.ts#L107)                 | 107  | write                            | emits `dist/.vite/license.md` via `emitFile()`                      |
+| [ssrManifestPlugin.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/ssr/ssrManifestPlugin.ts#L106) | 106  | write                            | emits `dist/.vite/ssr-manifest.json` via `emitFile()`               |
+
+Note: `manifest.json` is emitted by a native Rolldown plugin (`native:manifest`),
+not by Vite JS code.
+
+## Vite — Cache Directory (`cacheDir`, default `node_modules/.vite/`)
+
+| File                                                                                                             | Line | Operation                | Description                                                         |
+| ---------------------------------------------------------------------------------------------------------------- | ---- | ------------------------ | ------------------------------------------------------------------- |
+| [optimizer/index.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/optimizer/index.ts#L405)  | 405  | read                     | reads `cacheDir/deps/_metadata.json`                                |
+| [optimizer/index.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/optimizer/index.ts#L600)  | 600  | read                     | `existsSync(depsCacheDir)` — checks cache presence                  |
+| [optimizer/index.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/optimizer/index.ts#L1417) | 1417 | read (`readdir`, `stat`) | scans for stale temp dirs older than 24h                            |
+| [optimizer/index.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/optimizer/index.ts#L531)  | 531  | write                    | writes `package.json` (`"type":"module"`) into processing cache dir |
+| [optimizer/index.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/optimizer/index.ts#L586)  | 586  | write                    | writes `_metadata.json`                                             |
+| [optimizer/index.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/optimizer/index.ts#L858)  | 858  | write                    | `bundle.write()` — writes pre-bundled deps to `cacheDir/deps/`      |
+| [config.ts](https://github.com/vitejs/vite/blob/v8.0.8/packages/vite/src/node/config.ts#L2542)                   | 2542 | write                    | creates `node_modules/.vite-temp/` for bundled config files         |
+
+---
+
+## Rolldown — TypeScript API (`output.dir`, default `dist/`)
+
+| File                                                                                                                             | Line | Operation         | Description                                                            |
+| -------------------------------------------------------------------------------------------------------------------------------- | ---- | ----------------- | ---------------------------------------------------------------------- |
+| [output-options.ts](https://github.com/rolldown/rolldown/blob/v1.0.0-rc.15/packages/rolldown/src/options/output-options.ts#L702) | 702  | —                 | `cleanDir?: boolean` option definition                                 |
+| [build.ts](https://github.com/rolldown/rolldown/blob/v1.0.0-rc.15/packages/rolldown/src/api/build.ts#L65)                        | 65   | write (delegates) | `build.write(output)` — standalone entry point, delegates to Rust core |
+
+## Rolldown — Rust Core
+
+| File                                                                                                                  | Line | Operation         | Description                                                           |
+| --------------------------------------------------------------------------------------------------------------------- | ---- | ----------------- | --------------------------------------------------------------------- |
+| [bundle/bundle.rs](https://github.com/rolldown/rolldown/blob/v1.0.0-rc.15/crates/rolldown/src/bundle/bundle.rs#L161)  | 161  | read + delete     | calls `clean_dir(&fs, &dist_dir)` when `clean_dir` option is set      |
+| [bundle/bundle.rs](https://github.com/rolldown/rolldown/blob/v1.0.0-rc.15/crates/rolldown/src/bundle/bundle.rs#L175)  | 175  | write             | `fs.create_dir_all(&dist_dir)` — creates output dir                   |
+| [bundle/bundle.rs](https://github.com/rolldown/rolldown/blob/v1.0.0-rc.15/crates/rolldown/src/bundle/bundle.rs#L202)  | 202  | write             | `fs.create_dir_all(p)` — creates parent dirs for output chunks        |
+| [bundle/bundle.rs](https://github.com/rolldown/rolldown/blob/v1.0.0-rc.15/crates/rolldown/src/bundle/bundle.rs#L209)  | 209  | write             | `fs.write(&dest, chunk.content_as_bytes())` — writes each output file |
+| [utils/fs_utils.rs](https://github.com/rolldown/rolldown/blob/v1.0.0-rc.15/crates/rolldown/src/utils/fs_utils.rs#L10) | 10   | —                 | `clean_dir()` function definition                                     |
+| [utils/fs_utils.rs](https://github.com/rolldown/rolldown/blob/v1.0.0-rc.15/crates/rolldown/src/utils/fs_utils.rs#L25) | 25   | read (`read_dir`) | lists directory entries to clean                                      |
+| [utils/fs_utils.rs](https://github.com/rolldown/rolldown/blob/v1.0.0-rc.15/crates/rolldown/src/utils/fs_utils.rs#L27) | 27   | delete            | `remove_dir_all` for subdirectories                                   |
+| [utils/fs_utils.rs](https://github.com/rolldown/rolldown/blob/v1.0.0-rc.15/crates/rolldown/src/utils/fs_utils.rs#L29) | 29   | delete            | `remove_file` for files                                               |
+
+Rolldown has no disk cache.
+
+---
+
+## Where to add `ignoreInputs` / `ignoreOutputs`
+
+A single Vite plugin calling the runner IPC covers all of the above because
+Rolldown's Rust code runs as a NAPI addon inside the same Node.js process —
+fspy traces syscalls regardless of whether they originate from JS or Rust.
+
+```ts
+// Vite plugin (added once to vite.config.ts, no-op when VP_IPC is absent)
+buildStart() {
+  const ipcPath = process.env.VP_IPC
+  if (!ipcPath) return
+  const outDir  = this.environment.config.build.outDir  // e.g. "dist"
+  const cacheDir = this.environment.config.cacheDir     // e.g. "node_modules/.vite"
+  ignoreInputs([outDir, cacheDir])   // suppress reads: emptyDir, clean_dir, dep optimizer
+  ignoreOutputs([cacheDir])          // suppress writes: pre-bundled deps, metadata
+  // outDir writes are real outputs — do NOT ignore them
+}
+```
+
+`ignoreInputs(["dist"])` covers:
+
+- Vite `emptyDir` reads (`readdirSync` in `utils.ts:591`)
+- Rolldown `clean_dir` reads (`read_dir` in `fs_utils.rs:25`) — same process, same syscalls
+
+`ignoreInputs(["node_modules/.vite"])` covers:
+
+- Dep optimizer `readFile`, `existsSync`, `readdir` reads
+
+`ignoreOutputs(["node_modules/.vite"])` covers:
+
+- Dep optimizer `bundle.write`, `writeFileSync`, `.vite-temp` writes — not real task outputs
+
+### Injection without modifying `vite.config.ts`
+
+Vite has no env-based plugin injection mechanism. Options:
+
+- **`NODE_OPTIONS=--import`**: monkey-patch Vite's `build`/`createServer` before startup — works but fragile across Vite versions, requires Node 20+
+- **Explicit plugin in config**: stable, recommended — the plugin is a no-op outside of `vp run`


### PR DESCRIPTION
Add three new crates that together define the runner-tool IPC:

- `vite_task_ipc_shared` — message types + wire format shared by both
  ends. Spawned tools tell the runner what they read, wrote, or cared
  about; the runner uses that to decide what to fingerprint in the
  cache.
- `vite_task_server` — async server hosted in the runner. One server
  instance per task execution.
- `vite_task_client` — synchronous blocking client used by spawned
  tools. The sync API is deliberate: most tools are JS, called
  one-method-at-a-time, and don't want a runtime imposed on them.

The two sides are wired together end-to-end in
`vite_task_server/tests/integration.rs`, so this PR is independently
reviewable as "does the wire format and transport work correctly?"
without depending on runner internals.

Design notes: `docs/runner-task-ipc/`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>