### PR TITLE
feat(cache): honor runner ignored inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- **Added** Runner-aware tools can now call `ignoreInput(path)` to exclude non-semantic reads from auto-inferred task cache inputs.
 - **Changed** Tracked environment values in task cache fingerprints are now stored only as SHA-256 digests, and env-related cache miss details report names without values.
 - **Added** Runner-aware `getEnvs` match sets can now participate in task cache fingerprints, so changing, adding, or removing a matching env var invalidates the cache ([#450](https://github.com/voidzero-dev/vite-task/pull/450)).
 - **Added** Runner-aware `getEnvs` calls now return env values served by the runner for matching env glob patterns ([#449](https://github.com/voidzero-dev/vite-task/pull/449)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4324,6 +4324,7 @@ version = "0.0.0"
 dependencies = [
  "native_str",
  "rustc-hash",
+ "vite_path",
  "vite_task_ipc_shared",
  "winapi",
  "wincode",
@@ -4415,6 +4416,7 @@ name = "vite_task_server"
 version = "0.0.0"
 dependencies = [
  "futures",
+ "native_str",
  "rustc-hash",
  "tempfile",
  "thiserror 2.0.18",
@@ -4423,6 +4425,7 @@ dependencies = [
  "tracing",
  "uuid",
  "vite_glob",
+ "vite_path",
  "vite_task_client",
  "vite_task_ipc_shared",
  "wincode",

--- a/crates/vite_task/src/session/execute/cache_update.rs
+++ b/crates/vite_task/src/session/execute/cache_update.rs
@@ -3,6 +3,7 @@
 
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
+use rustc_hash::FxHashSet;
 use vite_path::{AbsolutePath, RelativePathBuf};
 use vite_str::Str;
 use vite_task_plan::cache_metadata::{CacheMetadata, EnvValueHash};
@@ -67,6 +68,12 @@ pub(super) async fn update_cache(
         return (CacheUpdateStatus::NotUpdated(CacheNotUpdatedReason::ToolRequested), None);
     }
 
+    // Tool-reported paths to exclude from auto input tracking. Absolute paths
+    // are normalized to workspace-relative; anything outside is dropped.
+    let ignored_input_rels: FxHashSet<RelativePathBuf> = reports
+        .map(|r| normalize_ignored_paths(&r.ignored_inputs, workspace_root))
+        .unwrap_or_default();
+
     if cancelled {
         // Cancelled (Ctrl-C or sibling failure) — result is untrustworthy.
         return (CacheUpdateStatus::NotUpdated(CacheNotUpdatedReason::Cancelled), None);
@@ -77,7 +84,8 @@ pub(super) async fn update_cache(
         return (CacheUpdateStatus::NotUpdated(CacheNotUpdatedReason::NonZeroExitStatus), None);
     }
 
-    let fspy_outcome = observe_fspy(outcome, input_negative_globs, workspace_root);
+    let fspy_outcome =
+        observe_fspy(outcome, input_negative_globs, &ignored_input_rels, workspace_root);
 
     if let Some(TrackingOutcome { read_write_overlap: Some(path), .. }) = &fspy_outcome {
         // fspy-inferred read-write overlap: the task wrote to a file it also
@@ -167,6 +175,7 @@ pub(super) async fn update_cache(
 fn observe_fspy(
     outcome: &ChildOutcome,
     input_negative_globs: Option<&[wax::Glob<'static>]>,
+    ignored_input_rels: &FxHashSet<RelativePathBuf>,
     workspace_root: &AbsolutePath,
 ) -> Option<TrackingOutcome> {
     #[cfg(fspy)]
@@ -175,14 +184,19 @@ fn observe_fspy(
 
         outcome.path_accesses.as_ref().zip(input_negative_globs).map(|(raw, negatives)| {
             let tracked = TrackedPathAccesses::from_raw(raw, workspace_root, negatives);
+            let path_reads: HashMap<RelativePathBuf, PathRead> = tracked
+                .path_reads
+                .into_iter()
+                .filter(|(path, _)| !is_ignored(path, ignored_input_rels))
+                .collect();
             let read_write_overlap =
-                tracked.path_reads.keys().find(|p| tracked.path_writes.contains(*p)).cloned();
-            TrackingOutcome { path_reads: tracked.path_reads, read_write_overlap }
+                path_reads.keys().find(|p| tracked.path_writes.contains(*p)).cloned();
+            TrackingOutcome { path_reads, read_write_overlap }
         })
     }
     #[cfg(not(fspy))]
     {
-        let _ = (outcome, input_negative_globs, workspace_root);
+        let _ = (outcome, input_negative_globs, ignored_input_rels, workspace_root);
         None
     }
 }
@@ -199,6 +213,27 @@ fn collect_tracked_reports(
         })
         .transpose()
         .map(Option::unwrap_or_default)
+}
+
+/// Normalize tool-reported absolute paths to cleaned workspace-relative paths.
+/// Paths outside the workspace are dropped — they can't contribute to inputs.
+fn normalize_ignored_paths(
+    paths: &FxHashSet<Arc<AbsolutePath>>,
+    workspace_root: &AbsolutePath,
+) -> FxHashSet<RelativePathBuf> {
+    paths
+        .iter()
+        .filter_map(|p| p.strip_prefix(workspace_root).ok().flatten()?.clean().ok())
+        .collect()
+}
+
+/// Whether `path` is covered by any `ignored` entry. An ignored entry matches
+/// itself (exact file) and everything under it (directory subtree).
+fn is_ignored(path: &RelativePathBuf, ignored: &FxHashSet<RelativePathBuf>) -> bool {
+    if ignored.is_empty() {
+        return false;
+    }
+    ignored.contains(path) || ignored.iter().any(|ig| path.strip_prefix(ig).is_some())
 }
 
 /// Select tool-reported env records to embed in the post-run fingerprint.
@@ -286,4 +321,29 @@ fn collect_and_archive_outputs(
     archive::create_output_archive(workspace_root, &output_files, &archive_path)?;
 
     Ok(Some(archive_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rustc_hash::FxHashSet;
+    use vite_path::{AbsolutePath, RelativePathBuf};
+
+    use super::normalize_ignored_paths;
+
+    #[test]
+    fn normalize_ignored_paths_cleans_relative_components() {
+        let workspace_root =
+            AbsolutePath::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let ignored =
+            workspace_root.join(if cfg!(windows) { r"pkg\..\cache" } else { "pkg/../cache" });
+        let mut ignored_paths = FxHashSet::default();
+        ignored_paths.insert(Arc::<AbsolutePath>::from(ignored));
+
+        let normalized = normalize_ignored_paths(&ignored_paths, workspace_root);
+
+        let expected = RelativePathBuf::new("cache").unwrap();
+        assert!(normalized.contains(&expected));
+    }
 }

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/scripts/ignore_input.mjs
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/scripts/ignore_input.mjs
@@ -1,0 +1,9 @@
+import { mkdirSync, readFileSync } from 'node:fs';
+import { ignoreInput } from '@voidzero-dev/vite-task-client';
+
+mkdirSync('cache_like', { recursive: true });
+
+ignoreInput('cache_like');
+
+const value = readFileSync('cache_like/input.txt', 'utf8').trim();
+console.log(value);

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots.toml
@@ -1,4 +1,79 @@
 [[e2e]]
+name = "ignore_input_keeps_cache_valid"
+comment = """
+Exercises `ignoreInput` through `@voidzero-dev/vite-task-client`. The runner treats `cache_like/` as non-input for auto-inferred reads, but declared inputs under that path stay in the configured cache key.
+"""
+ignore = true
+steps = [
+  { argv = [
+    "vtt",
+    "write-file",
+    "cache_like/input.txt",
+    "before",
+  ], comment = "seed the file the task will read and ignore" },
+  { argv = [
+    "vt",
+    "run",
+    "ignore-input",
+  ], comment = "populate the cache" },
+  { argv = [
+    "vtt",
+    "write-file",
+    "cache_like/input.txt",
+    "after",
+  ], comment = "mutate the ignored input — would invalidate if tracked" },
+  { argv = [
+    "vt",
+    "run",
+    "ignore-input",
+  ], comment = "cache hit: cache_like/ was ignored via ignoreInput" },
+  { argv = [
+    "vtt",
+    "write-file",
+    "cache_like/input.txt",
+    "manual-before",
+  ], comment = "seed the declared input for input: [cache_like/input.txt]" },
+  { argv = [
+    "vt",
+    "run",
+    "ignore-input-manual-input",
+  ], comment = "populate the cache with the manual-only input fingerprint" },
+  { argv = [
+    "vtt",
+    "write-file",
+    "cache_like/input.txt",
+    "manual-after",
+  ], comment = "mutate the declared input for input: [cache_like/input.txt]" },
+  { argv = [
+    "vt",
+    "run",
+    "ignore-input-manual-input",
+  ], comment = "cache miss: manual input config wins over ignoreInput" },
+  { argv = [
+    "vtt",
+    "write-file",
+    "cache_like/input.txt",
+    "auto-manual-before",
+  ], comment = "seed the declared input for input: [{ auto: true }, cache_like/input.txt]" },
+  { argv = [
+    "vt",
+    "run",
+    "ignore-input-auto-manual-input",
+  ], comment = "populate the cache with the auto-plus-manual input fingerprint" },
+  { argv = [
+    "vtt",
+    "write-file",
+    "cache_like/input.txt",
+    "auto-manual-after",
+  ], comment = "mutate the declared input for input: [{ auto: true }, cache_like/input.txt]" },
+  { argv = [
+    "vt",
+    "run",
+    "ignore-input-auto-manual-input",
+  ], comment = "cache miss: explicit input still wins when auto inference is also enabled" },
+]
+
+[[e2e]]
 name = "disable_cache_forces_reexecution"
 comment = """
 Exercises `disableCache`. The tool asks the runner not to cache this run,

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/ignore_input_keeps_cache_valid.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/ignore_input_keeps_cache_valid.md
@@ -1,0 +1,102 @@
+# ignore_input_keeps_cache_valid
+
+Exercises `ignoreInput` through `@voidzero-dev/vite-task-client`. The runner treats `cache_like/` as non-input for auto-inferred reads, but declared inputs under that path stay in the configured cache key.
+
+## `vtt write-file cache_like/input.txt before`
+
+seed the file the task will read and ignore
+
+```
+```
+
+## `vt run ignore-input`
+
+populate the cache
+
+```
+$ node scripts/ignore_input.mjs
+before
+```
+
+## `vtt write-file cache_like/input.txt after`
+
+mutate the ignored input — would invalidate if tracked
+
+```
+```
+
+## `vt run ignore-input`
+
+cache hit: cache_like/ was ignored via ignoreInput
+
+```
+$ node scripts/ignore_input.mjs ◉ cache hit, replaying
+before
+
+---
+vt run: cache hit.
+```
+
+## `vtt write-file cache_like/input.txt manual-before`
+
+seed the declared input for input: [cache_like/input.txt]
+
+```
+```
+
+## `vt run ignore-input-manual-input`
+
+populate the cache with the manual-only input fingerprint
+
+```
+$ node scripts/ignore_input.mjs
+manual-before
+```
+
+## `vtt write-file cache_like/input.txt manual-after`
+
+mutate the declared input for input: [cache_like/input.txt]
+
+```
+```
+
+## `vt run ignore-input-manual-input`
+
+cache miss: manual input config wins over ignoreInput
+
+```
+$ node scripts/ignore_input.mjs ○ cache miss: 'cache_like/input.txt' modified, executing
+manual-after
+```
+
+## `vtt write-file cache_like/input.txt auto-manual-before`
+
+seed the declared input for input: [{ auto: true }, cache_like/input.txt]
+
+```
+```
+
+## `vt run ignore-input-auto-manual-input`
+
+populate the cache with the auto-plus-manual input fingerprint
+
+```
+$ node scripts/ignore_input.mjs
+auto-manual-before
+```
+
+## `vtt write-file cache_like/input.txt auto-manual-after`
+
+mutate the declared input for input: [{ auto: true }, cache_like/input.txt]
+
+```
+```
+
+## `vt run ignore-input-auto-manual-input`
+
+cache miss: explicit input still wins when auto inference is also enabled
+
+```
+$ node scripts/ignore_input.mjs ○ cache miss: 'cache_like/input.txt' modified, executing
+auto-manual-after
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/vite-task.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/vite-task.json
@@ -1,5 +1,21 @@
 {
   "tasks": {
+    "ignore-input": {
+      "command": "node scripts/ignore_input.mjs",
+      "cache": true
+    },
+    "ignore-input-manual-input": {
+      "command": "node scripts/ignore_input.mjs",
+      "input": ["cache_like/input.txt"],
+      "output": [],
+      "cache": true
+    },
+    "ignore-input-auto-manual-input": {
+      "command": "node scripts/ignore_input.mjs",
+      "input": [{ "auto": true }, "cache_like/input.txt"],
+      "output": [],
+      "cache": true
+    },
     "disable-cache": {
       "command": "node scripts/disable_cache.mjs",
       "cache": true

--- a/crates/vite_task_client/Cargo.toml
+++ b/crates/vite_task_client/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 [dependencies]
 native_str = { workspace = true }
 rustc-hash = { workspace = true }
+vite_path = { workspace = true }
 vite_task_ipc_shared = { workspace = true }
 wincode = { workspace = true, features = ["derive"] }
 

--- a/crates/vite_task_client/src/lib.rs
+++ b/crates/vite_task_client/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
 
 use native_str::NativeStr;
 use rustc_hash::FxHashMap;
+use vite_path::{self, AbsolutePath};
 use vite_task_ipc_shared::{GetEnvResponse, GetEnvsResponse, IPC_ENV_NAME, Request};
 use wincode::{SchemaRead, config::DefaultConfig};
 
@@ -46,10 +47,25 @@ impl Client {
         Self { stream: RefCell::new(stream), scratch: RefCell::new(Vec::new()) }
     }
 
+    /// `path` can be a file or a directory; for a directory, all files inside
+    /// it are ignored. Relative paths are resolved against the current working
+    /// directory before being sent to the runner.
+    ///
     /// Fire-and-forget: the call returns once the request is flushed to the
     /// kernel pipe buffer; the runner processes it during its drain phase
     /// after this process exits. See the `Request` type in the IPC protocol
     /// crate for why this is safe.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails to send, or if a relative `path`
+    /// cannot be resolved against the current working directory.
+    pub fn ignore_input(&self, path: &OsStr) -> io::Result<()> {
+        let ns = resolve_path(path)?;
+        self.send(&Request::IgnoreInput(&ns))
+    }
+
+    /// Fire-and-forget — see [`Self::ignore_input`].
     ///
     /// # Errors
     ///
@@ -127,6 +143,16 @@ impl Client {
         wincode::deserialize_exact(&scratch)
             .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
     }
+}
+
+fn resolve_path(path: &OsStr) -> io::Result<Box<NativeStr>> {
+    if let Some(abs) = AbsolutePath::new(path) {
+        return Ok(Box::<NativeStr>::from(abs.as_path().as_os_str()));
+    }
+
+    let mut absolute = vite_path::current_dir()?;
+    absolute.push(path);
+    Ok(Box::<NativeStr>::from(absolute.as_absolute_path().as_path().as_os_str()))
 }
 
 #[cfg(unix)]

--- a/crates/vite_task_client_napi/src/lib.rs
+++ b/crates/vite_task_client_napi/src/lib.rs
@@ -74,11 +74,11 @@ pub struct RunnerClient {
 
 #[napi]
 impl RunnerClient {
-    /// No-op for now: the runner cannot apply ignore reports yet. Becomes a
-    /// real request once auto output tracking can consume them.
     #[napi]
-    pub fn ignore_input(&self, _path: String) -> Result<()> {
-        Ok(())
+    pub fn ignore_input(&self, path: String) -> Result<()> {
+        self.client
+            .ignore_input(OsStr::new(&path))
+            .map_err(|err| err_string(vite_str::format!("{err}")))
     }
 
     /// No-op for now — see [`Self::ignore_input`].

--- a/crates/vite_task_ipc_shared/src/lib.rs
+++ b/crates/vite_task_ipc_shared/src/lib.rs
@@ -16,9 +16,9 @@ pub const NODE_CLIENT_PATH_ENV_NAME: &str = "VP_RUN_NODE_CLIENT_PATH";
 
 /// IPC request frame sent by tools to the runner.
 ///
-/// `DisableCache` is fire-and-forget: the runner processes it when it
-/// arrives and never writes a response. `GetEnv` and `GetEnvs` are
-/// round-trips and pair with the matching response types below.
+/// `IgnoreInput` and `DisableCache` are fire-and-forget: the runner processes
+/// them when they arrive and never writes a response. `GetEnv` and `GetEnvs`
+/// are round-trips and pair with the matching response types below.
 ///
 /// Fire-and-forget is safe because nothing in the runner observes individual
 /// IPC events live — the recorded set is only consumed *after* the per-task
@@ -27,6 +27,7 @@ pub const NODE_CLIENT_PATH_ENV_NAME: &str = "VP_RUN_NODE_CLIENT_PATH";
 /// will still consume every buffered frame.
 #[derive(Debug, SchemaWrite, SchemaRead)]
 pub enum Request<'a> {
+    IgnoreInput(&'a NativeStr),
     GetEnv { name: &'a NativeStr, tracked: bool },
     GetEnvs { pattern: &'a str, tracked: bool },
     DisableCache,

--- a/crates/vite_task_server/Cargo.toml
+++ b/crates/vite_task_server/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 futures = { workspace = true }
+native_str = { workspace = true }
 rustc-hash = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
@@ -15,6 +16,7 @@ tokio = { workspace = true, features = ["io-util", "net", "rt", "macros"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 vite_glob = { workspace = true }
+vite_path = { workspace = true }
 vite_task_ipc_shared = { workspace = true }
 wincode = { workspace = true, features = ["derive"] }
 

--- a/crates/vite_task_server/src/lib.rs
+++ b/crates/vite_task_server/src/lib.rs
@@ -6,13 +6,16 @@ use std::{
 };
 
 use futures::{FutureExt, StreamExt, future::LocalBoxFuture, stream::FuturesUnordered};
-use rustc_hash::FxHashMap;
+use native_str::NativeStr;
+use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_util::sync::CancellationToken;
+use vite_path::AbsolutePath;
 use vite_task_ipc_shared::{GetEnvResponse, GetEnvsResponse, IPC_ENV_NAME, Request};
 use wincode::{SchemaWrite, config::DefaultConfig};
 
 pub trait Handler {
+    fn ignore_input(&mut self, path: &Arc<AbsolutePath>);
     fn disable_cache(&mut self);
     fn get_env(&mut self, name: &OsStr, tracked: bool) -> Option<Arc<OsStr>>;
     /// Returns the subset of the env map whose names match `pattern` as a glob.
@@ -39,11 +42,14 @@ pub enum Error {
     #[error("invalid message from the task")]
     InvalidRequest(#[source] wincode::ReadError),
 
-    #[error("failed to send response to the task")]
-    WriteResponse(#[source] io::Error),
+    #[error("non-absolute path from the task: {path:?}")]
+    NonAbsolutePath { path: OsString },
 
     #[error("invalid glob pattern from the task: {:?}", .0.pattern)]
     InvalidGlob(Box<InvalidGlob>),
+
+    #[error("failed to send response to the task")]
+    WriteResponse(#[source] io::Error),
 }
 
 /// Payload for [`Error::InvalidGlob`]. Boxed so the `Error` enum stays small.
@@ -59,6 +65,7 @@ pub struct InvalidGlob {
 /// Call [`Recorder::into_reports`] after the driver future completes to
 /// recover the collected [`Reports`].
 pub struct Recorder {
+    ignored_inputs: FxHashSet<Arc<AbsolutePath>>,
     cache_disabled: bool,
     tracked_get_env: FxHashMap<Arc<OsStr>, Option<Arc<OsStr>>>,
     tracked_get_envs: FxHashMap<Arc<str>, EnvGlobRecord>,
@@ -79,6 +86,7 @@ pub struct EnvGlobRecord {
 /// The data collected by a [`Recorder`] over the server's lifetime.
 #[derive(Debug, Default)]
 pub struct Reports {
+    pub ignored_inputs: FxHashSet<Arc<AbsolutePath>>,
     pub cache_disabled: bool,
     pub tracked_get_env: FxHashMap<Arc<OsStr>, Option<Arc<OsStr>>>,
     pub tracked_get_envs: FxHashMap<Arc<str>, EnvGlobRecord>,
@@ -88,6 +96,7 @@ impl Recorder {
     #[must_use]
     pub fn new(envs: Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>) -> Self {
         Self {
+            ignored_inputs: FxHashSet::default(),
             cache_disabled: false,
             tracked_get_env: FxHashMap::default(),
             tracked_get_envs: FxHashMap::default(),
@@ -98,6 +107,7 @@ impl Recorder {
     #[must_use]
     pub fn into_reports(self) -> Reports {
         Reports {
+            ignored_inputs: self.ignored_inputs,
             cache_disabled: self.cache_disabled,
             tracked_get_env: self.tracked_get_env,
             tracked_get_envs: self.tracked_get_envs,
@@ -106,6 +116,10 @@ impl Recorder {
 }
 
 impl Handler for Recorder {
+    fn ignore_input(&mut self, path: &Arc<AbsolutePath>) {
+        self.ignored_inputs.insert(Arc::clone(path));
+    }
+
     fn disable_cache(&mut self) {
         self.cache_disabled = true;
     }
@@ -360,11 +374,16 @@ async fn handle_client<H: Handler>(mut stream: Stream, handler: &RefCell<H>) -> 
         let request: Request<'_> =
             wincode::deserialize_exact(&buf).map_err(Error::InvalidRequest)?;
 
-        // The fire-and-forget branch (`DisableCache`) intentionally writes no
-        // response. Nothing in the runner observes individual IPC events
-        // live; the recorded set is collected after this driver drains. See
-        // `Request` in `vite_task_ipc_shared` for the rationale.
+        // Fire-and-forget branches (`IgnoreInput`, `DisableCache`)
+        // intentionally write no response. Nothing in the runner observes
+        // individual IPC events live; the recorded set is collected after
+        // this driver drains. See `Request` in `vite_task_ipc_shared` for
+        // the rationale.
         match request {
+            Request::IgnoreInput(ns) => {
+                let path = native_str_to_abs_path(ns)?;
+                handler.borrow_mut().ignore_input(&path);
+            }
             Request::DisableCache => {
                 handler.borrow_mut().disable_cache();
             }
@@ -388,6 +407,13 @@ async fn handle_client<H: Handler>(mut stream: Stream, handler: &RefCell<H>) -> 
             }
         }
     }
+}
+
+fn native_str_to_abs_path(ns: &NativeStr) -> Result<Arc<AbsolutePath>, Error> {
+    let os_str = ns.to_cow_os_str();
+    AbsolutePath::new(&*os_str)
+        .map(Arc::from)
+        .ok_or_else(|| Error::NonAbsolutePath { path: os_str.into_owned() })
 }
 
 async fn read_frame(stream: &mut Stream, buf: &mut Vec<u8>) -> io::Result<()> {

--- a/crates/vite_task_server/tests/integration.rs
+++ b/crates/vite_task_server/tests/integration.rs
@@ -1,13 +1,20 @@
 use std::{
     ffi::{OsStr, OsString},
-    io,
+    io::{self, Read, Write},
     sync::Arc,
     thread,
 };
 
+use native_str::NativeStr;
+
+#[cfg(unix)]
+type RawStream = std::os::unix::net::UnixStream;
+#[cfg(windows)]
+type RawStream = std::fs::File;
 use rustc_hash::FxHashMap;
 use tokio::runtime::Builder;
 use vite_task_client::Client;
+use vite_task_ipc_shared::Request;
 use vite_task_server::{Error, Recorder, Reports, ServerHandle, serve};
 
 fn env_map(pairs: &[(&str, &str)]) -> FxHashMap<Arc<OsStr>, Arc<OsStr>> {
@@ -57,15 +64,41 @@ fn flush(client: &Client) {
     let _ = client.get_env(OsStr::new("__VP_TEST_FLUSH__"), false).unwrap();
 }
 
+#[cfg(unix)]
+fn connect_raw(name: &OsStr) -> RawStream {
+    std::os::unix::net::UnixStream::connect(name).expect("connect raw")
+}
+
+#[cfg(windows)]
+fn connect_raw(name: &OsStr) -> RawStream {
+    std::fs::OpenOptions::new().read(true).write(true).open(name).expect("connect raw")
+}
+
+fn send_frame(stream: &mut RawStream, request: &Request<'_>) {
+    let bytes = wincode::serialize(request).expect("serialize");
+    let len = u32::try_from(bytes.len()).expect("frame length fits u32");
+    stream.write_all(&len.to_le_bytes()).expect("write len");
+    stream.write_all(&bytes).expect("write body");
+    stream.flush().expect("flush");
+}
+
 #[test]
 fn single_client_fire_and_forget() {
+    #[cfg(unix)]
+    let in_path = "/tmp/in.txt";
+    #[cfg(windows)]
+    let in_path = r"C:\tmp\in.txt";
+
     let reports = run_with_server(env_map(&[]), |envs| {
         let client = connect(&envs);
+        client.ignore_input(OsStr::new(in_path)).unwrap();
         client.disable_cache().unwrap();
         flush(&client);
     })
     .expect("driver returned error");
 
+    let inputs: Vec<_> = reports.ignored_inputs.iter().map(|p| p.as_path().as_os_str()).collect();
+    assert_eq!(inputs, vec![OsStr::new(in_path)]);
     assert!(reports.cache_disabled);
 }
 
@@ -109,12 +142,20 @@ fn get_env_untracked_then_tracked_records_once() {
 
 #[test]
 fn concurrent_clients() {
+    #[cfg(unix)]
+    let paths = ["/tmp/worker_0", "/tmp/worker_1", "/tmp/worker_2", "/tmp/worker_3"];
+    #[cfg(windows)]
+    let paths = [r"C:\tmp\worker_0", r"C:\tmp\worker_1", r"C:\tmp\worker_2", r"C:\tmp\worker_3"];
+
     let reports = run_with_server(env_map(&[("SHARED", "value")]), move |envs| {
-        let threads: Vec<_> = (0..4)
-            .map(|_| {
+        let threads: Vec<_> = paths
+            .iter()
+            .map(|path| {
                 let envs = envs.clone();
+                let path = *path;
                 thread::spawn(move || {
                     let client = connect(&envs);
+                    client.ignore_input(OsStr::new(path)).unwrap();
                     let value = client.get_env(OsStr::new("SHARED"), true).unwrap();
                     assert_eq!(value.as_deref(), Some(OsStr::new("value")));
                 })
@@ -127,8 +168,48 @@ fn concurrent_clients() {
     .expect("driver returned error");
 
     assert!(!reports.cache_disabled);
+    assert_eq!(reports.ignored_inputs.len(), 4);
     let shared = reports.tracked_get_env.get(OsStr::new("SHARED")).expect("recorded");
     assert_eq!(shared.as_deref(), Some(OsStr::new("value")));
+}
+
+#[test]
+fn relative_input_joined_with_cwd() {
+    let cwd = vite_path::current_dir().expect("cwd");
+    let expected = cwd.as_path().join("sub/file.txt");
+
+    let reports = run_with_server(env_map(&[]), |envs| {
+        let client = connect(&envs);
+        client.ignore_input(OsStr::new("sub/file.txt")).unwrap();
+        flush(&client);
+    })
+    .expect("driver returned error");
+
+    let inputs: Vec<_> = reports.ignored_inputs.iter().map(|p| p.as_path().as_os_str()).collect();
+    assert_eq!(inputs, vec![expected.as_os_str()]);
+}
+
+#[test]
+fn server_returns_error_on_non_absolute_path() {
+    let err = run_with_server(env_map(&[]), |envs| {
+        let name = &envs[0].1;
+        let mut stream = connect_raw(name);
+
+        let ns: Box<NativeStr> = OsStr::new("relative/path").into();
+        send_frame(&mut stream, &Request::IgnoreInput(&ns));
+
+        let mut buf = [0u8; 1];
+        let read_err = stream.read_exact(&mut buf).expect_err("server should close connection");
+        assert_eq!(read_err.kind(), io::ErrorKind::UnexpectedEof);
+    })
+    .expect_err("driver should surface the protocol error");
+
+    match err {
+        Error::NonAbsolutePath { path } => {
+            assert_eq!(path, OsStr::new("relative/path"));
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

Runner-aware tools sometimes read files that are cache-like implementation details rather than semantic task inputs. Those reads should not make auto-input fingerprints unstable or prevent cache hits when the tool can identify them.

## Scope

Add the `ignoreInput(path)` IPC request, expose it through the Rust and Node clients, validate and record absolute paths on the server, and filter matching fspy-inferred reads before post-run fingerprinting and read/write overlap checks. Add an e2e that mutates an ignored file between runs and still gets a cache hit.