### PR TITLE
feat(client): serve getEnv over runner IPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4320,6 +4320,7 @@ dependencies = [
 name = "vite_task_client"
 version = "0.0.0"
 dependencies = [
+ "native_str",
  "vite_task_ipc_shared",
  "winapi",
  "wincode",
@@ -4363,6 +4364,7 @@ dependencies = [
 name = "vite_task_ipc_shared"
 version = "0.0.0"
 dependencies = [
+ "native_str",
  "wincode",
 ]
 
@@ -4409,6 +4411,7 @@ name = "vite_task_server"
 version = "0.0.0"
 dependencies = [
  "futures",
+ "rustc-hash",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/vite_task/src/session/execute/mod.rs
+++ b/crates/vite_task/src/session/execute/mod.rs
@@ -18,6 +18,7 @@ use std::{
 };
 
 use futures_util::future::LocalBoxFuture;
+use rustc_hash::FxHashMap;
 use tokio_util::sync::CancellationToken;
 use vite_path::{AbsolutePath, RelativePathBuf};
 use vite_task_ipc_shared::NODE_CLIENT_PATH_ENV_NAME;
@@ -156,6 +157,7 @@ impl<'a> ExecutionMode<'a> {
         cache_metadata: Option<&'a CacheMetadata>,
         stdio_config: StdioConfig,
         globbed_inputs: BTreeMap<RelativePathBuf, u64>,
+        envs: &BTreeMap<Arc<OsStr>, Arc<OsStr>>,
     ) -> Result<Self, ExecutionError> {
         let Some(metadata) = cache_metadata else {
             return Ok(Self::Uncached {
@@ -182,8 +184,10 @@ impl<'a> ExecutionMode<'a> {
         // Bind runner IPC for every cached task. The merged cache-control API
         // (`disableCache`) must work even when a task uses explicit inputs and
         // therefore does not need fspy auto-input inference.
+        let server_envs: FxHashMap<Arc<OsStr>, Arc<OsStr>> =
+            envs.iter().map(|(name, value)| (Arc::clone(name), Arc::clone(value))).collect();
         let (ipc_envs, ServerHandle { driver, stop_accepting }) =
-            serve(Recorder::new()).map_err(ExecutionError::IpcServerBind)?;
+            serve(Recorder::new(Arc::new(server_envs))).map_err(ExecutionError::IpcServerBind)?;
         let tracking =
             Tracking { fspy, ipc_envs: ipc_envs.collect(), ipc_server_fut: driver, stop_accepting };
 
@@ -405,8 +409,16 @@ async fn run(
     };
 
     // 4. Fold the cache/fspy/stdio decisions into the typed mode.
-    let mut mode = ExecutionMode::build(cache_metadata, stdio_config, globbed_inputs)
-        .map_err(Report::failed)?;
+    let mut mode = ExecutionMode::build(
+        cache_metadata,
+        stdio_config,
+        globbed_inputs,
+        // TODO(env-track): A later PR in this stack replaces this child env
+        // map with the full planned env context so IPC can serve envs even
+        // when they were not declared in `env` or `untrackedEnv`.
+        &spawn_execution.spawn_command.all_envs,
+    )
+    .map_err(Report::failed)?;
 
     // Measure end-to-end duration here — spawn() doesn't track time.
     let start = Instant::now();

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/scripts/fetch_env.mjs
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/scripts/fetch_env.mjs
@@ -1,0 +1,5 @@
+import { getEnv } from '@voidzero-dev/vite-task-client';
+
+const value = getEnv('PROBE_ENV') ?? '(unset)';
+
+console.log('PROBE_ENV=' + value);

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots.toml
@@ -46,3 +46,22 @@ steps = [
     "--last-details",
   ], comment = "summary names the opt-out as the not-cached reason" },
 ]
+
+[[e2e]]
+name = "fetch_env_reads_declared_env"
+comment = """
+Exercises `getEnv(name)`: the tool asks the runner for a declared env var and prints the served value. This verifies the round-trip IPC behavior before any runner-reported env is added to the cache fingerprint.
+"""
+ignore = true
+steps = [
+  { argv = [
+    "vt",
+    "run",
+    "fetch-env-declared",
+  ], envs = [
+    [
+      "PROBE_ENV",
+      "served",
+    ],
+  ], comment = "runner serves PROBE_ENV from the spawned task env map" },
+]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/fetch_env_reads_declared_env.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/fetch_env_reads_declared_env.md
@@ -1,0 +1,12 @@
+# fetch_env_reads_declared_env
+
+Exercises `getEnv(name)`: the tool asks the runner for a declared env var and prints the served value. This verifies the round-trip IPC behavior before any runner-reported env is added to the cache fingerprint.
+
+## `PROBE_ENV=served vt run fetch-env-declared`
+
+runner serves PROBE_ENV from the spawned task env map
+
+```
+$ node scripts/fetch_env.mjs
+PROBE_ENV=served
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/vite-task.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/vite-task.json
@@ -8,6 +8,12 @@
       "command": "node scripts/disable_cache.mjs",
       "input": [],
       "cache": true
+    },
+    "fetch-env-declared": {
+      "command": "node scripts/fetch_env.mjs",
+      // TODO(env-track): Remove this explicit env declaration down the stack and update the e2e name once runner-tracked env reads cover it.
+      "env": ["PROBE_ENV"],
+      "cache": true
     }
   }
 }

--- a/crates/vite_task_client/Cargo.toml
+++ b/crates/vite_task_client/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 rust-version.workspace = true
 
 [dependencies]
+native_str = { workspace = true }
 vite_task_ipc_shared = { workspace = true }
 wincode = { workspace = true, features = ["derive"] }
 

--- a/crates/vite_task_client/src/lib.rs
+++ b/crates/vite_task_client/src/lib.rs
@@ -1,10 +1,13 @@
 use std::{
     cell::RefCell,
     ffi::OsStr,
-    io::{self, Write},
+    io::{self, Read, Write},
+    sync::Arc,
 };
 
-use vite_task_ipc_shared::{IPC_ENV_NAME, Request};
+use native_str::NativeStr;
+use vite_task_ipc_shared::{GetEnvResponse, IPC_ENV_NAME, Request};
+use wincode::{SchemaRead, config::DefaultConfig};
 
 #[cfg(unix)]
 type Stream = std::os::unix::net::UnixStream;
@@ -13,6 +16,7 @@ type Stream = std::fs::File;
 
 pub struct Client {
     stream: RefCell<Stream>,
+    scratch: RefCell<Vec<u8>>,
 }
 
 impl Client {
@@ -38,7 +42,7 @@ impl Client {
     }
 
     const fn from_stream(stream: Stream) -> Self {
-        Self { stream: RefCell::new(stream) }
+        Self { stream: RefCell::new(stream), scratch: RefCell::new(Vec::new()) }
     }
 
     /// Fire-and-forget: the call returns once the request is flushed to the
@@ -53,7 +57,25 @@ impl Client {
         self.send(&Request::DisableCache)
     }
 
-    fn send(&self, request: &Request) -> io::Result<()> {
+    /// Requests an env value from the runner. Returns `None` if the runner
+    /// reports the env is not available.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request or response fails.
+    // TODO(env-track): A later PR in this stack adds a tracked flag so env
+    // reads can participate in cache fingerprints instead of being IPC-only.
+    pub fn get_env(&self, name: &OsStr) -> io::Result<Option<Arc<OsStr>>> {
+        let name = Box::<NativeStr>::from(name);
+
+        self.send(&Request::GetEnv { name: &name })?;
+        let response: GetEnvResponse = self.recv()?;
+        Ok(response
+            .env_value
+            .map(|env_value| Arc::<OsStr>::from(env_value.to_cow_os_str().as_ref())))
+    }
+
+    fn send(&self, request: &Request<'_>) -> io::Result<()> {
         let bytes = wincode::serialize(request)
             .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
         let len = u32::try_from(bytes.len())
@@ -63,6 +85,22 @@ impl Client {
         stream.write_all(&bytes)?;
         stream.flush()?;
         Ok(())
+    }
+
+    fn recv<T>(&self) -> io::Result<T>
+    where
+        for<'de> T: SchemaRead<'de, DefaultConfig, Dst = T>,
+    {
+        let mut stream = self.stream.borrow_mut();
+        let mut scratch = self.scratch.borrow_mut();
+        let mut len_bytes = [0u8; 4];
+        stream.read_exact(&mut len_bytes)?;
+        let len = u32::from_le_bytes(len_bytes) as usize;
+        scratch.clear();
+        scratch.resize(len, 0);
+        stream.read_exact(&mut scratch)?;
+        wincode::deserialize_exact(&scratch)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
     }
 }
 

--- a/crates/vite_task_client_napi/src/lib.rs
+++ b/crates/vite_task_client_napi/src/lib.rs
@@ -37,7 +37,7 @@
     reason = "no-op stubs keep the signature of the real implementations that replace them"
 )]
 
-use std::collections::HashMap;
+use std::{collections::HashMap, ffi::OsStr};
 
 use napi::{Error, Result};
 use napi_derive::napi;
@@ -92,16 +92,17 @@ impl RunnerClient {
         self.client.disable_cache().map_err(|err| err_string(vite_str::format!("{err}")))
     }
 
-    /// No-op for now: always returns `None`, so callers fall back to their
-    /// own process env. Becomes a real request once env tracking can
-    /// fingerprint the served values.
     #[napi]
-    pub fn get_env(
-        &self,
-        _name: String,
-        _options: Option<GetEnvOptions>,
-    ) -> Result<Option<String>> {
-        Ok(None)
+    pub fn get_env(&self, name: String, _options: Option<GetEnvOptions>) -> Result<Option<String>> {
+        let value = self
+            .client
+            .get_env(OsStr::new(&name))
+            .map_err(|err| err_string(vite_str::format!("{err}")))?;
+        value.map_or(Ok(None), |value| {
+            value.to_str().map(|s| Some(s.to_owned())).ok_or_else(|| {
+                err_string(vite_str::format!("env value for {name} is not valid UTF-8"))
+            })
+        })
     }
 
     /// No-op for now: always returns an empty match-set — see

--- a/crates/vite_task_ipc_shared/Cargo.toml
+++ b/crates/vite_task_ipc_shared/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 rust-version.workspace = true
 
 [dependencies]
+native_str = { workspace = true }
 wincode = { workspace = true, features = ["derive"] }
 
 [lints]

--- a/crates/vite_task_ipc_shared/src/lib.rs
+++ b/crates/vite_task_ipc_shared/src/lib.rs
@@ -1,3 +1,4 @@
+use native_str::NativeStr;
 use wincode::{SchemaRead, SchemaWrite};
 
 pub const IPC_ENV_NAME: &str = "VP_RUN_IPC_NAME";
@@ -15,7 +16,8 @@ pub const NODE_CLIENT_PATH_ENV_NAME: &str = "VP_RUN_NODE_CLIENT_PATH";
 /// IPC request frame sent by tools to the runner.
 ///
 /// `DisableCache` is fire-and-forget: the runner processes it when it
-/// arrives and never writes a response.
+/// arrives and never writes a response. `GetEnv` is a round-trip and pairs
+/// with [`GetEnvResponse`].
 ///
 /// Fire-and-forget is safe because nothing in the runner observes individual
 /// IPC events live — the recorded set is only consumed *after* the per-task
@@ -23,6 +25,14 @@ pub const NODE_CLIENT_PATH_ENV_NAME: &str = "VP_RUN_NODE_CLIENT_PATH";
 /// process exits. So a tool can `flush + exit` and the server's drain phase
 /// will still consume every buffered frame.
 #[derive(Debug, SchemaWrite, SchemaRead)]
-pub enum Request {
+pub enum Request<'a> {
+    // TODO(env-track): A later PR in this stack adds a tracked flag once the
+    // runner records served env reads into the post-run cache fingerprint.
+    GetEnv { name: &'a NativeStr },
     DisableCache,
+}
+
+#[derive(Debug, SchemaWrite, SchemaRead)]
+pub struct GetEnvResponse {
+    pub env_value: Option<Box<NativeStr>>,
 }

--- a/crates/vite_task_server/Cargo.toml
+++ b/crates/vite_task_server/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 futures = { workspace = true }
+rustc-hash = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "net", "rt", "macros"] }

--- a/crates/vite_task_server/src/lib.rs
+++ b/crates/vite_task_server/src/lib.rs
@@ -2,15 +2,19 @@ use std::{
     cell::RefCell,
     ffi::{OsStr, OsString},
     io,
+    sync::Arc,
 };
 
 use futures::{FutureExt, StreamExt, future::LocalBoxFuture, stream::FuturesUnordered};
-use tokio::io::AsyncReadExt;
+use rustc_hash::FxHashMap;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_util::sync::CancellationToken;
-use vite_task_ipc_shared::{IPC_ENV_NAME, Request};
+use vite_task_ipc_shared::{GetEnvResponse, IPC_ENV_NAME, Request};
+use wincode::{SchemaWrite, config::DefaultConfig};
 
 pub trait Handler {
     fn disable_cache(&mut self);
+    fn get_env(&mut self, name: &OsStr) -> Option<Arc<OsStr>>;
 }
 
 /// A protocol-level failure observed while servicing a client.
@@ -24,14 +28,21 @@ pub enum Error {
 
     #[error("invalid message from the task")]
     InvalidRequest(#[source] wincode::ReadError),
+
+    #[error("failed to send response to the task")]
+    WriteResponse(#[source] io::Error),
 }
 
-/// A [`Handler`] that records every report.
+/// A [`Handler`] that records every report and resolves `get_env` against
+/// provided envs.
 ///
 /// Call [`Recorder::into_reports`] after the driver future completes to
 /// recover the collected [`Reports`].
 pub struct Recorder {
     cache_disabled: bool,
+    /// The envs `get_env` resolves against. The runner supplies these for the
+    /// spawned task; the server never re-reads the live process env.
+    envs: Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>,
 }
 
 /// The data collected by a [`Recorder`] over the server's lifetime.
@@ -42,25 +53,23 @@ pub struct Reports {
 
 impl Recorder {
     #[must_use]
-    pub const fn new() -> Self {
-        Self { cache_disabled: false }
+    pub const fn new(envs: Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>) -> Self {
+        Self { cache_disabled: false, envs }
     }
 
     #[must_use]
-    pub const fn into_reports(self) -> Reports {
+    pub fn into_reports(self) -> Reports {
         Reports { cache_disabled: self.cache_disabled }
-    }
-}
-
-impl Default for Recorder {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
 impl Handler for Recorder {
     fn disable_cache(&mut self) {
         self.cache_disabled = true;
+    }
+
+    fn get_env(&mut self, name: &OsStr) -> Option<Arc<OsStr>> {
+        self.envs.get(name).cloned()
     }
 }
 
@@ -274,15 +283,21 @@ async fn handle_client<H: Handler>(mut stream: Stream, handler: &RefCell<H>) -> 
             Err(err) => return Err(Error::ReadFrame(err)),
         }
 
-        let request: Request = wincode::deserialize_exact(&buf).map_err(Error::InvalidRequest)?;
+        let request: Request<'_> =
+            wincode::deserialize_exact(&buf).map_err(Error::InvalidRequest)?;
 
-        // `DisableCache` is fire-and-forget and intentionally gets no
+        // The fire-and-forget branch (`DisableCache`) intentionally writes no
         // response. Nothing in the runner observes individual IPC events
         // live; the recorded set is collected after this driver drains. See
         // `Request` in `vite_task_ipc_shared` for the rationale.
         match request {
             Request::DisableCache => {
                 handler.borrow_mut().disable_cache();
+            }
+            Request::GetEnv { name } => {
+                let value = handler.borrow_mut().get_env(name.to_cow_os_str().as_ref());
+                let response = GetEnvResponse { env_value: value.as_deref().map(Into::into) };
+                write_response(&mut stream, &response).await.map_err(Error::WriteResponse)?;
             }
         }
     }
@@ -295,5 +310,19 @@ async fn read_frame(stream: &mut Stream, buf: &mut Vec<u8>) -> io::Result<()> {
     buf.clear();
     buf.resize(len, 0);
     stream.read_exact(buf).await?;
+    Ok(())
+}
+
+async fn write_response<T>(stream: &mut Stream, response: &T) -> io::Result<()>
+where
+    T: SchemaWrite<DefaultConfig, Src = T> + ?Sized,
+{
+    let bytes = wincode::serialize(response)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    let len = u32::try_from(bytes.len())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "response too large"))?;
+    stream.write_all(&len.to_le_bytes()).await?;
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
     Ok(())
 }

--- a/crates/vite_task_server/tests/integration.rs
+++ b/crates/vite_task_server/tests/integration.rs
@@ -1,21 +1,33 @@
 use std::{
     ffi::{OsStr, OsString},
-    sync::mpsc,
+    sync::Arc,
     thread,
 };
 
+use rustc_hash::FxHashMap;
 use tokio::runtime::Builder;
 use vite_task_client::Client;
-use vite_task_server::{Error, Handler, Recorder, ServerHandle, serve};
+use vite_task_server::{Error, Recorder, Reports, ServerHandle, serve};
 
-fn run_with_server<H, F>(handler: H, client_work: F) -> Result<H, Error>
+fn env_map(pairs: &[(&str, &str)]) -> FxHashMap<Arc<OsStr>, Arc<OsStr>> {
+    pairs
+        .iter()
+        .map(|(k, v)| (Arc::<OsStr>::from(OsStr::new(k)), Arc::<OsStr>::from(OsStr::new(v))))
+        .collect()
+}
+
+fn run_with_server<F>(
+    envs: FxHashMap<Arc<OsStr>, Arc<OsStr>>,
+    client_work: F,
+) -> Result<Reports, Error>
 where
-    H: Handler + 'static,
     F: FnOnce(Vec<(&'static OsStr, OsString)>) + Send + 'static,
 {
+    let recorder = Recorder::new(Arc::new(envs));
+
     let rt = Builder::new_current_thread().enable_all().build().unwrap();
     rt.block_on(async move {
-        let (envs, ServerHandle { driver, stop_accepting }) = serve(handler).expect("bind server");
+        let (envs, ServerHandle { driver, stop_accepting }) = serve(recorder).expect("bind server");
         let envs: Vec<_> = envs.collect();
 
         let client = async move {
@@ -26,7 +38,7 @@ where
         };
 
         let (result, ()) = tokio::join!(driver, client);
-        result
+        result.map(Recorder::into_reports)
     })
 }
 
@@ -36,62 +48,58 @@ fn connect(envs: &[(&'static OsStr, OsString)]) -> Client {
         .expect("serve should yield an IPC env")
 }
 
-/// Wraps [`Recorder`] and reports every handled `disableCache` on a channel.
-///
-/// The protocol is fire-and-forget only, so there is no round-trip request a
-/// test could use to flush the connection. Without the notification, a client
-/// that sends and returns immediately could let the test signal stop-accepting
-/// before the server has even accepted the connection, dropping the frame.
-struct NotifyingRecorder {
-    inner: Recorder,
-    handled: mpsc::Sender<()>,
-}
-
-impl Handler for NotifyingRecorder {
-    fn disable_cache(&mut self) {
-        self.inner.disable_cache();
-        let _ = self.handled.send(());
-    }
+/// Force a round-trip so the server has definitely processed every prior
+/// fire-and-forget frame on this connection: frames on a single stream are
+/// read sequentially, so once the server answers a `get_env` everything
+/// before it must already have been dispatched to the handler.
+fn flush(client: &Client) {
+    let _ = client.get_env(OsStr::new("__VP_TEST_FLUSH__")).unwrap();
 }
 
 #[test]
 fn single_client_fire_and_forget() {
-    let (tx, rx) = mpsc::channel();
-    let handler =
-        run_with_server(NotifyingRecorder { inner: Recorder::new(), handled: tx }, move |envs| {
-            let client = connect(&envs);
-            client.disable_cache().unwrap();
-            // Hold the stop-accepting signal until the server has processed
-            // the frame.
-            rx.recv().unwrap();
-        })
-        .expect("driver returned error");
+    let reports = run_with_server(env_map(&[]), |envs| {
+        let client = connect(&envs);
+        client.disable_cache().unwrap();
+        flush(&client);
+    })
+    .expect("driver returned error");
 
-    assert!(handler.inner.into_reports().cache_disabled);
+    assert!(reports.cache_disabled);
+}
+
+#[test]
+fn get_env_found_and_not_found() {
+    let reports = run_with_server(env_map(&[("NODE_ENV", "production")]), |envs| {
+        let client = connect(&envs);
+        let present = client.get_env(OsStr::new("NODE_ENV")).unwrap();
+        assert_eq!(present.as_deref(), Some(OsStr::new("production")));
+        let missing = client.get_env(OsStr::new("MISSING")).unwrap();
+        assert!(missing.is_none());
+    })
+    .expect("driver returned error");
+
+    assert!(!reports.cache_disabled);
 }
 
 #[test]
 fn concurrent_clients() {
-    let (tx, rx) = mpsc::channel();
-    let handler =
-        run_with_server(NotifyingRecorder { inner: Recorder::new(), handled: tx }, move |envs| {
-            let threads: Vec<_> = (0..4)
-                .map(|_| {
-                    let envs = envs.clone();
-                    thread::spawn(move || {
-                        let client = connect(&envs);
-                        client.disable_cache().unwrap();
-                    })
+    let reports = run_with_server(env_map(&[("SHARED", "value")]), move |envs| {
+        let threads: Vec<_> = (0..4)
+            .map(|_| {
+                let envs = envs.clone();
+                thread::spawn(move || {
+                    let client = connect(&envs);
+                    let value = client.get_env(OsStr::new("SHARED")).unwrap();
+                    assert_eq!(value.as_deref(), Some(OsStr::new("value")));
                 })
-                .collect();
-            for t in threads {
-                t.join().unwrap();
-            }
-            for _ in 0..4 {
-                rx.recv().unwrap();
-            }
-        })
-        .expect("driver returned error");
+            })
+            .collect();
+        for t in threads {
+            t.join().unwrap();
+        }
+    })
+    .expect("driver returned error");
 
-    assert!(handler.inner.into_reports().cache_disabled);
+    assert!(!reports.cache_disabled);
 }


### PR DESCRIPTION
## Motivation

The JS client exposes `getEnv`, but before this slice it still fell back to no-op behavior. Runner-aware tools need a real request/response path for single env reads before those reads can be used for cache tracking.

## Scope

Add the `GetEnv` protocol frame, Rust client response handling, server-side resolution from the spawned task env map, and a real NAPI `getEnv` implementation. This PR intentionally does not add tracked env reads to cache fingerprints.

## Verification

- `cargo test -p vite_task_server --test integration`
- `UPDATE_SNAPSHOTS=1 cargo test -p vite_task_bin --test e2e_snapshots fetch_env_reads_declared_env -- --ignored`
- `cargo test -p vite_task_bin --test e2e_snapshots fetch_env_reads_declared_env -- --ignored`
