### PR TITLE
chore(lint): enforce the session-env-snapshot rule for std::env::vars_os

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -8,6 +8,7 @@ disallowed-methods = [
   { path = "str::replace", reason = "To avoid memory allocation, use `cow_utils::CowUtils::cow_replace` instead." },
   { path = "str::replacen", reason = "To avoid memory allocation, use `cow_utils::CowUtils::cow_replacen` instead." },
   { path = "std::env::current_dir", reason = "To get an `AbsolutePathBuf`, Use `vite_path::current_dir` instead." },
+  { path = "std::env::vars_os", reason = "Read process env only in `Session::init`, then use the session env snapshot downstream." },
   { path = "std::thread::sleep", reason = "Use proper synchronization (channels, condvars, etc.) instead of sleeping. Sleep is only acceptable for intentional user-facing delays (e.g. animations, debouncing)." },
   { path = "tokio::time::sleep", reason = "Use proper synchronization (channels, signals, etc.) instead of sleeping. Sleep is only acceptable for intentional user-facing delays (e.g. animations, debouncing)." },
 ]

--- a/crates/vite_task/src/session/mod.rs
+++ b/crates/vite_task/src/session/mod.rs
@@ -196,6 +196,10 @@ impl<'a> Session<'a> {
     /// if workspace initialization fails.
     #[tracing::instrument(level = "debug", skip_all)]
     pub fn init(config: SessionConfig<'a>) -> anyhow::Result<Self> {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "Session::init is the only place that bootstraps the session env snapshot"
+        )]
         let envs = std::env::vars_os()
             .map(|(k, v)| (Arc::<OsStr>::from(k.as_os_str()), Arc::<OsStr>::from(v.as_os_str())))
             .collect();


### PR DESCRIPTION
## Motivation

The session env snapshot rule says `std::env::vars_os` should be read once in `Session::init`, then downstream planning, execution, IPC, and cache validation should use captured env maps. Main followed that rule by convention; this makes the convention enforceable.

## Changes

- Add `std::env::vars_os` to the root clippy `disallowed-methods` list.
- Annotate `Session::init` as the one sanctioned bootstrap reader.

## Verification

- `cargo fmt`
- `cargo clippy --all-features -- -D warnings`
- `cargo test`
- Restacked `infra-env-track` and `auto-output-track`, then ran `cargo clippy --all-features -- -D warnings` at the top of the stack.