### PR TITLE
feat: add aube workspace discovery

### DIFF
--- a/crates/vite_workspace/src/lib.rs
+++ b/crates/vite_workspace/src/lib.rs
@@ -249,6 +249,9 @@ pub fn load_package_graph(
     let workspaces = match &workspace_root.workspace_file {
         WorkspaceFile::AubeWorkspaceYaml(file_with_path)
         | WorkspaceFile::PnpmWorkspaceYaml(file_with_path) => {
+            // NOTE: `aube-workspace.yaml` is intentionally compatible with pnpm's workspace YAML
+            // format for the fields we currently read (specifically `packages: [...]` glob
+            // patterns). We deserialize both via `PnpmWorkspace` to reuse the same expansion logic.
             let workspace: PnpmWorkspace = serde_norway::from_slice(file_with_path.content())
                 .map_err(|e| Error::SerdeYaml {
                     file_path: Arc::clone(file_with_path.path()),

--- a/crates/vite_workspace/src/lib.rs
+++ b/crates/vite_workspace/src/lib.rs
@@ -247,7 +247,8 @@ pub fn load_package_graph(
 ) -> Result<DiGraph<PackageInfo, DependencyType, PackageIx>, Error> {
     let mut graph_builder = PackageGraphBuilder::default();
     let workspaces = match &workspace_root.workspace_file {
-        WorkspaceFile::PnpmWorkspaceYaml(file_with_path) => {
+        WorkspaceFile::AubeWorkspaceYaml(file_with_path)
+        | WorkspaceFile::PnpmWorkspaceYaml(file_with_path) => {
             let workspace: PnpmWorkspace = serde_norway::from_slice(file_with_path.content())
                 .map_err(|e| Error::SerdeYaml {
                     file_path: Arc::clone(file_with_path.path()),
@@ -373,6 +374,65 @@ mod tests {
   - "packages/*"
 "#;
         fs::write(temp_dir_path.join("pnpm-workspace.yaml"), workspace_yaml).unwrap();
+
+        // Create root package.json
+        let root_package = serde_json::json!({
+            "name": "monorepo-root",
+            "private": true
+        });
+        fs::write(temp_dir_path.join("package.json"), root_package.to_string()).unwrap();
+
+        // Create packages directory
+        fs::create_dir_all(temp_dir_path.join("packages")).unwrap();
+
+        // Create package A
+        fs::create_dir_all(temp_dir_path.join("packages/pkg-a")).unwrap();
+        let pkg_a = serde_json::json!({
+            "name": "pkg-a",
+            "dependencies": {}
+        });
+        fs::write(temp_dir_path.join("packages/pkg-a/package.json"), pkg_a.to_string()).unwrap();
+
+        // Create package B that depends on A
+        fs::create_dir_all(temp_dir_path.join("packages/pkg-b")).unwrap();
+        let pkg_b = serde_json::json!({
+            "name": "pkg-b",
+            "dependencies": {
+                "pkg-a": "workspace:*"
+            }
+        });
+        fs::write(temp_dir_path.join("packages/pkg-b/package.json"), pkg_b.to_string()).unwrap();
+
+        let graph = discover_package_graph(temp_dir_path).unwrap();
+
+        // Should have 3 nodes: root + pkg-a + pkg-b
+        assert_eq!(graph.node_count(), 3);
+        // Should have 1 edge: pkg-b -> pkg-a
+        assert_eq!(graph.edge_count(), 1);
+
+        // Verify the dependency edge exists
+        let mut found_edge = false;
+        for edge_ref in graph.edge_references() {
+            let source = &graph[edge_ref.source()];
+            let target = &graph[edge_ref.target()];
+            if source.package_json.name == "pkg-b" && target.package_json.name == "pkg-a" {
+                found_edge = true;
+                assert_eq!(*edge_ref.weight(), DependencyType::Normal);
+            }
+        }
+        assert!(found_edge, "Should have found edge from pkg-b to pkg-a");
+    }
+
+    #[test]
+    fn test_get_package_graph_aube_workspace() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_dir_path = AbsolutePath::new(temp_dir.path()).unwrap();
+
+        // Create aube-workspace.yaml
+        let workspace_yaml = r#"packages:
+    - "packages/*"
+"#;
+        fs::write(temp_dir_path.join("aube-workspace.yaml"), workspace_yaml).unwrap();
 
         // Create root package.json
         let root_package = serde_json::json!({

--- a/crates/vite_workspace/src/package_manager.rs
+++ b/crates/vite_workspace/src/package_manager.rs
@@ -100,7 +100,7 @@ pub fn find_package_root(original_cwd: &AbsolutePath) -> Result<PackageRoot<'_>,
 /// - `NonWorkspacePackage` is the package.json file of a non-workspace package.
 #[derive(Debug)]
 pub enum WorkspaceFile {
-    /// The aube-workspace.yaml file of an aube workspace.
+    /// The `aube-workspace.yaml` file of an Aube workspace.
     AubeWorkspaceYaml(FileWithPath),
     /// The pnpm-workspace.yaml file of a pnpm workspace.
     PnpmWorkspaceYaml(FileWithPath),

--- a/crates/vite_workspace/src/package_manager.rs
+++ b/crates/vite_workspace/src/package_manager.rs
@@ -100,6 +100,8 @@ pub fn find_package_root(original_cwd: &AbsolutePath) -> Result<PackageRoot<'_>,
 /// - `NonWorkspacePackage` is the package.json file of a non-workspace package.
 #[derive(Debug)]
 pub enum WorkspaceFile {
+    /// The aube-workspace.yaml file of an aube workspace.
+    AubeWorkspaceYaml(FileWithPath),
     /// The pnpm-workspace.yaml file of a pnpm workspace.
     PnpmWorkspaceYaml(FileWithPath),
     /// The package.json file of a yarn/npm workspace.
@@ -147,6 +149,24 @@ pub fn find_workspace_root(
                 WorkspaceRoot {
                     path: Arc::from(cwd),
                     workspace_file: WorkspaceFile::PnpmWorkspaceYaml(file_with_path),
+                },
+                relative_cwd,
+            ));
+        }
+
+        // Check for aube-workspace.yaml for aube workspaces.
+        //
+        // Aube can operate in repositories that still use pnpm's workspace YAML during
+        // migration. We therefore keep pnpm-workspace.yaml as the highest-priority
+        // workspace marker when both are present.
+        let aube_workspace_path: Arc<AbsolutePath> = cwd.join("aube-workspace.yaml").into();
+        if let Some(file_with_path) = FileWithPath::open_if_exists(aube_workspace_path)? {
+            let relative_cwd =
+                original_cwd.strip_prefix(cwd)?.expect("cwd must be within the aube workspace");
+            return Ok((
+                WorkspaceRoot {
+                    path: Arc::from(cwd),
+                    workspace_file: WorkspaceFile::AubeWorkspaceYaml(file_with_path),
                 },
                 relative_cwd,
             ));
@@ -256,6 +276,17 @@ mod tests {
         let file_with_path = FileWithPath::open(Arc::clone(&path)).unwrap();
         assert_eq!(file_with_path.content(), b"packages:\n  - apps/*\n");
         assert_eq!(&**file_with_path.path(), &*path);
+    }
+
+    #[test]
+    fn find_workspace_root_detects_aube_workspace_yaml() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_dir_path = AbsolutePath::new(temp_dir.path()).unwrap();
+        fs::write(temp_dir_path.join("aube-workspace.yaml"), b"packages:\n  - apps/*\n").unwrap();
+
+        let (workspace_root, relative) = find_workspace_root(temp_dir_path).unwrap();
+        assert!(relative.as_str().is_empty());
+        assert!(matches!(workspace_root.workspace_file, WorkspaceFile::AubeWorkspaceYaml(_)));
     }
 
     #[test]


### PR DESCRIPTION
Adds Aube workspace discovery to `vite_workspace`. Part of the larger effort to add first-class Aube support to Vite+.

Aube: https://aube.en.dev/ (repo: https://github.com/endevco/aube)
- Detect `aube-workspace.yaml` as a workspace-root marker.
- Keep `pnpm-workspace.yaml` as the higher-priority marker when both exist.
- Load workspace packages from `aube-workspace.yaml` using the same YAML shape as pnpm workspaces.

## Problem / Motivation

Aube isn't supported as part of Vite+, this includes Aube workspaces which requires the `vite_workspace` crate to be modified so it can look for Aube's reliable workspace-root marker. Without proper support in `vite_workspae` Vite+'s workspace discovery and package graph building won't work the same way they do for pnpm/yarn/npm workspaces. 

The nuance is handling Aube's package manager compatibility features. Aube is able to read pre-existing npm/yarn/pnpm lock files, making it more awkward to determine the workspace format to use especially when there are multiple workspace yaml files.

## Solution

- Extend `WorkspaceFile` with `AubeWorkspaceYaml`.
- Teach `find_workspace_root` to detect `aube-workspace.yaml`.
- Update graph discovery to treat Aube workspaces like pnpm workspaces for package pattern expansion.

## Behavior Changes

- Repos containing `aube-workspace.yaml` are now treated as workspaces by `vite_workspace`.

## Verification

- Added new tests for Aube
- All tests pass

## Follow-up

pnpm-style diff selectors are being developed separately on [`wip/diff-selectors`](https://github.com/ThunderStrike/vite-task/tree/wip/diff-selectors).