### PR TITLE
feat(client): serve getEnvs over runner IPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - **Changed** Tracked environment values in task cache fingerprints are now stored only as SHA-256 digests, and env-related cache miss details report names without values.
+- **Added** Runner-aware `getEnvs` calls now return env values served by the runner for matching env glob patterns ([#449](https://github.com/voidzero-dev/vite-task/pull/449)).
 - **Fixed** Runner-aware `getEnv` reads now affect task cache fingerprints, so changing a tool-served env value invalidates cached output and names the env var in the miss message ([#454](https://github.com/voidzero-dev/vite-task/pull/454)).
 - **Added** Runner-aware tools can now opt the current task run out of caching through the new IPC channel; Vite dev server integration uses this automatically ([#441](https://github.com/voidzero-dev/vite-task/pull/441))
 - **Fixed** Prefix environment assignments like `PATH=... command` now affect executable lookup during task planning, so tools provided only by the prefixed `PATH` can be resolved correctly ([#440](https://github.com/voidzero-dev/vite-task/pull/440))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4321,6 +4321,7 @@ name = "vite_task_client"
 version = "0.0.0"
 dependencies = [
  "native_str",
+ "rustc-hash",
  "vite_task_ipc_shared",
  "winapi",
  "wincode",
@@ -4365,6 +4366,7 @@ name = "vite_task_ipc_shared"
 version = "0.0.0"
 dependencies = [
  "native_str",
+ "rustc-hash",
  "wincode",
 ]
 
@@ -4418,6 +4420,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "uuid",
+ "vite_glob",
  "vite_task_client",
  "vite_task_ipc_shared",
  "wincode",

--- a/crates/native_str/src/lib.rs
+++ b/crates/native_str/src/lib.rs
@@ -37,7 +37,7 @@ use wincode::{
 /// **Not portable across platforms.** The binary representation is platform-specific.
 /// Deserializing a `NativeStr` serialized on a different platform leads to unspecified
 /// behavior (garbage data), but is not unsafe. Designed for same-platform IPC only.
-#[derive(TransparentWrapper, PartialEq, Eq)]
+#[derive(TransparentWrapper, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct NativeStr {
     // On unix, this is the raw bytes of the OsStr.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/scripts/fetch_envs.mjs
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/scripts/fetch_envs.mjs
@@ -1,0 +1,8 @@
+import { getEnvs } from '@voidzero-dev/vite-task-client';
+
+const matches = getEnvs('PROBE_*');
+const sorted = Object.entries(matches).sort(([a], [b]) => a.localeCompare(b));
+
+for (const [key, value] of sorted) {
+  console.log(`${key}=${value}`);
+}

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots.toml
@@ -171,3 +171,30 @@ steps = [
     ],
   ], comment = "cache miss: tracked env changed despite input auto-inference being disabled" },
 ]
+
+[[e2e]]
+name = "fetch_envs_reads_match_set"
+comment = """
+Exercises `getEnvs(pattern)`: the tool asks the runner for every env matching `PROBE_*` and prints the served match set. This verifies the bulk env IPC round trip before match sets are added to cache fingerprints.
+"""
+ignore = true
+steps = [
+  { argv = [
+    "vt",
+    "run",
+    "fetch-envs",
+  ], envs = [
+    [
+      "PROBE_A",
+      "a",
+    ],
+    [
+      "PROBE_B",
+      "b",
+    ],
+    [
+      "UNRELATED",
+      "noise",
+    ],
+  ], comment = "runner serves only envs matching PROBE_*" },
+]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/fetch_envs_reads_match_set.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/fetch_envs_reads_match_set.md
@@ -1,0 +1,13 @@
+# fetch_envs_reads_match_set
+
+Exercises `getEnvs(pattern)`: the tool asks the runner for every env matching `PROBE_*` and prints the served match set. This verifies the bulk env IPC round trip before match sets are added to cache fingerprints.
+
+## `PROBE_A=a PROBE_B=b UNRELATED=noise vt run fetch-envs`
+
+runner serves only envs matching PROBE_*
+
+```
+$ node scripts/fetch_envs.mjs
+PROBE_A=a
+PROBE_B=b
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/vite-task.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/vite-task.json
@@ -20,6 +20,10 @@
       "output": [],
       "cache": true
     },
+    "fetch-envs": {
+      "command": "node scripts/fetch_envs.mjs",
+      "cache": true
+    },
     "fetch-prefixed-env": {
       "command": "PREFIXED_ENV=from-command node scripts/fetch_env.mjs PREFIXED_ENV",
       "cache": true

--- a/crates/vite_task_client/Cargo.toml
+++ b/crates/vite_task_client/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 native_str = { workspace = true }
+rustc-hash = { workspace = true }
 vite_task_ipc_shared = { workspace = true }
 wincode = { workspace = true, features = ["derive"] }
 

--- a/crates/vite_task_client/src/lib.rs
+++ b/crates/vite_task_client/src/lib.rs
@@ -6,7 +6,8 @@ use std::{
 };
 
 use native_str::NativeStr;
-use vite_task_ipc_shared::{GetEnvResponse, IPC_ENV_NAME, Request};
+use rustc_hash::FxHashMap;
+use vite_task_ipc_shared::{GetEnvResponse, GetEnvsResponse, IPC_ENV_NAME, Request};
 use wincode::{SchemaRead, config::DefaultConfig};
 
 #[cfg(unix)]
@@ -71,6 +72,30 @@ impl Client {
         Ok(response
             .env_value
             .map(|env_value| Arc::<OsStr>::from(env_value.to_cow_os_str().as_ref())))
+    }
+
+    /// Requests every env whose name matches `pattern` from the runner. The
+    /// returned map is keyed by env name with its value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request or response fails, or if the server
+    /// rejects the pattern as an invalid glob.
+    // TODO(env-track): A later PR in this stack adds a tracked flag so matched
+    // env sets can participate in cache fingerprints instead of being IPC-only.
+    pub fn get_envs(&self, pattern: &str) -> io::Result<FxHashMap<Arc<OsStr>, Arc<OsStr>>> {
+        self.send(&Request::GetEnvs { pattern })?;
+        let response: GetEnvsResponse = self.recv()?;
+        Ok(response
+            .entries
+            .into_iter()
+            .map(|(name, value)| {
+                (
+                    Arc::<OsStr>::from(name.to_cow_os_str().as_ref()),
+                    Arc::<OsStr>::from(value.to_cow_os_str().as_ref()),
+                )
+            })
+            .collect())
     }
 
     fn send(&self, request: &Request<'_>) -> io::Result<()> {

--- a/crates/vite_task_client_napi/src/lib.rs
+++ b/crates/vite_task_client_napi/src/lib.rs
@@ -105,15 +105,27 @@ impl RunnerClient {
         })
     }
 
-    /// No-op for now: always returns an empty match-set — see
-    /// [`Self::get_env`].
     #[napi]
     pub fn get_envs(
         &self,
-        _pattern: String,
+        pattern: String,
         _options: Option<GetEnvOptions>,
     ) -> Result<HashMap<String, String>> {
-        Ok(HashMap::new())
+        let matches =
+            self.client.get_envs(&pattern).map_err(|err| err_string(vite_str::format!("{err}")))?;
+        let mut result = HashMap::with_capacity(matches.len());
+        for (name, value) in matches {
+            let name = name.to_str().ok_or_else(|| {
+                err_string(vite_str::format!(
+                    "env name matched by pattern {pattern} is not valid UTF-8"
+                ))
+            })?;
+            let value = value.to_str().ok_or_else(|| {
+                err_string(vite_str::format!("env value for {name} is not valid UTF-8"))
+            })?;
+            result.insert(name.to_owned(), value.to_owned());
+        }
+        Ok(result)
     }
 }
 

--- a/crates/vite_task_ipc_shared/Cargo.toml
+++ b/crates/vite_task_ipc_shared/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 native_str = { workspace = true }
+rustc-hash = { workspace = true }
 wincode = { workspace = true, features = ["derive"] }
 
 [lints]

--- a/crates/vite_task_ipc_shared/src/lib.rs
+++ b/crates/vite_task_ipc_shared/src/lib.rs
@@ -1,4 +1,5 @@
 use native_str::NativeStr;
+use rustc_hash::FxHashMap;
 use wincode::{SchemaRead, SchemaWrite};
 
 pub const IPC_ENV_NAME: &str = "VP_RUN_IPC_NAME";
@@ -16,8 +17,8 @@ pub const NODE_CLIENT_PATH_ENV_NAME: &str = "VP_RUN_NODE_CLIENT_PATH";
 /// IPC request frame sent by tools to the runner.
 ///
 /// `DisableCache` is fire-and-forget: the runner processes it when it
-/// arrives and never writes a response. `GetEnv` is a round-trip and pairs
-/// with [`GetEnvResponse`].
+/// arrives and never writes a response. `GetEnv` and `GetEnvs` are
+/// round-trips and pair with the matching response types below.
 ///
 /// Fire-and-forget is safe because nothing in the runner observes individual
 /// IPC events live — the recorded set is only consumed *after* the per-task
@@ -27,10 +28,18 @@ pub const NODE_CLIENT_PATH_ENV_NAME: &str = "VP_RUN_NODE_CLIENT_PATH";
 #[derive(Debug, SchemaWrite, SchemaRead)]
 pub enum Request<'a> {
     GetEnv { name: &'a NativeStr },
+    GetEnvs { pattern: &'a str },
     DisableCache,
 }
 
 #[derive(Debug, SchemaWrite, SchemaRead)]
 pub struct GetEnvResponse {
     pub env_value: Option<Box<NativeStr>>,
+}
+
+#[derive(Debug, SchemaWrite, SchemaRead)]
+pub struct GetEnvsResponse {
+    /// Match snapshot for the glob pattern. Keys/values are byte-faithful
+    /// (`NativeStr`) so non-UTF-8 env values are preserved over the wire.
+    pub entries: FxHashMap<Box<NativeStr>, Box<NativeStr>>,
 }

--- a/crates/vite_task_server/Cargo.toml
+++ b/crates/vite_task_server/Cargo.toml
@@ -14,6 +14,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "net", "rt", "macros"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+vite_glob = { workspace = true }
 vite_task_ipc_shared = { workspace = true }
 wincode = { workspace = true, features = ["derive"] }
 

--- a/crates/vite_task_server/src/lib.rs
+++ b/crates/vite_task_server/src/lib.rs
@@ -9,12 +9,21 @@ use futures::{FutureExt, StreamExt, future::LocalBoxFuture, stream::FuturesUnord
 use rustc_hash::FxHashMap;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_util::sync::CancellationToken;
-use vite_task_ipc_shared::{GetEnvResponse, IPC_ENV_NAME, Request};
+use vite_task_ipc_shared::{GetEnvResponse, GetEnvsResponse, IPC_ENV_NAME, Request};
 use wincode::{SchemaWrite, config::DefaultConfig};
 
 pub trait Handler {
     fn disable_cache(&mut self);
     fn get_env(&mut self, name: &OsStr) -> Option<Arc<OsStr>>;
+    /// Returns the subset of the env map whose names match `pattern` as a glob.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `pattern` fails to parse as a glob.
+    fn get_envs(
+        &mut self,
+        pattern: &str,
+    ) -> Result<FxHashMap<Arc<OsStr>, Arc<OsStr>>, vite_glob::env::EnvGlobError>;
 }
 
 /// A protocol-level failure observed while servicing a client.
@@ -31,6 +40,16 @@ pub enum Error {
 
     #[error("failed to send response to the task")]
     WriteResponse(#[source] io::Error),
+
+    #[error("invalid glob pattern from the task: {:?}", .0.pattern)]
+    InvalidGlob(Box<InvalidGlob>),
+}
+
+/// Payload for [`Error::InvalidGlob`]. Boxed so the `Error` enum stays small.
+#[derive(Debug)]
+pub struct InvalidGlob {
+    pub pattern: Box<str>,
+    pub source: vite_glob::env::EnvGlobError,
 }
 
 /// A [`Handler`] that records every report and resolves `get_env` against
@@ -79,6 +98,25 @@ impl Handler for Recorder {
                 value
             }
         }
+    }
+
+    fn get_envs(
+        &mut self,
+        pattern: &str,
+    ) -> Result<FxHashMap<Arc<OsStr>, Arc<OsStr>>, vite_glob::env::EnvGlobError> {
+        let glob = vite_glob::env::EnvGlob::new(pattern)?;
+        Ok(self
+            .envs
+            .iter()
+            .filter_map(|(name, value)| {
+                let name_str = name.to_str()?;
+                if glob.is_match(name_str) {
+                    Some((Arc::clone(name), Arc::clone(value)))
+                } else {
+                    None
+                }
+            })
+            .collect())
     }
 }
 
@@ -306,6 +344,18 @@ async fn handle_client<H: Handler>(mut stream: Stream, handler: &RefCell<H>) -> 
             Request::GetEnv { name } => {
                 let value = handler.borrow_mut().get_env(name.to_cow_os_str().as_ref());
                 let response = GetEnvResponse { env_value: value.as_deref().map(Into::into) };
+                write_response(&mut stream, &response).await.map_err(Error::WriteResponse)?;
+            }
+            Request::GetEnvs { pattern } => {
+                let matches = handler.borrow_mut().get_envs(pattern).map_err(|source| {
+                    Error::InvalidGlob(Box::new(InvalidGlob {
+                        pattern: Box::<str>::from(pattern),
+                        source,
+                    }))
+                })?;
+                let response = GetEnvsResponse {
+                    entries: matches.iter().map(|(k, v)| ((&**k).into(), (&**v).into())).collect(),
+                };
                 write_response(&mut stream, &response).await.map_err(Error::WriteResponse)?;
             }
         }

--- a/crates/vite_task_server/tests/integration.rs
+++ b/crates/vite_task_server/tests/integration.rs
@@ -1,5 +1,6 @@
 use std::{
     ffi::{OsStr, OsString},
+    io,
     sync::Arc,
     thread,
 };
@@ -109,4 +110,57 @@ fn concurrent_clients() {
     assert!(!reports.cache_disabled);
     let shared = reports.env_records.get(OsStr::new("SHARED")).expect("recorded");
     assert_eq!(shared.as_deref(), Some(OsStr::new("value")));
+}
+
+#[test]
+fn get_envs_returns_matching_entries() {
+    let reports = run_with_server(
+        env_map(&[("PROBE_A", "alpha"), ("PROBE_B", "beta"), ("UNRELATED", "noise")]),
+        |envs| {
+            let client = connect(&envs);
+            let matches = client.get_envs("PROBE_*").unwrap();
+            assert_eq!(matches.len(), 2);
+            assert_eq!(
+                matches.get(OsStr::new("PROBE_A")).map(AsRef::as_ref),
+                Some(OsStr::new("alpha"))
+            );
+            assert_eq!(
+                matches.get(OsStr::new("PROBE_B")).map(AsRef::as_ref),
+                Some(OsStr::new("beta"))
+            );
+            assert!(!matches.contains_key(OsStr::new("UNRELATED")));
+        },
+    )
+    .expect("driver returned error");
+
+    assert!(!reports.cache_disabled);
+}
+
+#[test]
+fn get_envs_empty_match_set_is_returned() {
+    let reports = run_with_server(env_map(&[("FOO", "x"), ("BAR", "y")]), |envs| {
+        let client = connect(&envs);
+        let matches = client.get_envs("PROBE_*").unwrap();
+        assert!(matches.is_empty());
+    })
+    .expect("driver returned error");
+
+    assert!(!reports.cache_disabled);
+}
+
+#[test]
+fn get_envs_invalid_pattern_surfaces_error() {
+    let err = run_with_server(env_map(&[]), |envs| {
+        let client = connect(&envs);
+        let send_err = client.get_envs("{unclosed").expect_err("server should reject");
+        assert_eq!(send_err.kind(), io::ErrorKind::UnexpectedEof);
+    })
+    .expect_err("driver should surface the protocol error");
+
+    match err {
+        Error::InvalidGlob(inner) => {
+            assert_eq!(inner.pattern.as_ref(), "{unclosed");
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
 }


### PR DESCRIPTION
## Motivation

Tools need a bulk env read path for APIs like Vite `loadEnv`, which discover envs by prefix rather than by a single name. Before this slice, `getEnvs` existed on the JS surface but returned an empty match set.

## Scope

Add the `GetEnvs` protocol frame, Rust client support, NAPI `getEnvs` implementation, server-side env glob matching, invalid-glob error surfacing, and print-only e2e coverage. The NAPI boundary now errors if a matched env name or value cannot be represented as UTF-8 instead of silently dropping it.

This PR intentionally does not add `getEnvs` match sets to cache fingerprints and does not add the `tracked` option. Those are later PRs in the stack.

## Verification

- `cargo test -p vite_task_server --test integration`
- `UPDATE_SNAPSHOTS=1 cargo test -p vite_task_bin --test e2e_snapshots fetch_envs_reads_match_set -- --ignored`
- `cargo test -p vite_task_bin --test e2e_snapshots fetch_envs_reads_match_set -- --ignored`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`