### PR TITLE
feat(cache): name the changed env var in cache-miss message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- **Changed** Cache misses caused by a tracked env var now name the env var inline, for example `cache miss: env 'NODE_ENV' changed`, instead of the generic `envs changed` message ([#438](https://github.com/voidzero-dev/vite-task/pull/438))
 - **Fixed** The task cache is now stored in a per-schema-version subdirectory (e.g. `node_modules/.vite/task-cache/v13/`), so switching between branches that pin different Vite+ versions no longer fails with `Unrecognized database version`. Each version keeps its own cache directory; a cache from a different version is ignored rather than aborting the run ([#433](https://github.com/voidzero-dev/vite-task/pull/433))
 - **Added** A task's `env` and `untrackedEnv` glob patterns now support `!` negation: a `!`-prefixed pattern excludes matching variables (e.g. `["VITE_*", "!VITE_SECRET"]` tracks every `VITE_*` except `VITE_SECRET`) ([#425](https://github.com/voidzero-dev/vite-task/pull/425))
 - **Fixed** `package.json` and `pnpm-workspace.yaml` files with a UTF-8 BOM no longer fail to parse ([#424](https://github.com/voidzero-dev/vite-task/pull/424))

--- a/crates/vite_task/src/session/cache/display.rs
+++ b/crates/vite_task/src/session/cache/display.rs
@@ -119,6 +119,34 @@ pub fn detect_spawn_fingerprint_changes(
     changes
 }
 
+/// Names of the env vars involved in a set of spawn-fingerprint changes, in the
+/// order detected. Only env changes are collected; untracked-env and non-env
+/// changes are skipped.
+fn env_change_names(changes: &[SpawnFingerprintChange]) -> Vec<&Str> {
+    changes
+        .iter()
+        .filter_map(|change| match change {
+            SpawnFingerprintChange::Env(mismatch) => Some(mismatch.name()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Inline cache-miss reason naming the env var(s) that changed, e.g.
+/// `env 'NODE_ENV' changed` or `envs 'A', 'B' changed`. Falls back to the
+/// generic `envs changed` when no names are available.
+fn format_env_changed_inline(names: &[&Str]) -> Str {
+    match names {
+        [] => Str::from("envs changed"),
+        [name] => vite_str::format!("env '{name}' changed"),
+        names => {
+            let quoted: Vec<Str> = names.iter().map(|name| vite_str::format!("'{name}'")).collect();
+            let joined = quoted.iter().map(Str::as_str).collect::<Vec<_>>().join(", ");
+            vite_str::format!("envs {joined} changed")
+        }
+    }
+}
+
 /// Format cache status for inline display (during Start event).
 ///
 /// Returns `Some(formatted_string)` for Hit, Miss with reason, and Disabled, None for `NotFound`.
@@ -145,22 +173,27 @@ pub fn format_cache_status_inline(cache_status: &CacheStatus) -> Option<Str> {
                 FingerprintMismatch::SpawnFingerprint { old, new } => {
                     let changes = detect_spawn_fingerprint_changes(old, new);
                     match changes.first() {
-                        Some(SpawnFingerprintChange::Env(_)) => "envs changed",
+                        Some(SpawnFingerprintChange::Env(_)) => {
+                            format_env_changed_inline(&env_change_names(&changes))
+                        }
                         Some(
                             SpawnFingerprintChange::UntrackedEnvAdded { .. }
                             | SpawnFingerprintChange::UntrackedEnvRemoved { .. },
-                        ) => "untracked env config changed",
-                        Some(SpawnFingerprintChange::ProgramChanged) => "program changed",
-                        Some(SpawnFingerprintChange::ArgsChanged) => "args changed",
-                        Some(SpawnFingerprintChange::CwdChanged) => "working directory changed",
-                        None => "configuration changed",
+                        ) => Str::from("untracked env config changed"),
+                        Some(SpawnFingerprintChange::ProgramChanged) => {
+                            Str::from("program changed")
+                        }
+                        Some(SpawnFingerprintChange::ArgsChanged) => Str::from("args changed"),
+                        Some(SpawnFingerprintChange::CwdChanged) => {
+                            Str::from("working directory changed")
+                        }
+                        None => Str::from("configuration changed"),
                     }
                 }
-                FingerprintMismatch::InputConfig => "input configuration changed",
-                FingerprintMismatch::OutputConfig => "output configuration changed",
+                FingerprintMismatch::InputConfig => Str::from("input configuration changed"),
+                FingerprintMismatch::OutputConfig => Str::from("output configuration changed"),
                 FingerprintMismatch::InputChanged { kind, path } => {
-                    let desc = format_input_change_str(*kind, path.as_str());
-                    return Some(vite_str::format!("○ cache miss: {desc}, executing"));
+                    format_input_change_str(*kind, path.as_str())
                 }
             };
             Some(vite_str::format!("○ cache miss: {reason}, executing"))

--- a/crates/vite_task/src/session/cache/mod.rs
+++ b/crates/vite_task/src/session/cache/mod.rs
@@ -155,6 +155,18 @@ pub enum EnvMismatch {
     Changed { name: Str, old_value: Str, new_value: Str },
 }
 
+impl EnvMismatch {
+    /// The name of the env var that diverged.
+    #[must_use]
+    pub const fn name(&self) -> &Str {
+        match self {
+            Self::Added { name, .. } | Self::Removed { name, .. } | Self::Changed { name, .. } => {
+                name
+            }
+        }
+    }
+}
+
 impl Display for EnvMismatch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/env_added.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/env_added.md
@@ -16,6 +16,6 @@ initial content
 cache miss: env added
 
 ```
-$ vtt print-file test.txt ○ cache miss: envs changed, executing
+$ vtt print-file test.txt ○ cache miss: env 'MY_ENV' changed, executing
 initial content
 ```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/env_removed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/env_removed.md
@@ -16,6 +16,6 @@ initial content
 cache miss: env removed
 
 ```
-$ vtt print-file test.txt ○ cache miss: envs changed, executing
+$ vtt print-file test.txt ○ cache miss: env 'MY_ENV' changed, executing
 initial content
 ```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/env_value_changed.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/cache_miss_reasons/snapshots/env_value_changed.md
@@ -16,6 +16,6 @@ initial content
 cache miss: env value changed
 
 ```
-$ vtt print-file test.txt ○ cache miss: envs changed, executing
+$ vtt print-file test.txt ○ cache miss: env 'MY_ENV' changed, executing
 initial content
 ```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/individual_cache_for_env/snapshots/individual_cache_for_env.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/individual_cache_for_env/snapshots/individual_cache_for_env.md
@@ -16,7 +16,7 @@ $ vtt print-env FOO
 cache miss, different env
 
 ```
-$ vtt print-env FOO ○ cache miss: envs changed, executing
+$ vtt print-env FOO ○ cache miss: env 'FOO' changed, executing
 2
 ```
 


### PR DESCRIPTION
## Motivation

The task runner already detects which fingerprinted env vars changed between cache entries, but the inline cache-miss status collapsed that detail to `envs changed`. That made the live output less useful than the persisted detailed summary.

## Changes

- Add `EnvMismatch::name()` so cache display code can reuse the detected env var name.
- Render inline env cache misses as `env 'NAME' changed` or `envs 'A', 'B' changed`.
- Update the cache-miss snapshots that exercise env additions, removals, value changes, and per-env cache keys.
- Add the changelog entry for #438.

## Verification

- `cargo test -p vite_task_bin --test e2e_snapshots cache_miss_reasons`
- `cargo test -p vite_task_bin --test e2e_snapshots individual_cache_for_env`
- `cargo fmt`
- `cargo check --all-features`
- `cargo clippy --all-features -- -D warnings`
- `cargo test`