### PR TITLE
feat(client): napi binding + JS wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,11 @@ jobs:
       - name: Deduplicate dependencies
         run: pnpm dedupe --check
 
+      - name: Check vite-task-client types are not stale
+        run: |
+          pnpm build-vite-task-client-types
+          git diff --exit-code packages/vite-task-client/index.d.ts
+
   done:
     runs-on: namespace-profile-linux-x64-default
     if: always()

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -3,6 +3,7 @@
   "ignorePatterns": [
     "crates/fspy_detours_sys/detours",
     "crates/vite_task_graph/run-config.ts",
-    "**/fixtures/*/snapshots"
+    "**/fixtures/*/snapshots",
+    "packages/vite-task-client/index.d.ts"
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -606,6 +606,15 @@ name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -923,7 +932,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
@@ -1820,6 +1829,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,6 +2052,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "napi"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d395473824516f38dd1071a1a37bc57daa7be65b293ebba4ead5f7abb017a2"
+dependencies = [
+ "bitflags 2.10.0",
+ "ctor",
+ "futures",
+ "napi-build",
+ "napi-sys",
+ "nohash-hasher",
+ "rustc-hash",
+]
+
+[[package]]
+name = "napi-build"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
+
+[[package]]
+name = "napi-derive"
+version = "3.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b3f766e04667e6da0e181e2da4f85475d5a6513b7cf6a80bea184e224a5b42"
+dependencies = [
+ "convert_case 0.11.0",
+ "ctor",
+ "napi-derive-backend",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "napi-derive-backend"
+version = "5.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d5af30503edf933ce7377cf6d4c877a62b0f1107ea05585f1b5e430e88d5baf"
+dependencies = [
+ "convert_case 0.11.0",
+ "proc-macro2",
+ "quote",
+ "semver 1.0.27",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "napi-sys"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
+dependencies = [
+ "libloading 0.9.0",
+]
+
+[[package]]
 name = "native_str"
 version = "0.0.0"
 dependencies = [
@@ -2091,6 +2167,12 @@ dependencies = [
  "libc",
  "memoffset 0.9.1",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -4225,6 +4307,17 @@ dependencies = [
  "vite_task_ipc_shared",
  "winapi",
  "wincode",
+]
+
+[[package]]
+name = "vite_task_client_napi"
+version = "0.1.0"
+dependencies = [
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "vite_str",
+ "vite_task_client",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,9 @@ libc = "0.2.185"
 libtest-mimic = "0.8.2"
 memmap2 = "0.9.7"
 monostate = "1.0.2"
+napi = "3"
+napi-build = "2"
+napi-derive = "3"
 native_str = { path = "crates/native_str" }
 nix = { version = "0.31.2", features = ["dir", "signal"] }
 ntapi = "0.4.1"
@@ -150,6 +153,7 @@ vite_str = { path = "crates/vite_str" }
 vite_task = { path = "crates/vite_task" }
 vite_task_bin = { path = "crates/vite_task_bin" }
 vite_task_client = { path = "crates/vite_task_client" }
+vite_task_client_napi = { path = "crates/vite_task_client_napi", artifact = "cdylib", target = "target" }
 vite_task_graph = { path = "crates/vite_task_graph" }
 vite_task_ipc_shared = { path = "crates/vite_task_ipc_shared" }
 vite_task_plan = { path = "crates/vite_task_plan" }
@@ -171,6 +175,7 @@ ignored = [
   # These are artifact dependencies. They are not directly `use`d in Rust code.
   "fspy_preload_unix",
   "fspy_preload_windows",
+  "vite_task_client_napi",
   # Registered in the workspace dependency table so downstream PRs in the
   # runner-aware-tools stack can pick it up via `workspace = true` without
   # touching this file. No in-tree consumer in this PR.

--- a/crates/vite_task_client_napi/Cargo.toml
+++ b/crates/vite_task_client_napi/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "vite_task_client_napi"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+test = false
+doctest = false
+
+[dependencies]
+napi = { workspace = true, features = ["napi6"] }
+napi-derive = { workspace = true }
+vite_str = { workspace = true }
+vite_task_client = { workspace = true }
+
+[build-dependencies]
+napi-build = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/vite_task_client_napi/README.md
+++ b/crates/vite_task_client_napi/README.md
@@ -1,0 +1,3 @@
+# vite_task_client_napi
+
+Node addon that lets JS/TS tools running inside a `vp run` task talk to the runner over IPC via `vite_task_client`.

--- a/crates/vite_task_client_napi/build.rs
+++ b/crates/vite_task_client_napi/build.rs
@@ -1,0 +1,5 @@
+extern crate napi_build;
+
+fn main() {
+    napi_build::setup();
+}

--- a/crates/vite_task_client_napi/src/lib.rs
+++ b/crates/vite_task_client_napi/src/lib.rs
@@ -1,0 +1,142 @@
+//! Node addon that exposes a `load()` factory which returns a
+//! `RunnerClient` JS class instance bound to the runner's IPC connection.
+//! Not intended to be published directly — the runner hands the compiled
+//! `.node` file to child processes via the `VP_RUN_NODE_CLIENT_PATH` env
+//! var, and the JS wrapper in `@voidzero-dev/vite-task-client`
+//! `require()`s it lazily.
+//!
+//! The factory shape (`load() -> RunnerClient`, rather than methods
+//! exported at the top level) is a deliberate layer of indirection so
+//! the addon can evolve over time: a future wrapper can pass an options
+//! argument (e.g. a version field) and receive a differently-shaped
+//! addon, without breaking older addons that ignore the argument.
+//!
+//! `load()` is callable only inside a runner-spawned task: when the IPC
+//! env is absent or the connection refuses, `load()` throws and the JS
+//! wrapper falls into no-op mode.
+
+// The napi boundary forces std `String` through function signatures; clippy's
+// blanket bans on disallowed types / needless-pass-by-value / missing Errors
+// sections are all about pure-Rust call sites and don't apply here (JS never
+// reads rustdoc). `disallowed_macros` is allowed because `napi-derive` expands
+// to `std::format!` inside `check_status!`, and the macro output isn't ours
+// to rewrite.
+#![expect(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::missing_errors_doc,
+    clippy::needless_pass_by_value,
+    reason = "napi bindings require owned std String + std::format! at the JS boundary"
+)]
+
+use std::{collections::HashMap, ffi::OsStr};
+
+use napi::{Error, Result};
+use napi_derive::napi;
+use vite_task_client::Client;
+
+/// Options for [`RunnerClient::get_env`] and [`RunnerClient::get_envs`].
+///
+/// Modeled as a JS plain object rather than a positional boolean so future
+/// knobs (e.g. a `default` value) can be added without an ABI break on the
+/// JS wrapper side.
+///
+/// Every field is optional so the napi addon — the cross-version API
+/// stability boundary between the runner-shipped `.node` and the
+/// separately-npm-published JS wrapper — can fill in defaults and let old
+/// wrappers keep working against new runners (and vice versa).
+#[napi(object)]
+pub struct GetEnvOptions {
+    /// Whether the runner should record this env as a cache-key dependency.
+    /// Defaults to `true`.
+    pub tracked: Option<bool>,
+}
+
+/// Handle returned by [`load`]. Holds the IPC connection and exposes the
+/// runner-side operations as instance methods.
+#[napi]
+pub struct RunnerClient {
+    client: Client,
+}
+
+#[napi]
+impl RunnerClient {
+    #[napi]
+    pub fn ignore_input(&self, path: String) -> Result<()> {
+        self.client
+            .ignore_input(OsStr::new(&path))
+            .map_err(|err| err_string(vite_str::format!("{err}")))
+    }
+
+    #[napi]
+    pub fn ignore_output(&self, path: String) -> Result<()> {
+        self.client
+            .ignore_output(OsStr::new(&path))
+            .map_err(|err| err_string(vite_str::format!("{err}")))
+    }
+
+    #[napi]
+    pub fn disable_cache(&self) -> Result<()> {
+        self.client.disable_cache().map_err(|err| err_string(vite_str::format!("{err}")))
+    }
+
+    #[napi]
+    pub fn get_env(&self, name: String, options: Option<GetEnvOptions>) -> Result<Option<String>> {
+        let tracked = options.and_then(|o| o.tracked).unwrap_or(true);
+        let value = self
+            .client
+            .get_env(OsStr::new(&name), tracked)
+            .map_err(|err| err_string(vite_str::format!("{err}")))?;
+        value.map_or(Ok(None), |value| {
+            value.to_str().map(|s| Some(s.to_owned())).ok_or_else(|| {
+                err_string(vite_str::format!("env value for {name} is not valid UTF-8"))
+            })
+        })
+    }
+
+    #[napi]
+    pub fn get_envs(
+        &self,
+        pattern: String,
+        options: Option<GetEnvOptions>,
+    ) -> Result<HashMap<String, String>> {
+        let tracked = options.and_then(|o| o.tracked).unwrap_or(true);
+        let matches = self
+            .client
+            .get_envs(&pattern, tracked)
+            .map_err(|err| err_string(vite_str::format!("{err}")))?;
+        // Entries whose name or value contains non-UTF-8 bytes can't cross
+        // the JS boundary as `String`. Unlike `get_env` (which errors out),
+        // bulk fetch drops them silently — the caller has no way to know
+        // which one is bad, and a partial match-set is usually still useful.
+        Ok(matches
+            .into_iter()
+            .filter_map(|(k, v)| Some((k.to_str()?.to_owned(), v.to_str()?.to_owned())))
+            .collect())
+    }
+}
+
+/// Connect to the runner and return a [`RunnerClient`]. Throws when the
+/// IPC env is missing or the connection fails.
+#[napi]
+pub fn load() -> Result<RunnerClient> {
+    let client = Client::from_envs(std::env::vars_os())
+        .map_err(|err| {
+            err_string(vite_str::format!("vp run client: failed to connect to runner IPC: {err}"))
+        })?
+        .ok_or_else(|| {
+            err_static(
+                "vp run client: runner IPC env is not set; this module is only usable \
+                 inside a `vp run` task",
+            )
+        })?;
+    Ok(RunnerClient { client })
+}
+
+fn err_static(msg: &'static str) -> Error {
+    Error::from_reason(msg)
+}
+
+fn err_string(msg: vite_str::Str) -> Error {
+    Error::from_reason(msg.as_str())
+}

--- a/package.json
+++ b/package.json
@@ -4,15 +4,18 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "prepare": "husky"
+    "prepare": "husky",
+    "build-vite-task-client-types": "tsc -p packages/vite-task-client/tsconfig.json"
   },
   "devDependencies": {
+    "@tsconfig/strictest": "catalog:",
     "@types/node": "catalog:",
     "husky": "catalog:",
     "lint-staged": "catalog:",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
-    "oxlint-tsgolint": "catalog:"
+    "oxlint-tsgolint": "catalog:",
+    "typescript": "catalog:"
   },
   "lint-staged": {
     "*": "oxfmt --no-error-on-unmatched-pattern",

--- a/packages/vite-task-client/README.md
+++ b/packages/vite-task-client/README.md
@@ -1,0 +1,3 @@
+# @voidzero-dev/vite-task-client
+
+Node client that lets JS/TS tools report ignored inputs/outputs, fetch tracked env values, and opt out of caching when running inside a `vp run` task.

--- a/packages/vite-task-client/index.d.ts
+++ b/packages/vite-task-client/index.d.ts
@@ -1,0 +1,61 @@
+/**
+ * Tell the runner to ignore reads under `path` when inferring cache inputs.
+ *
+ * No-op when not running inside a runner.
+ *
+ * @param {string} path
+ * @returns {void}
+ */
+export function ignoreInput(path: string): void;
+/**
+ * Tell the runner to ignore writes under `path` when inferring cache outputs.
+ *
+ * No-op when not running inside a runner.
+ *
+ * @param {string} path
+ * @returns {void}
+ */
+export function ignoreOutput(path: string): void;
+/**
+ * Tell the runner not to cache this run.
+ *
+ * No-op when not running inside a runner.
+ *
+ * @returns {void}
+ */
+export function disableCache(): void;
+/**
+ * Ask the runner for the value of the env var `name` and return it, or
+ * `undefined` when the runner has no such env.
+ *
+ * With `tracked: true` (the default) the runner records `name` as a
+ * dependency, so a change to its value invalidates this run's cache entry.
+ *
+ * Has no effect on `process.env`; the caller decides what to do with the
+ * returned value. Returns `undefined` when not running inside a runner.
+ *
+ * @param {string} name
+ * @param {{ tracked?: boolean }} [options]
+ * @returns {string | undefined}
+ */
+export function getEnv(name: string, options?: {
+    tracked?: boolean;
+}): string | undefined;
+/**
+ * Ask the runner for every env whose name matches `pattern` (a glob, e.g.
+ * `VITE_*`) and return the match-set as a plain object.
+ *
+ * With `tracked: true` (the default) the runner records the pattern as a
+ * dependency, so adding, removing, or changing a matching env invalidates
+ * this run's cache entry.
+ *
+ * Has no effect on `process.env`; the caller decides what to do with the
+ * returned values. Returns an empty object when not running inside a runner.
+ *
+ * @param {string} pattern
+ * @param {{ tracked?: boolean }} [options]
+ * @returns {Record<string, string>}
+ */
+export function getEnvs(pattern: string, options?: {
+    tracked?: boolean;
+}): Record<string, string>;

--- a/packages/vite-task-client/index.js
+++ b/packages/vite-task-client/index.js
@@ -1,0 +1,120 @@
+// The JSDoc in this file is the source of truth for the package's public
+// types. `index.d.ts` is generated from it via `pnpm run build:types`
+// (using `tsc` with `@tsconfig/strictest`) — edit JSDoc here, not the
+// `.d.ts`. CI fails if the committed `.d.ts` drifts from a fresh regen.
+
+import { createRequire } from 'node:module';
+
+/**
+ * Methods exposed by the napi addon. Keep this shape in sync with the
+ * `RunnerClient` returned by `load()` in
+ * `crates/vite_task_client_napi/src/lib.rs` — any new method added there
+ * needs a matching entry here, and vice versa.
+ *
+ * @type {{
+ *   ignoreInput: (path: string) => void,
+ *   ignoreOutput: (path: string) => void,
+ *   disableCache: () => void,
+ *   getEnv: (name: string, options?: { tracked?: boolean }) => string | undefined,
+ *   getEnvs: (pattern: string, options?: { tracked?: boolean }) => Record<string, string>,
+ * } | null | undefined}
+ */
+let addon;
+
+function load() {
+  if (addon !== undefined) return addon;
+  try {
+    const path = process.env['VP_RUN_NODE_CLIENT_PATH'];
+    if (path) {
+      // The addon exports a `load(options?)` factory rather than the
+      // methods directly, so the addon shape can evolve in lockstep with
+      // this wrapper: a future wrapper can pass `{ version: N }` to opt
+      // into a new shape without breaking older addons that only know v1.
+      // Today's wrapper passes nothing and accepts whatever the addon's
+      // current default version returns.
+      addon = createRequire(import.meta.url)(path).load();
+      return addon;
+    }
+  } catch {
+    // Fall through — the runner's IPC env is absent or the addon refused to
+    // load. Memoize the unavailable decision so subsequent calls don't retry.
+  }
+  addon = null;
+  return addon;
+}
+
+/**
+ * Tell the runner to ignore reads under `path` when inferring cache inputs.
+ *
+ * No-op when not running inside a runner.
+ *
+ * @param {string} path
+ * @returns {void}
+ */
+export function ignoreInput(path) {
+  load()?.ignoreInput(path);
+}
+
+/**
+ * Tell the runner to ignore writes under `path` when inferring cache outputs.
+ *
+ * No-op when not running inside a runner.
+ *
+ * @param {string} path
+ * @returns {void}
+ */
+export function ignoreOutput(path) {
+  load()?.ignoreOutput(path);
+}
+
+/**
+ * Tell the runner not to cache this run.
+ *
+ * No-op when not running inside a runner.
+ *
+ * @returns {void}
+ */
+export function disableCache() {
+  load()?.disableCache();
+}
+
+/**
+ * Ask the runner for the value of the env var `name` and return it, or
+ * `undefined` when the runner has no such env.
+ *
+ * With `tracked: true` (the default) the runner records `name` as a
+ * dependency, so a change to its value invalidates this run's cache entry.
+ *
+ * Has no effect on `process.env`; the caller decides what to do with the
+ * returned value. Returns `undefined` when not running inside a runner.
+ *
+ * @param {string} name
+ * @param {{ tracked?: boolean }} [options]
+ * @returns {string | undefined}
+ */
+export function getEnv(name, options) {
+  const a = load();
+  if (!a) return undefined;
+  return a.getEnv(name, options);
+}
+
+/**
+ * Ask the runner for every env whose name matches `pattern` (a glob, e.g.
+ * `VITE_*`) and return the match-set as a plain object.
+ *
+ * With `tracked: true` (the default) the runner records the pattern as a
+ * dependency, so adding, removing, or changing a matching env invalidates
+ * this run's cache entry.
+ *
+ * Has no effect on `process.env`; the caller decides what to do with the
+ * returned values. Returns an empty object when not running inside a runner.
+ *
+ * @param {string} pattern
+ * @param {{ tracked?: boolean }} [options]
+ * @returns {Record<string, string>}
+ */
+export function getEnvs(pattern, options) {
+  const a = load();
+  if (!a) return {};
+  return a.getEnvs(pattern, options);
+}

--- a/packages/vite-task-client/package.json
+++ b/packages/vite-task-client/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@voidzero-dev/vite-task-client",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./index.js",
+  "types": "./index.d.ts"
+}

--- a/packages/vite-task-client/tsconfig.json
+++ b/packages/vite-task-client/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@tsconfig/strictest/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["index.js"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@tsconfig/strictest':
+      specifier: ^2.0.8
+      version: 2.0.8
     '@types/node':
       specifier: 25.0.3
       version: 25.0.3
@@ -24,11 +27,17 @@ catalogs:
     oxlint-tsgolint:
       specifier: ^0.18.0
       version: 0.18.1
+    typescript:
+      specifier: ^6.0.3
+      version: 6.0.3
 
 importers:
 
   .:
     devDependencies:
+      '@tsconfig/strictest':
+        specifier: 'catalog:'
+        version: 2.0.8
       '@types/node':
         specifier: 'catalog:'
         version: 25.0.3
@@ -47,6 +56,9 @@ importers:
       oxlint-tsgolint:
         specifier: 'catalog:'
         version: 0.18.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
 
   packages/tools:
     dependencies:
@@ -62,6 +74,8 @@ importers:
       oxlint-tsgolint:
         specifier: 'catalog:'
         version: 0.18.1
+
+  packages/vite-task-client: {}
 
 packages:
 
@@ -342,6 +356,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tsconfig/strictest@2.0.8':
+    resolution: {integrity: sha512-XnQ7vNz5HRN0r88GYf1J9JJjqtZPiHt2woGJOo2dYqyHGGcd6OLGqSlBB6p1j9mpzja6Oe5BoPqWmeDx6X9rLw==}
+
   '@types/node@25.0.3':
     resolution: {integrity: sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==}
 
@@ -499,6 +516,11 @@ packages:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -655,6 +677,8 @@ snapshots:
 
   '@oxlint/binding-win32-x64-msvc@1.55.0':
     optional: true
+
+  '@tsconfig/strictest@2.0.8': {}
 
   '@types/node@25.0.3':
     dependencies:
@@ -840,6 +864,8 @@ snapshots:
   tinyexec@1.1.2: {}
 
   tinypool@2.1.0: {}
+
+  typescript@6.0.3: {}
 
   undici-types@7.16.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,13 +1,16 @@
 packages:
   - .
   - packages/tools
+  - packages/vite-task-client
 
 catalog:
+  '@tsconfig/strictest': ^2.0.8
   '@types/node': 25.0.3
   husky: ^9.1.7
   lint-staged: ^17.0.0
   oxfmt: 0.42.0
   oxlint: ^1.55.0
   oxlint-tsgolint: ^0.18.0
+  typescript: ^6.0.3
 
 catalogMode: prefer


### PR DESCRIPTION
Adds the JS surface that lets spawned Node tools talk to the runner
over the IPC introduced in the previous PR:

- `crates/vite_task_client_napi` — napi binding that exposes the Rust
  `Client` to JS as a `RunnerClient` returned from `load()`.
- `packages/vite-task-client` — JS wrapper with `ignoreInput`,
  `ignoreOutput`, `disableCache`, `getEnv`, and `getEnvs`. Types live
  in `index.js` as JSDoc; `index.d.ts` is generated via
  `pnpm build-vite-task-client-types` and a CI staleness check fails
  the build if the committed `.d.ts` drifts from the source.

The package is consumable as a no-op outside the runner: when
`VP_RUN_NODE_CLIENT_PATH` isn't set, `load()` returns `null` and every
exported function becomes a no-op (or returns `undefined`/`{}`). That
means the wrapper is safe to add as a regular dependency from a tool
that wants to opt in to runner-aware behavior without requiring its
users to run under `vp`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>