### PR TITLE
feat(cache): fingerprint tracked getEnv reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- **Added** Runner-aware `getEnv` reads can now participate in task cache fingerprints, so changing a tool-served env value invalidates the cache and names the env var in the miss message.
 - **Added** Runner-aware tools can now opt the current task run out of caching through the new IPC channel; Vite dev server integration uses this automatically ([#441](https://github.com/voidzero-dev/vite-task/pull/441))
 - **Fixed** Prefix environment assignments like `PATH=... command` now affect executable lookup during task planning, so tools provided only by the prefixed `PATH` can be resolved correctly ([#440](https://github.com/voidzero-dev/vite-task/pull/440))
 - **Changed** Cache misses caused by a tracked env var now name the env var inline, for example `cache miss: env 'NODE_ENV' changed`, instead of the generic `envs changed` message ([#438](https://github.com/voidzero-dev/vite-task/pull/438))

--- a/crates/vite_task/src/session/cache/display.rs
+++ b/crates/vite_task/src/session/cache/display.rs
@@ -195,6 +195,9 @@ pub fn format_cache_status_inline(cache_status: &CacheStatus) -> Option<Str> {
                 FingerprintMismatch::InputChanged { kind, path } => {
                     format_input_change_str(*kind, path.as_str())
                 }
+                FingerprintMismatch::TrackedEnvChanged(mismatch) => {
+                    format_env_changed_inline(&[mismatch.name()])
+                }
             };
             Some(vite_str::format!("○ cache miss: {reason}, executing"))
         }

--- a/crates/vite_task/src/session/cache/mod.rs
+++ b/crates/vite_task/src/session/cache/mod.rs
@@ -3,7 +3,9 @@
 pub mod archive;
 pub mod display;
 
-use std::{collections::BTreeMap, fmt::Display, fs::File, io::Write, sync::Arc, time::Duration};
+use std::{
+    collections::BTreeMap, ffi::OsStr, fmt::Display, fs::File, io::Write, sync::Arc, time::Duration,
+};
 
 // Re-export display functions for convenience
 pub use display::format_cache_status_inline;
@@ -12,6 +14,7 @@ pub use display::{
     format_spawn_change,
 };
 use rusqlite::{Connection, OptionalExtension as _};
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use vite_path::{AbsolutePath, RelativePathBuf};
@@ -165,6 +168,23 @@ impl EnvMismatch {
             }
         }
     }
+
+    /// Compare a stored env value against the current one, returning the
+    /// mismatch if they differ. `None` on either side means the env is unset
+    /// there; two unset or two equal values are not a mismatch.
+    #[must_use]
+    pub fn compare(name: &Str, stored: Option<&Str>, current: Option<&Str>) -> Option<Self> {
+        match (stored, current) {
+            (None, Some(value)) => Some(Self::Added { name: name.clone(), value: value.clone() }),
+            (Some(value), None) => Some(Self::Removed { name: name.clone(), value: value.clone() }),
+            (Some(old_value), Some(new_value)) if old_value != new_value => Some(Self::Changed {
+                name: name.clone(),
+                old_value: old_value.clone(),
+                new_value: new_value.clone(),
+            }),
+            _ => None,
+        }
+    }
 }
 
 impl Display for EnvMismatch {
@@ -198,23 +218,16 @@ pub enum FingerprintMismatch {
         kind: InputChangeKind,
         path: RelativePathBuf,
     },
+    /// A runner-aware tool-tracked env var changed between runs.
+    TrackedEnvChanged(EnvMismatch),
 }
 
-impl Display for FingerprintMismatch {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::SpawnFingerprint { old, new } => {
-                write!(f, "Spawn fingerprint changed: old={old:?}, new={new:?}")
-            }
-            Self::InputConfig => {
-                write!(f, "input configuration changed")
-            }
-            Self::OutputConfig => {
-                write!(f, "output configuration changed")
-            }
-            Self::InputChanged { kind, path } => {
-                write!(f, "{}", display::format_input_change_str(*kind, path.as_str()))
-            }
+impl From<crate::session::execute::fingerprint::PostRunMismatch> for FingerprintMismatch {
+    fn from(mismatch: crate::session::execute::fingerprint::PostRunMismatch) -> Self {
+        use crate::session::execute::fingerprint::PostRunMismatch;
+        match mismatch {
+            PostRunMismatch::InputChanged { kind, path } => Self::InputChanged { kind, path },
+            PostRunMismatch::TrackedEnvChanged(mismatch) => Self::TrackedEnvChanged(mismatch),
         }
     }
 }
@@ -240,7 +253,7 @@ pub fn split_path(path: &str) -> (Option<&str>, &str) {
 /// its own cache warm across branch switches, and a cache from a different
 /// version is simply ignored (it lives in a directory this build never looks
 /// at) rather than aborting the run. Bumping the version starts a fresh cache.
-const CACHE_SCHEMA_VERSION: u32 = 13;
+const CACHE_SCHEMA_VERSION: u32 = 14;
 
 /// Name of the per-version subdirectory (e.g. `v13`) under the task-cache
 /// directory that holds the database and output archives for the current
@@ -292,6 +305,7 @@ impl ExecutionCache {
         cache_metadata: &CacheMetadata,
         globbed_inputs: &BTreeMap<RelativePathBuf, u64>,
         workspace_root: &AbsolutePath,
+        envs: &FxHashMap<Arc<OsStr>, Arc<OsStr>>,
     ) -> anyhow::Result<Result<CacheEntryValue, CacheMiss>> {
         let spawn_fingerprint = &cache_metadata.spawn_fingerprint;
         let execution_cache_key = &cache_metadata.execution_cache_key;
@@ -307,11 +321,11 @@ impl ExecutionCache {
                 return Ok(Err(CacheMiss::FingerprintMismatch(mismatch)));
             }
 
-            // Validate post-run fingerprint (inferred inputs from fspy)
-            if let Some((kind, path)) = cache_value.post_run_fingerprint.validate(workspace_root)? {
-                return Ok(Err(CacheMiss::FingerprintMismatch(
-                    FingerprintMismatch::InputChanged { kind, path },
-                )));
+            // Validate post-run fingerprint (inferred inputs + tracked envs)
+            if let Some(mismatch) =
+                cache_value.post_run_fingerprint.validate(workspace_root, envs)?
+            {
+                return Ok(Err(CacheMiss::FingerprintMismatch(mismatch.into())));
             }
             // Associate the execution key to the cache entry key if not already,
             // so that next time we can find it and report what changed

--- a/crates/vite_task/src/session/execute/cache_update.rs
+++ b/crates/vite_task/src/session/execute/cache_update.rs
@@ -1,7 +1,7 @@
 //! Post-run cache update: decide whether a finished spawn may be cached and,
 //! if so, store its fingerprint, captured output, and output archive.
 
-use std::{sync::Arc, time::Duration};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use vite_path::{AbsolutePath, RelativePathBuf};
 use vite_str::Str;
@@ -97,13 +97,19 @@ pub(super) async fn update_cache(
         return (CacheUpdateStatus::NotUpdated(CacheNotUpdatedReason::FspyUnsupported), None);
     }
 
+    // Collect tool-reported tracked envs for the post-run fingerprint. Env
+    // names that the user already declared are skipped because their values
+    // are already part of the spawn fingerprint.
+    let tracked_envs = reports.map(|r| collect_tracked_envs(r, metadata)).unwrap_or_default();
+
     // Paths already in globbed_inputs are skipped: the overlap check above
     // guarantees no input modification, so the prerun hash is the correct
     // post-exec hash.
     let empty_path_reads = HashMap::default();
     let path_reads = fspy_outcome.as_ref().map_or(&empty_path_reads, |o| &o.path_reads);
     let post_run_fingerprint =
-        match PostRunFingerprint::create(path_reads, workspace_root, &globbed_inputs) {
+        match PostRunFingerprint::create(path_reads, workspace_root, &globbed_inputs, tracked_envs)
+        {
             Ok(fingerprint) => fingerprint,
             Err(err) => {
                 return (
@@ -164,6 +170,26 @@ fn observe_fspy(
         let _ = (outcome, input_negative_globs, workspace_root);
         None
     }
+}
+
+/// Select tool-reported env records to embed in the post-run fingerprint.
+/// Only `tracked: true` records are included, and names that the user already
+/// declared as fingerprinted are skipped.
+fn collect_tracked_envs(reports: &Reports, metadata: &CacheMetadata) -> BTreeMap<Str, Option<Str>> {
+    let fingerprinted = &metadata.spawn_fingerprint.env_fingerprints().fingerprinted_envs;
+    reports
+        .env_records
+        .iter()
+        .filter(|(_, record)| record.tracked)
+        .filter_map(|(name, record)| {
+            let name_str = name.to_str()?;
+            if fingerprinted.contains_key(name_str) {
+                return None;
+            }
+            let value = record.value.as_ref().and_then(|value| value.to_str().map(Str::from));
+            Some((Str::from(name_str), value))
+        })
+        .collect()
 }
 
 /// Collect output files matching the configured globs and create a tar.zst

--- a/crates/vite_task/src/session/execute/fingerprint.rs
+++ b/crates/vite_task/src/session/execute/fingerprint.rs
@@ -5,18 +5,23 @@
 
 use std::{
     collections::BTreeMap,
+    ffi::OsStr,
     fs::File,
     io::{self, BufRead},
     sync::Arc,
 };
 
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use vite_path::{AbsolutePath, RelativePathBuf};
 use vite_str::Str;
 use wincode::{SchemaRead, SchemaWrite};
 
-use crate::{collections::HashMap, session::cache::InputChangeKind};
+use crate::{
+    collections::HashMap,
+    session::cache::{EnvMismatch, InputChangeKind},
+};
 
 /// Path read access info
 #[derive(Debug, Clone, Copy)]
@@ -31,6 +36,21 @@ pub struct PostRunFingerprint {
     /// Paths inferred from fspy during execution with their content fingerprints.
     /// Only populated when `input_config.includes_auto` is true.
     pub inferred_inputs: HashMap<RelativePathBuf, PathFingerprint>,
+
+    /// Env vars observed via runner-aware IPC `getEnv` with `tracked: true`.
+    /// Key is the env name; value is the env value at execution time, or
+    /// `None` if unset. Validated at cache lookup against the same plan env
+    /// context that served the original request.
+    pub tracked_envs: BTreeMap<Str, Option<Str>>,
+}
+
+/// A mismatch between the stored post-run fingerprint and the current state.
+#[derive(Debug, Clone)]
+pub enum PostRunMismatch {
+    /// An inferred input file or directory changed.
+    InputChanged { kind: InputChangeKind, path: RelativePathBuf },
+    /// A tool-tracked env var changed value, appeared, or disappeared.
+    TrackedEnvChanged(EnvMismatch),
 }
 
 /// Fingerprint for a single path (file or directory)
@@ -69,11 +89,13 @@ impl PostRunFingerprint {
     /// * `inferred_path_reads` - Map of paths that were read during execution (from fspy)
     /// * `base_dir` - Workspace root for resolving relative paths
     /// * `globbed_inputs` - Prerun glob fingerprint; paths here are skipped
+    /// * `tracked_envs` - Tool-requested env vars (name -> value), validated on lookup
     #[tracing::instrument(level = "debug", skip_all, name = "create_post_run_fingerprint")]
     pub fn create(
         inferred_path_reads: &HashMap<RelativePathBuf, PathRead>,
         base_dir: &AbsolutePath,
         globbed_inputs: &BTreeMap<RelativePathBuf, u64>,
+        tracked_envs: BTreeMap<Str, Option<Str>>,
     ) -> anyhow::Result<Self> {
         let inferred_inputs = inferred_path_reads
             .par_iter()
@@ -85,16 +107,17 @@ impl PostRunFingerprint {
             })
             .collect::<anyhow::Result<HashMap<_, _>>>()?;
 
-        Ok(Self { inferred_inputs })
+        Ok(Self { inferred_inputs, tracked_envs })
     }
 
-    /// Validates the fingerprint against current filesystem state.
-    /// Returns `Some((kind, path))` if an input changed, `None` if all valid.
+    /// Validates the fingerprint against current filesystem state and env
+    /// context. Returns `Some(mismatch)` if anything changed, `None` if all valid.
     #[tracing::instrument(level = "debug", skip_all, name = "validate_post_run_fingerprint")]
     pub fn validate(
         &self,
         base_dir: &AbsolutePath,
-    ) -> anyhow::Result<Option<(InputChangeKind, RelativePathBuf)>> {
+        envs: &FxHashMap<Arc<OsStr>, Arc<OsStr>>,
+    ) -> anyhow::Result<Option<PostRunMismatch>> {
         let input_mismatch = self.inferred_inputs.par_iter().find_map_any(
             |(input_relative_path, path_fingerprint)| {
                 let input_full_path = Arc::<AbsolutePath>::from(base_dir.join(input_relative_path));
@@ -120,11 +143,25 @@ impl PostRunFingerprint {
                     } else {
                         input_relative_path.clone()
                     };
-                    Some(Ok((kind, path)))
+                    Some(Ok(PostRunMismatch::InputChanged { kind, path }))
                 }
             },
         );
-        input_mismatch.transpose()
+        if let Some(result) = input_mismatch {
+            return result.map(Some);
+        }
+
+        for (name, stored_value) in &self.tracked_envs {
+            let current_value =
+                envs.get(OsStr::new(name.as_str())).and_then(|value| value.to_str().map(Str::from));
+            if let Some(mismatch) =
+                EnvMismatch::compare(name, stored_value.as_ref(), current_value.as_ref())
+            {
+                return Ok(Some(PostRunMismatch::TrackedEnvChanged(mismatch)));
+            }
+        }
+
+        Ok(None)
     }
 }
 

--- a/crates/vite_task/src/session/execute/mod.rs
+++ b/crates/vite_task/src/session/execute/mod.rs
@@ -531,7 +531,10 @@ async fn lookup_cache(
         Report::failed(ExecutionError::Cache { kind: CacheErrorKind::Lookup, source: err })
     })?;
 
-    match cache.try_hit(cache_metadata, &globbed_inputs, workspace_root).await {
+    match cache
+        .try_hit(cache_metadata, &globbed_inputs, workspace_root, &cache_metadata.unfiltered_envs)
+        .await
+    {
         Ok(Ok(cached)) => Ok(CacheLookup::Hit(cached)),
         Ok(Err(miss)) => Ok(CacheLookup::Miss { miss, globbed_inputs }),
         Err(err) => {

--- a/crates/vite_task/src/session/reporter/summary.rs
+++ b/crates/vite_task/src/session/reporter/summary.rs
@@ -17,7 +17,7 @@ use vite_str::Str;
 use super::{CACHE_MISS_STYLE, COMMAND_STYLE, ColorizeExt};
 use crate::session::{
     cache::{
-        CacheMiss, FingerprintMismatch, InputChangeKind, SpawnFingerprintChange,
+        CacheMiss, EnvMismatch, FingerprintMismatch, InputChangeKind, SpawnFingerprintChange,
         detect_spawn_fingerprint_changes, format_input_change_str, format_spawn_change,
     },
     event::{
@@ -135,6 +135,8 @@ pub enum SavedCacheMissReason {
     ConfigChanged,
     /// An input file or folder changed.
     InputChanged { kind: InputChangeKind, path: Str },
+    /// A runner-aware tool reported a tracked env var that changed between runs.
+    TrackedEnvChanged(EnvMismatch),
 }
 
 /// An execution error, serializable for persistence.
@@ -277,6 +279,9 @@ impl SavedCacheMissReason {
                 }
                 FingerprintMismatch::InputChanged { kind, path } => {
                     Self::InputChanged { kind: *kind, path: Str::from(path.as_str()) }
+                }
+                FingerprintMismatch::TrackedEnvChanged(mismatch) => {
+                    Self::TrackedEnvChanged(mismatch.clone())
                 }
             },
         }
@@ -566,6 +571,9 @@ impl TaskResult {
                     SavedCacheMissReason::InputChanged { kind, path } => {
                         let desc = format_input_change_str(*kind, path.as_str());
                         vite_str::format!("→ Cache miss: {desc}")
+                    }
+                    SavedCacheMissReason::TrackedEnvChanged(mismatch) => {
+                        vite_str::format!("→ Cache miss: {mismatch}")
                     }
                 },
             },

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots.toml
@@ -93,3 +93,81 @@ steps = [
     "outer-prefixed",
   ], comment = "outer prefix env reaches the inner tool via the runner" },
 ]
+
+[[e2e]]
+name = "fetch_env_tracked_invalidates_on_change"
+comment = """
+Exercises `getEnv(name, { tracked: true })`. The env value becomes part of the post-run fingerprint: the same value still hits, and a different value misses with the env var named in the miss message.
+"""
+ignore = true
+steps = [
+  { argv = [
+    "vt",
+    "run",
+    "fetch-env",
+  ], envs = [
+    [
+      "PROBE_ENV",
+      "first",
+    ],
+  ], comment = "first run captures PROBE_ENV=first in the post-run fingerprint" },
+  { argv = [
+    "vt",
+    "run",
+    "fetch-env",
+  ], envs = [
+    [
+      "PROBE_ENV",
+      "first",
+    ],
+  ], comment = "cache hit: PROBE_ENV unchanged" },
+  { argv = [
+    "vt",
+    "run",
+    "fetch-env",
+  ], envs = [
+    [
+      "PROBE_ENV",
+      "second",
+    ],
+  ], comment = "cache miss: tracked PROBE_ENV changed" },
+]
+
+[[e2e]]
+name = "fetch_env_tracks_with_explicit_inputs"
+comment = """
+Runner-aware env tracking must not depend on fspy auto-input inference. This task uses `input: []`, but `getEnv(name, { tracked: true })` still records the served value and later env changes miss.
+"""
+ignore = true
+steps = [
+  { argv = [
+    "vt",
+    "run",
+    "fetch-env-explicit-input",
+  ], envs = [
+    [
+      "PROBE_ENV",
+      "first",
+    ],
+  ], comment = "first run captures PROBE_ENV even though input auto-inference is disabled" },
+  { argv = [
+    "vt",
+    "run",
+    "fetch-env-explicit-input",
+  ], envs = [
+    [
+      "PROBE_ENV",
+      "first",
+    ],
+  ], comment = "cache hit: explicit inputs are unchanged and PROBE_ENV is unchanged" },
+  { argv = [
+    "vt",
+    "run",
+    "fetch-env-explicit-input",
+  ], envs = [
+    [
+      "PROBE_ENV",
+      "second",
+    ],
+  ], comment = "cache miss: tracked env changed despite input auto-inference being disabled" },
+]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/fetch_env_tracked_invalidates_on_change.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/fetch_env_tracked_invalidates_on_change.md
@@ -1,0 +1,36 @@
+# fetch_env_tracked_invalidates_on_change
+
+Exercises `getEnv(name, { tracked: true })`. The env value becomes part of the post-run fingerprint: the same value still hits, and a different value misses with the env var named in the miss message.
+
+## `PROBE_ENV=first vt run fetch-env`
+
+first run captures PROBE_ENV=first in the post-run fingerprint
+
+```
+$ node scripts/fetch_env.mjs PROBE_ENV
+served PROBE_ENV=first
+process.env PROBE_ENV=(unset)
+```
+
+## `PROBE_ENV=first vt run fetch-env`
+
+cache hit: PROBE_ENV unchanged
+
+```
+$ node scripts/fetch_env.mjs PROBE_ENV ◉ cache hit, replaying
+served PROBE_ENV=first
+process.env PROBE_ENV=(unset)
+
+---
+vt run: cache hit.
+```
+
+## `PROBE_ENV=second vt run fetch-env`
+
+cache miss: tracked PROBE_ENV changed
+
+```
+$ node scripts/fetch_env.mjs PROBE_ENV ○ cache miss: env 'PROBE_ENV' changed, executing
+served PROBE_ENV=second
+process.env PROBE_ENV=(unset)
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/fetch_env_tracks_with_explicit_inputs.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/fetch_env_tracks_with_explicit_inputs.md
@@ -1,0 +1,36 @@
+# fetch_env_tracks_with_explicit_inputs
+
+Runner-aware env tracking must not depend on fspy auto-input inference. This task uses `input: []`, but `getEnv(name, { tracked: true })` still records the served value and later env changes miss.
+
+## `PROBE_ENV=first vt run fetch-env-explicit-input`
+
+first run captures PROBE_ENV even though input auto-inference is disabled
+
+```
+$ node scripts/fetch_env.mjs PROBE_ENV
+served PROBE_ENV=first
+process.env PROBE_ENV=(unset)
+```
+
+## `PROBE_ENV=first vt run fetch-env-explicit-input`
+
+cache hit: explicit inputs are unchanged and PROBE_ENV is unchanged
+
+```
+$ node scripts/fetch_env.mjs PROBE_ENV ◉ cache hit, replaying
+served PROBE_ENV=first
+process.env PROBE_ENV=(unset)
+
+---
+vt run: cache hit.
+```
+
+## `PROBE_ENV=second vt run fetch-env-explicit-input`
+
+cache miss: tracked env changed despite input auto-inference being disabled
+
+```
+$ node scripts/fetch_env.mjs PROBE_ENV ○ cache miss: env 'PROBE_ENV' changed, executing
+served PROBE_ENV=second
+process.env PROBE_ENV=(unset)
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/vite-task.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/vite-task.json
@@ -13,6 +13,11 @@
       "command": "node scripts/fetch_env.mjs PROBE_ENV",
       "cache": true
     },
+    "fetch-env-explicit-input": {
+      "command": "node scripts/fetch_env.mjs PROBE_ENV",
+      "input": [],
+      "cache": true
+    },
     "fetch-prefixed-env": {
       "command": "PREFIXED_ENV=from-command node scripts/fetch_env.mjs PREFIXED_ENV",
       "cache": true

--- a/crates/vite_task_client/src/lib.rs
+++ b/crates/vite_task_client/src/lib.rs
@@ -63,12 +63,10 @@ impl Client {
     /// # Errors
     ///
     /// Returns an error if the request or response fails.
-    // TODO(env-track): A later PR in this stack adds a tracked flag so env
-    // reads can participate in cache fingerprints instead of being IPC-only.
-    pub fn get_env(&self, name: &OsStr) -> io::Result<Option<Arc<OsStr>>> {
+    pub fn get_env(&self, name: &OsStr, tracked: bool) -> io::Result<Option<Arc<OsStr>>> {
         let name = Box::<NativeStr>::from(name);
 
-        self.send(&Request::GetEnv { name: &name })?;
+        self.send(&Request::GetEnv { name: &name, tracked })?;
         let response: GetEnvResponse = self.recv()?;
         Ok(response
             .env_value

--- a/crates/vite_task_client_napi/src/lib.rs
+++ b/crates/vite_task_client_napi/src/lib.rs
@@ -93,10 +93,11 @@ impl RunnerClient {
     }
 
     #[napi]
-    pub fn get_env(&self, name: String, _options: Option<GetEnvOptions>) -> Result<Option<String>> {
+    pub fn get_env(&self, name: String, options: Option<GetEnvOptions>) -> Result<Option<String>> {
+        let tracked = options.and_then(|o| o.tracked).unwrap_or(true);
         let value = self
             .client
-            .get_env(OsStr::new(&name))
+            .get_env(OsStr::new(&name), tracked)
             .map_err(|err| err_string(vite_str::format!("{err}")))?;
         value.map_or(Ok(None), |value| {
             value.to_str().map(|s| Some(s.to_owned())).ok_or_else(|| {

--- a/crates/vite_task_ipc_shared/src/lib.rs
+++ b/crates/vite_task_ipc_shared/src/lib.rs
@@ -26,9 +26,7 @@ pub const NODE_CLIENT_PATH_ENV_NAME: &str = "VP_RUN_NODE_CLIENT_PATH";
 /// will still consume every buffered frame.
 #[derive(Debug, SchemaWrite, SchemaRead)]
 pub enum Request<'a> {
-    // TODO(env-track): A later PR in this stack adds a tracked flag once the
-    // runner records served env reads into the post-run cache fingerprint.
-    GetEnv { name: &'a NativeStr },
+    GetEnv { name: &'a NativeStr, tracked: bool },
     DisableCache,
 }
 

--- a/crates/vite_task_server/src/lib.rs
+++ b/crates/vite_task_server/src/lib.rs
@@ -14,7 +14,7 @@ use wincode::{SchemaWrite, config::DefaultConfig};
 
 pub trait Handler {
     fn disable_cache(&mut self);
-    fn get_env(&mut self, name: &OsStr) -> Option<Arc<OsStr>>;
+    fn get_env(&mut self, name: &OsStr, tracked: bool) -> Option<Arc<OsStr>>;
 }
 
 /// A protocol-level failure observed while servicing a client.
@@ -40,26 +40,38 @@ pub enum Error {
 /// recover the collected [`Reports`].
 pub struct Recorder {
     cache_disabled: bool,
+    env_records: FxHashMap<Arc<OsStr>, EnvRecord>,
     /// The envs `get_env` resolves against. The runner supplies these for the
     /// spawned task; the server never re-reads the live process env.
     envs: Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>,
+}
+
+/// A record of an env value requested via `get_env`.
+///
+/// `tracked` is the monotonic OR of every `tracked` flag sent for this name:
+/// once true, it stays true.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnvRecord {
+    pub tracked: bool,
+    pub value: Option<Arc<OsStr>>,
 }
 
 /// The data collected by a [`Recorder`] over the server's lifetime.
 #[derive(Debug, Default)]
 pub struct Reports {
     pub cache_disabled: bool,
+    pub env_records: FxHashMap<Arc<OsStr>, EnvRecord>,
 }
 
 impl Recorder {
     #[must_use]
-    pub const fn new(envs: Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>) -> Self {
-        Self { cache_disabled: false, envs }
+    pub fn new(envs: Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>) -> Self {
+        Self { cache_disabled: false, env_records: FxHashMap::default(), envs }
     }
 
     #[must_use]
     pub fn into_reports(self) -> Reports {
-        Reports { cache_disabled: self.cache_disabled }
+        Reports { cache_disabled: self.cache_disabled, env_records: self.env_records }
     }
 }
 
@@ -68,8 +80,14 @@ impl Handler for Recorder {
         self.cache_disabled = true;
     }
 
-    fn get_env(&mut self, name: &OsStr) -> Option<Arc<OsStr>> {
-        self.envs.get(name).cloned()
+    fn get_env(&mut self, name: &OsStr, tracked: bool) -> Option<Arc<OsStr>> {
+        if let Some(existing) = self.env_records.get_mut(name) {
+            existing.tracked |= tracked;
+            return existing.value.clone();
+        }
+        let value = self.envs.get(name).cloned();
+        self.env_records.insert(name.into(), EnvRecord { tracked, value: value.clone() });
+        value
     }
 }
 
@@ -294,8 +312,8 @@ async fn handle_client<H: Handler>(mut stream: Stream, handler: &RefCell<H>) -> 
             Request::DisableCache => {
                 handler.borrow_mut().disable_cache();
             }
-            Request::GetEnv { name } => {
-                let value = handler.borrow_mut().get_env(name.to_cow_os_str().as_ref());
+            Request::GetEnv { name, tracked } => {
+                let value = handler.borrow_mut().get_env(name.to_cow_os_str().as_ref(), tracked);
                 let response = GetEnvResponse { env_value: value.as_deref().map(Into::into) };
                 write_response(&mut stream, &response).await.map_err(Error::WriteResponse)?;
             }

--- a/crates/vite_task_server/tests/integration.rs
+++ b/crates/vite_task_server/tests/integration.rs
@@ -53,7 +53,7 @@ fn connect(envs: &[(&'static OsStr, OsString)]) -> Client {
 /// read sequentially, so once the server answers a `get_env` everything
 /// before it must already have been dispatched to the handler.
 fn flush(client: &Client) {
-    let _ = client.get_env(OsStr::new("__VP_TEST_FLUSH__")).unwrap();
+    let _ = client.get_env(OsStr::new("__VP_TEST_FLUSH__"), false).unwrap();
 }
 
 #[test]
@@ -72,14 +72,38 @@ fn single_client_fire_and_forget() {
 fn get_env_found_and_not_found() {
     let reports = run_with_server(env_map(&[("NODE_ENV", "production")]), |envs| {
         let client = connect(&envs);
-        let present = client.get_env(OsStr::new("NODE_ENV")).unwrap();
+        let present = client.get_env(OsStr::new("NODE_ENV"), true).unwrap();
         assert_eq!(present.as_deref(), Some(OsStr::new("production")));
-        let missing = client.get_env(OsStr::new("MISSING")).unwrap();
+        let missing = client.get_env(OsStr::new("MISSING"), false).unwrap();
         assert!(missing.is_none());
     })
     .expect("driver returned error");
 
     assert!(!reports.cache_disabled);
+    let node = reports.env_records.get(OsStr::new("NODE_ENV")).expect("NODE_ENV recorded");
+    assert!(node.tracked);
+    assert_eq!(node.value.as_deref(), Some(OsStr::new("production")));
+
+    let missing = reports.env_records.get(OsStr::new("MISSING")).expect("MISSING recorded");
+    assert!(!missing.tracked);
+    assert!(missing.value.is_none());
+}
+
+#[test]
+fn get_env_tracked_upgrade_is_monotonic() {
+    let reports = run_with_server(env_map(&[("NODE_ENV", "production")]), |envs| {
+        let client = connect(&envs);
+        let a = client.get_env(OsStr::new("NODE_ENV"), false).unwrap();
+        let b = client.get_env(OsStr::new("NODE_ENV"), true).unwrap();
+        let c = client.get_env(OsStr::new("NODE_ENV"), false).unwrap();
+        for v in [a, b, c] {
+            assert_eq!(v.as_deref(), Some(OsStr::new("production")));
+        }
+    })
+    .expect("driver returned error");
+
+    let node = reports.env_records.get(OsStr::new("NODE_ENV")).expect("recorded");
+    assert!(node.tracked, "tracked must remain true once set");
 }
 
 #[test]
@@ -90,7 +114,7 @@ fn concurrent_clients() {
                 let envs = envs.clone();
                 thread::spawn(move || {
                     let client = connect(&envs);
-                    let value = client.get_env(OsStr::new("SHARED")).unwrap();
+                    let value = client.get_env(OsStr::new("SHARED"), true).unwrap();
                     assert_eq!(value.as_deref(), Some(OsStr::new("value")));
                 })
             })
@@ -102,4 +126,7 @@ fn concurrent_clients() {
     .expect("driver returned error");
 
     assert!(!reports.cache_disabled);
+    let shared = reports.env_records.get(OsStr::new("SHARED")).expect("recorded");
+    assert!(shared.tracked);
+    assert_eq!(shared.value.as_deref(), Some(OsStr::new("value")));
 }


### PR DESCRIPTION
## Motivation

Once tools can read env values from the runner, cached tasks must remember tracked `getEnv` reads. Otherwise a later run can replay stale output after a tracked env value changes.

## Scope

Make the `getEnv` tracked option meaningful, record served single-env values in IPC reports, store tracked values in the post-run fingerprint, validate them during cache lookup, and render env-specific cache miss messages. This PR intentionally does not implement `getEnvs` or env glob match-set tracking.

## Verification

- `cargo test -p vite_task_server --test integration`
- `UPDATE_SNAPSHOTS=1 cargo test -p vite_task_bin --test e2e_snapshots fetch_env_tracked_invalidates_on_change -- --ignored`
- `UPDATE_SNAPSHOTS=1 cargo test -p vite_task_bin --test e2e_snapshots fetch_env_tracks_with_explicit_inputs -- --ignored`
- `cargo test -p vite_task_bin --test e2e_snapshots fetch_env_tracked_invalidates_on_change -- --ignored`
- `cargo test -p vite_task_bin --test e2e_snapshots fetch_env_tracks_with_explicit_inputs -- --ignored`
