### PR TITLE
feat(client): vite-task-client JS package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,11 @@ jobs:
       - name: Deduplicate dependencies
         run: pnpm dedupe --check
 
+      - name: Check vite-task-client types are not stale
+        run: |
+          pnpm build-vite-task-client-types
+          git diff --exit-code packages/vite-task-client/src/index.d.ts
+
   done:
     runs-on: namespace-profile-linux-x64-default
     if: always()

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -3,6 +3,7 @@
   "ignorePatterns": [
     "crates/fspy_detours_sys/detours",
     "crates/vite_task_graph/run-config.ts",
-    "**/fixtures/*/snapshots"
+    "**/fixtures/*/snapshots",
+    "packages/vite-task-client/src/index.d.ts"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -4,15 +4,18 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "prepare": "husky"
+    "prepare": "husky",
+    "build-vite-task-client-types": "tsc -p packages/vite-task-client/tsconfig.json"
   },
   "devDependencies": {
+    "@tsconfig/strictest": "catalog:",
     "@types/node": "catalog:",
     "husky": "catalog:",
     "lint-staged": "catalog:",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
-    "oxlint-tsgolint": "catalog:"
+    "oxlint-tsgolint": "catalog:",
+    "typescript": "catalog:"
   },
   "lint-staged": {
     "*": "oxfmt --no-error-on-unmatched-pattern",

--- a/packages/vite-task-client/README.md
+++ b/packages/vite-task-client/README.md
@@ -1,0 +1,77 @@
+# @voidzero-dev/vite-task-client
+
+A tiny Node.js client that lets your tool talk to the
+[Vite+](https://github.com/voidzero-dev/vite-plus) task runner (`vp run`)
+it's running under. Use it to hand the runner more precise
+cache-correctness information than it can infer from the outside.
+
+Outside a runner-managed task, every call is a graceful no-op — you can
+call into this from a tool that's also used standalone without any
+runtime detection or conditionals.
+
+## Install
+
+```sh
+npm install @voidzero-dev/vite-task-client
+```
+
+## Quick start
+
+```js
+import { ignoreInput, ignoreOutput, disableCache, getEnv } from '@voidzero-dev/vite-task-client';
+
+ignoreInput('./node_modules/.cache/my-tool');
+
+// `vp run` only exposes envs the task config declares; for everything
+// else, `getEnv` fetches the value from the runner and registers it as
+// a cache-key dependency in the same call.
+const apiVersion = process.env.MY_API_VERSION ?? getEnv('MY_API_VERSION');
+
+if (somethingNonDeterministicHappened) disableCache();
+```
+
+## Why this exists
+
+`vp run` decides whether a task's cached result is reusable by hashing
+everything your task read and everything it depends on. It infers that
+set automatically — watching filesystem syscalls, scanning declared
+inputs and env vars. That's safe but can be too coarse:
+
+- Your tool maintains its own cache under `node_modules/.cache/…`. Every
+  miss there would invalidate every other run, even though the contents
+  don't actually affect your output.
+- Your tool reads `process.env.MY_API_VERSION`, and `vp run`'s task
+  config doesn't list it.
+- Your tool has a non-deterministic mode it sometimes falls into and
+  should skip the cache entirely.
+
+These functions give you a precise way to correct each case from inside
+your tool, without forcing your users to rewrite their `vp run` task
+config.
+
+## API
+
+See [`src/index.d.ts`](./src/index.d.ts) for the full signatures and per-function
+behavior.
+
+## For `vite-task` developers
+
+This package is a thin pure-JS wrapper with **no `dependencies` in
+`package.json`** — its only runtime artifact is the napi addon, which
+the runner provides at execution time.
+
+That means when you change this package in a `vite-task` PR, the
+consuming tool can pull your unpublished commit directly via a git URL
+with a subpath, no npm release required:
+
+```jsonc
+// In the consuming tool's package.json
+{
+  "dependencies": {
+    "@voidzero-dev/vite-task-client": "github:voidzero-dev/vite-task#<commit-sha>&path:/packages/vite-task-client",
+  },
+}
+```
+
+(`&path:` is supported by pnpm. For npm/yarn, see your package
+manager's docs on monorepo-subpath git installs.)

--- a/packages/vite-task-client/package.json
+++ b/packages/vite-task-client/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@voidzero-dev/vite-task-client",
+  "version": "0.1.0",
+  "description": "Hand the Vite+ task runner (vp run) precise cache-correctness information from inside your tool.",
+  "keywords": [
+    "cache",
+    "caching",
+    "monorepo",
+    "runner",
+    "task",
+    "vite",
+    "vite-plus",
+    "vp"
+  ],
+  "homepage": "https://github.com/voidzero-dev/vite-task/tree/main/packages/vite-task-client#readme",
+  "bugs": "https://github.com/voidzero-dev/vite-task/issues",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/voidzero-dev/vite-task.git",
+    "directory": "packages/vite-task-client"
+  },
+  "files": [
+    "src"
+  ],
+  "type": "module",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/vite-task-client/src/index.d.ts
+++ b/packages/vite-task-client/src/index.d.ts
@@ -1,0 +1,61 @@
+/**
+ * Tell the runner to ignore reads under `path` when inferring cache inputs.
+ *
+ * No-op when not running inside a runner.
+ *
+ * @param {string} path
+ * @returns {void}
+ */
+export function ignoreInput(path: string): void;
+/**
+ * Tell the runner to ignore writes under `path` when inferring cache outputs.
+ *
+ * No-op when not running inside a runner.
+ *
+ * @param {string} path
+ * @returns {void}
+ */
+export function ignoreOutput(path: string): void;
+/**
+ * Tell the runner not to cache this run.
+ *
+ * No-op when not running inside a runner.
+ *
+ * @returns {void}
+ */
+export function disableCache(): void;
+/**
+ * Ask the runner for the value of the env var `name` and return it, or
+ * `undefined` when the runner has no such env.
+ *
+ * With `tracked: true` (the default) the runner records `name` as a
+ * dependency, so a change to its value invalidates this run's cache entry.
+ *
+ * Has no effect on `process.env`; the caller decides what to do with the
+ * returned value. Returns `undefined` when not running inside a runner.
+ *
+ * @param {string} name
+ * @param {{ tracked?: boolean }} [options]
+ * @returns {string | undefined}
+ */
+export function getEnv(name: string, options?: {
+    tracked?: boolean;
+}): string | undefined;
+/**
+ * Ask the runner for every env whose name matches `pattern` (a glob, e.g.
+ * `VITE_*`) and return the match-set as a plain object.
+ *
+ * With `tracked: true` (the default) the runner records the pattern as a
+ * dependency, so adding, removing, or changing a matching env invalidates
+ * this run's cache entry.
+ *
+ * Has no effect on `process.env`; the caller decides what to do with the
+ * returned values. Returns an empty object when not running inside a runner.
+ *
+ * @param {string} pattern
+ * @param {{ tracked?: boolean }} [options]
+ * @returns {Record<string, string>}
+ */
+export function getEnvs(pattern: string, options?: {
+    tracked?: boolean;
+}): Record<string, string>;

--- a/packages/vite-task-client/src/index.js
+++ b/packages/vite-task-client/src/index.js
@@ -1,0 +1,120 @@
+// The JSDoc in this file is the source of truth for the package's public
+// types. `index.d.ts` is generated from it via `pnpm run build:types`
+// (using `tsc` with `@tsconfig/strictest`) — edit JSDoc here, not the
+// `.d.ts`. CI fails if the committed `.d.ts` drifts from a fresh regen.
+
+import { createRequire } from 'node:module';
+
+/**
+ * Methods exposed by the napi addon. Keep this shape in sync with the
+ * `RunnerClient` returned by `load()` in
+ * `crates/vite_task_client_napi/src/lib.rs` — any new method added there
+ * needs a matching entry here, and vice versa.
+ *
+ * @type {{
+ *   ignoreInput: (path: string) => void,
+ *   ignoreOutput: (path: string) => void,
+ *   disableCache: () => void,
+ *   getEnv: (name: string, options?: { tracked?: boolean }) => string | undefined,
+ *   getEnvs: (pattern: string, options?: { tracked?: boolean }) => Record<string, string>,
+ * } | null | undefined}
+ */
+let addon;
+
+function load() {
+  if (addon !== undefined) return addon;
+  try {
+    const path = process.env['VP_RUN_NODE_CLIENT_PATH'];
+    if (path) {
+      // The addon exports a `load(options?)` factory rather than the
+      // methods directly, so the addon shape can evolve in lockstep with
+      // this wrapper: a future wrapper can pass `{ version: N }` to opt
+      // into a new shape without breaking older addons that only know v1.
+      // Today's wrapper passes nothing and accepts whatever the addon's
+      // current default version returns.
+      addon = createRequire(import.meta.url)(path).load();
+      return addon;
+    }
+  } catch {
+    // Fall through — the runner's IPC env is absent or the addon refused to
+    // load. Memoize the unavailable decision so subsequent calls don't retry.
+  }
+  addon = null;
+  return addon;
+}
+
+/**
+ * Tell the runner to ignore reads under `path` when inferring cache inputs.
+ *
+ * No-op when not running inside a runner.
+ *
+ * @param {string} path
+ * @returns {void}
+ */
+export function ignoreInput(path) {
+  load()?.ignoreInput(path);
+}
+
+/**
+ * Tell the runner to ignore writes under `path` when inferring cache outputs.
+ *
+ * No-op when not running inside a runner.
+ *
+ * @param {string} path
+ * @returns {void}
+ */
+export function ignoreOutput(path) {
+  load()?.ignoreOutput(path);
+}
+
+/**
+ * Tell the runner not to cache this run.
+ *
+ * No-op when not running inside a runner.
+ *
+ * @returns {void}
+ */
+export function disableCache() {
+  load()?.disableCache();
+}
+
+/**
+ * Ask the runner for the value of the env var `name` and return it, or
+ * `undefined` when the runner has no such env.
+ *
+ * With `tracked: true` (the default) the runner records `name` as a
+ * dependency, so a change to its value invalidates this run's cache entry.
+ *
+ * Has no effect on `process.env`; the caller decides what to do with the
+ * returned value. Returns `undefined` when not running inside a runner.
+ *
+ * @param {string} name
+ * @param {{ tracked?: boolean }} [options]
+ * @returns {string | undefined}
+ */
+export function getEnv(name, options) {
+  const a = load();
+  if (!a) return undefined;
+  return a.getEnv(name, options);
+}
+
+/**
+ * Ask the runner for every env whose name matches `pattern` (a glob, e.g.
+ * `VITE_*`) and return the match-set as a plain object.
+ *
+ * With `tracked: true` (the default) the runner records the pattern as a
+ * dependency, so adding, removing, or changing a matching env invalidates
+ * this run's cache entry.
+ *
+ * Has no effect on `process.env`; the caller decides what to do with the
+ * returned values. Returns an empty object when not running inside a runner.
+ *
+ * @param {string} pattern
+ * @param {{ tracked?: boolean }} [options]
+ * @returns {Record<string, string>}
+ */
+export function getEnvs(pattern, options) {
+  const a = load();
+  if (!a) return {};
+  return a.getEnvs(pattern, options);
+}

--- a/packages/vite-task-client/tsconfig.json
+++ b/packages/vite-task-client/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@tsconfig/strictest/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*.js"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@tsconfig/strictest':
+      specifier: ^2.0.8
+      version: 2.0.8
     '@types/node':
       specifier: 25.0.3
       version: 25.0.3
@@ -24,11 +27,17 @@ catalogs:
     oxlint-tsgolint:
       specifier: ^0.18.0
       version: 0.18.1
+    typescript:
+      specifier: ^6.0.3
+      version: 6.0.3
 
 importers:
 
   .:
     devDependencies:
+      '@tsconfig/strictest':
+        specifier: 'catalog:'
+        version: 2.0.8
       '@types/node':
         specifier: 'catalog:'
         version: 25.0.3
@@ -47,6 +56,9 @@ importers:
       oxlint-tsgolint:
         specifier: 'catalog:'
         version: 0.18.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
 
   packages/tools:
     dependencies:
@@ -62,6 +74,8 @@ importers:
       oxlint-tsgolint:
         specifier: 'catalog:'
         version: 0.18.1
+
+  packages/vite-task-client: {}
 
 packages:
 
@@ -342,6 +356,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tsconfig/strictest@2.0.8':
+    resolution: {integrity: sha512-XnQ7vNz5HRN0r88GYf1J9JJjqtZPiHt2woGJOo2dYqyHGGcd6OLGqSlBB6p1j9mpzja6Oe5BoPqWmeDx6X9rLw==}
+
   '@types/node@25.0.3':
     resolution: {integrity: sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==}
 
@@ -499,6 +516,11 @@ packages:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -655,6 +677,8 @@ snapshots:
 
   '@oxlint/binding-win32-x64-msvc@1.55.0':
     optional: true
+
+  '@tsconfig/strictest@2.0.8': {}
 
   '@types/node@25.0.3':
     dependencies:
@@ -840,6 +864,8 @@ snapshots:
   tinyexec@1.1.2: {}
 
   tinypool@2.1.0: {}
+
+  typescript@6.0.3: {}
 
   undici-types@7.16.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,13 +1,16 @@
 packages:
   - .
   - packages/tools
+  - packages/vite-task-client
 
 catalog:
+  '@tsconfig/strictest': ^2.0.8
   '@types/node': 25.0.3
   husky: ^9.1.7
   lint-staged: ^17.0.0
   oxfmt: 0.42.0
   oxlint: ^1.55.0
   oxlint-tsgolint: ^0.18.0
+  typescript: ^6.0.3
 
 catalogMode: prefer


### PR DESCRIPTION
Lays the groundwork for publishing `@voidzero-dev/vite-task-client` to
npm. JS-side only — `src/index.js` (JSDoc as source of truth),
`src/index.d.ts` regenerated from it, and the metadata required to
publish. No Rust changes; no runner integration.

The package is a thin wrapper with no `dependencies`: under a
`vp run` task it loads the runner-provided napi addon at runtime,
otherwise every method is a graceful no-op.

## Next steps

1. Publish `@voidzero-dev/vite-task-client@0.1.0` to npm.
2. Update the [Vite PR](https://github.com/vitejs/vite/pull/22453) to
   depend on the published `@voidzero-dev/vite-task-client`.
3. Merge #410 — the remaining Rust implementation (IPC protocol +
   transport, napi binding, executor refactor, cache integration, e2e
   tests).