### PR TITLE
chore: bump vite-task-client to 0.1.1

### DIFF
--- a/packages/vite-task-client/package.json
+++ b/packages/vite-task-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voidzero-dev/vite-task-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Hand the Vite+ task runner (vp run) precise cache-correctness information from inside your tool.",
   "keywords": [
     "cache",


### PR DESCRIPTION
Bumps `@voidzero-dev/vite-task-client` to `0.1.1` to exercise the new release workflow (#412) and verify npm trusted publishing (OIDC provenance) end-to-end.

Merging this to `main` triggers `release-vite-task-client.yml`, which detects the version bump and publishes to npm.