### PR TITLE
perf(plan): share the planning env map via Arc instead of cloning per command

### DIFF
--- a/crates/vite_task_plan/src/context.rs
+++ b/crates/vite_task_plan/src/context.rs
@@ -28,7 +28,13 @@ pub struct PlanContext<'a> {
     cwd: Arc<AbsolutePath>,
 
     /// The environment variables for the current execution context.
-    envs: FxHashMap<Arc<OsStr>, Arc<OsStr>>,
+    ///
+    /// `Arc`-shared with copy-on-write semantics: [`duplicate`](Self::duplicate)
+    /// and downstream consumers (`ScriptCommand::envs`) share the map;
+    /// mutations ([`add_envs`](Self::add_envs),
+    /// [`prepend_path`](Self::prepend_path)) clone only when the map is
+    /// currently shared.
+    envs: Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>,
 
     /// The callbacks for loading task graphs and parsing commands.
     callbacks: &'a mut (dyn PlanRequestParser + 'a),
@@ -54,7 +60,7 @@ impl<'a> PlanContext<'a> {
     pub fn new(
         workspace_path: &'a Arc<AbsolutePath>,
         cwd: Arc<AbsolutePath>,
-        envs: FxHashMap<Arc<OsStr>, Arc<OsStr>>,
+        envs: Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>,
         callbacks: &'a mut (dyn PlanRequestParser + 'a),
         indexed_task_graph: &'a IndexedTaskGraph,
         resolved_global_cache: ResolvedGlobalCacheConfig,
@@ -73,7 +79,7 @@ impl<'a> PlanContext<'a> {
         }
     }
 
-    pub const fn envs(&self) -> &FxHashMap<Arc<OsStr>, Arc<OsStr>> {
+    pub const fn envs(&self) -> &Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>> {
         &self.envs
     }
 
@@ -108,15 +114,22 @@ impl<'a> PlanContext<'a> {
     }
 
     pub fn prepend_path(&mut self, path_to_prepend: &AbsolutePath) -> Result<(), JoinPathsError> {
-        prepend_path_env(&mut self.envs, path_to_prepend)
+        prepend_path_env(Arc::make_mut(&mut self.envs), path_to_prepend)
     }
 
     pub fn add_envs(
         &mut self,
         new_envs: impl Iterator<Item = (impl AsRef<OsStr>, impl AsRef<OsStr>)>,
     ) {
+        // Don't touch the Arc for an empty iterator — `make_mut` would clone
+        // the shared map for nothing (most commands have no prefix envs).
+        let mut new_envs = new_envs.peekable();
+        if new_envs.peek().is_none() {
+            return;
+        }
+        let envs = Arc::make_mut(&mut self.envs);
         for (key, value) in new_envs {
-            self.envs.insert(Arc::from(key.as_ref()), Arc::from(value.as_ref()));
+            envs.insert(Arc::from(key.as_ref()), Arc::from(value.as_ref()));
         }
     }
 
@@ -154,7 +167,7 @@ impl<'a> PlanContext<'a> {
         PlanContext {
             workspace_path: self.workspace_path,
             cwd: Arc::clone(&self.cwd),
-            envs: self.envs.clone(),
+            envs: Arc::clone(&self.envs),
             callbacks: self.callbacks,
             task_call_stack: self.task_call_stack.clone(),
             indexed_task_graph: self.indexed_task_graph,

--- a/crates/vite_task_plan/src/lib.rs
+++ b/crates/vite_task_plan/src/lib.rs
@@ -200,7 +200,7 @@ pub async fn plan_query(
     query_plan_request: QueryPlanRequest,
     workspace_path: &Arc<AbsolutePath>,
     cwd: &Arc<AbsolutePath>,
-    envs: &FxHashMap<Arc<OsStr>, Arc<OsStr>>,
+    envs: &Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>,
     plan_request_parser: &mut (dyn PlanRequestParser + '_),
     task_graph_loader: &mut (dyn TaskGraphLoader + '_),
 ) -> Result<PlanResult, Error> {
@@ -216,7 +216,7 @@ pub async fn plan_query(
     let context = PlanContext::new(
         workspace_path,
         Arc::clone(cwd),
-        envs.clone(),
+        Arc::clone(envs),
         plan_request_parser,
         indexed_task_graph,
         resolved_global_cache,

--- a/crates/vite_task_plan/src/plan.rs
+++ b/crates/vite_task_plan/src/plan.rs
@@ -211,7 +211,7 @@ async fn plan_task_as_execution_node(
                 };
 
                 // Try to parse the args of an and_item to a plan request like `run -r build`
-                let envs: Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>> = context.envs().clone().into();
+                let envs = Arc::clone(context.envs());
                 let mut script_command = ScriptCommand {
                     program: and_item.program.clone(),
                     args: args.into(),
@@ -597,12 +597,14 @@ fn plan_spawn_execution(
     execution_cache_key: Option<ExecutionCacheKey>,
     prefix_envs: &BTreeMap<Str, Str>,
     resolved_task_options: &ResolvedTaskOptions,
-    envs: &FxHashMap<Arc<OsStr>, Arc<OsStr>>,
+    envs: &Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>,
     program_path: Arc<AbsolutePath>,
     args: Arc<[Str]>,
 ) -> Result<SpawnExecution, Error> {
-    // all envs available in the current context
-    let mut all_envs = envs.clone();
+    // The child env starts from the full context and is filtered in place by
+    // `EnvFingerprints::resolve` below — this clone is the one place the map's
+    // contents are actually copied per spawn.
+    let mut all_envs = (**envs).clone();
     let cwd = Arc::clone(&resolved_task_options.cwd);
 
     let mut resolved_cache_metadata = None;


### PR DESCRIPTION
## Motivation

The planning context's env map — the full session environment, typically hundreds of entries — was copied at every boundary it crossed during planning:

- once into `PlanContext` per plan (`plan_query`),
- once **per `&&`-item** by `PlanContext::duplicate` (each command gets a scoped context),
- once more per `&&`-item into `ScriptCommand::envs` for program lookup and plan-request callbacks,
- and once per spawn into `all_envs`.

Of these, only the last one does real work — the spawn env is filtered in place by `EnvFingerprints::resolve`. Every other copy duplicates an almost-always-identical map just to hand it to the next stage, and the cost scales with task count × command count, not with actual env changes.

The immediate trigger is the upcoming runner-aware caching work (#430/#431): it saves each spawn's **full env context** into the plan (`SpawnCommand::full_envs`) so `getEnv`/`getEnvs` and tracked-env validation resolve against the plan rather than the live process env. Without sharing, that would add yet another full map copy per spawn; with this change it costs a pointer.

## Approach

Wrap the map in `Arc` with copy-on-write semantics:

- Duplication and hand-off points (`duplicate`, `ScriptCommand::envs`, `PlanContext::new`) share the map — O(1).
- The two mutation points pay for a copy only when they change something: `prepend_path` once per task node (package `.bin` PATH prepend), and `add_envs` only when a command actually has prefix envs — an empty prefix set is guarded so it doesn't break sharing.
- The per-spawn `all_envs` clone remains, with a comment marking it as the one place the map's contents are genuinely copied.

No behavior change; `Session` already held the map in an `Arc`, so its call sites are untouched.
