### PR TITLE
feat(cache): fingerprint getEnvs match sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - **Changed** Tracked environment values in task cache fingerprints are now stored only as SHA-256 digests, and env-related cache miss details report names without values.
+- **Added** Runner-aware `getEnvs` match sets can now participate in task cache fingerprints, so changing, adding, or removing a matching env var invalidates the cache ([#450](https://github.com/voidzero-dev/vite-task/pull/450)).
 - **Added** Runner-aware `getEnvs` calls now return env values served by the runner for matching env glob patterns ([#449](https://github.com/voidzero-dev/vite-task/pull/449)).
 - **Fixed** Runner-aware `getEnv` reads now affect task cache fingerprints, so changing a tool-served env value invalidates cached output and names the env var in the miss message ([#454](https://github.com/voidzero-dev/vite-task/pull/454)).
 - **Added** Runner-aware tools can now opt the current task run out of caching through the new IPC channel; Vite dev server integration uses this automatically ([#441](https://github.com/voidzero-dev/vite-task/pull/441))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4267,6 +4267,7 @@ dependencies = [
  "tracing",
  "twox-hash",
  "uuid",
+ "vite_glob",
  "vite_path",
  "vite_select",
  "vite_str",

--- a/crates/vite_task/Cargo.toml
+++ b/crates/vite_task/Cargo.toml
@@ -45,6 +45,7 @@ tracing = { workspace = true }
 twox-hash = { workspace = true }
 materialized_artifact = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
+vite_glob = { workspace = true }
 vite_path = { workspace = true }
 vite_select = { workspace = true }
 vite_str = { workspace = true }

--- a/crates/vite_task/src/session/cache/display.rs
+++ b/crates/vite_task/src/session/cache/display.rs
@@ -188,7 +188,7 @@ pub fn format_cache_status_inline(cache_status: &CacheStatus) -> Option<Str> {
                 }
                 FingerprintMismatch::TrackedEnvChanged(mismatch)
                 | FingerprintMismatch::TrackedEnvGlobChanged { mismatch, .. } => {
-                    format_env_changed_inline(&[mismatch.name()])
+                    vite_str::format!("{mismatch}")
                 }
             };
             Some(vite_str::format!("○ cache miss: {reason}, executing"))
@@ -243,6 +243,30 @@ mod tests {
         assert_eq!(
             format_env_changed_inline(&[&first, &second]).as_str(),
             "envs 'API_KEY', 'NODE_ENV' changed"
+        );
+    }
+
+    #[test]
+    fn inline_tracked_env_mismatch_preserves_kind() {
+        let added = CacheStatus::Miss(CacheMiss::FingerprintMismatch(
+            FingerprintMismatch::TrackedEnvGlobChanged {
+                pattern: Str::from("PROBE_*"),
+                mismatch: EnvMismatch::Added { name: Str::from("PROBE_C") },
+            },
+        ));
+        let removed = CacheStatus::Miss(CacheMiss::FingerprintMismatch(
+            FingerprintMismatch::TrackedEnvChanged(EnvMismatch::Removed {
+                name: Str::from("PROBE_A"),
+            }),
+        ));
+
+        assert_eq!(
+            format_cache_status_inline(&added).as_deref(),
+            Some("○ cache miss: env 'PROBE_C' added, executing")
+        );
+        assert_eq!(
+            format_cache_status_inline(&removed).as_deref(),
+            Some("○ cache miss: env 'PROBE_A' removed, executing")
         );
     }
 }

--- a/crates/vite_task/src/session/cache/display.rs
+++ b/crates/vite_task/src/session/cache/display.rs
@@ -186,7 +186,8 @@ pub fn format_cache_status_inline(cache_status: &CacheStatus) -> Option<Str> {
                 FingerprintMismatch::InputChanged { kind, path } => {
                     format_input_change_str(*kind, path.as_str())
                 }
-                FingerprintMismatch::TrackedEnvChanged(mismatch) => {
+                FingerprintMismatch::TrackedEnvChanged(mismatch)
+                | FingerprintMismatch::TrackedEnvGlobChanged { mismatch, .. } => {
                     format_env_changed_inline(&[mismatch.name()])
                 }
             };

--- a/crates/vite_task/src/session/cache/mod.rs
+++ b/crates/vite_task/src/session/cache/mod.rs
@@ -252,7 +252,7 @@ pub fn split_path(path: &str) -> (Option<&str>, &str) {
 /// its own cache warm across branch switches, and a cache from a different
 /// version is simply ignored (it lives in a directory this build never looks
 /// at) rather than aborting the run. Bumping the version starts a fresh cache.
-const CACHE_SCHEMA_VERSION: u32 = 15;
+const CACHE_SCHEMA_VERSION: u32 = 16;
 
 /// Name of the per-version subdirectory (e.g. `v14`) under the task-cache
 /// directory that holds the database and output archives for the current

--- a/crates/vite_task/src/session/cache/mod.rs
+++ b/crates/vite_task/src/session/cache/mod.rs
@@ -211,14 +211,22 @@ pub enum FingerprintMismatch {
     },
     /// A runner-aware tool-tracked env var changed between runs.
     TrackedEnvChanged(EnvMismatch),
+    /// A runner-aware tool-tracked env glob's match-set changed between runs.
+    TrackedEnvGlobChanged {
+        pattern: Str,
+        mismatch: EnvMismatch,
+    },
 }
 
 impl From<crate::session::execute::fingerprint::PostRunMismatch> for FingerprintMismatch {
     fn from(mismatch: crate::session::execute::fingerprint::PostRunMismatch) -> Self {
         use crate::session::execute::fingerprint::PostRunMismatch;
         match mismatch {
-            PostRunMismatch::InputChanged { kind, path } => Self::InputChanged { kind, path },
-            PostRunMismatch::TrackedEnvChanged(mismatch) => Self::TrackedEnvChanged(mismatch),
+            PostRunMismatch::Input { kind, path } => Self::InputChanged { kind, path },
+            PostRunMismatch::TrackedEnv(mismatch) => Self::TrackedEnvChanged(mismatch),
+            PostRunMismatch::TrackedEnvGlob { pattern, mismatch } => {
+                Self::TrackedEnvGlobChanged { pattern, mismatch }
+            }
         }
     }
 }

--- a/crates/vite_task/src/session/execute/cache_update.rs
+++ b/crates/vite_task/src/session/execute/cache_update.rs
@@ -32,6 +32,9 @@ struct TrackingOutcome {
     read_write_overlap: Option<RelativePathBuf>,
 }
 
+type TrackedEnvValues = BTreeMap<Str, Option<EnvValueHash>>;
+type TrackedEnvGlobValues = BTreeMap<Str, BTreeMap<Str, EnvValueHash>>;
+
 /// Decide whether the finished run may be cached, and store it if so.
 ///
 /// Every outcome returns a `(status, error)` pair for the caller's single
@@ -100,8 +103,8 @@ pub(super) async fn update_cache(
     // Collect tool-reported tracked envs for the post-run fingerprint. Env
     // names that the user already declared are skipped because their values
     // are already part of the spawn fingerprint.
-    let tracked_envs = match collect_tracked_reports(reports, metadata) {
-        Ok(tracked_envs) => tracked_envs,
+    let (tracked_envs, tracked_env_globs) = match collect_tracked_reports(reports, metadata) {
+        Ok(tracked_reports) => tracked_reports,
         Err(err) => {
             return (
                 CacheUpdateStatus::NotUpdated(CacheNotUpdatedReason::CacheDisabled),
@@ -115,17 +118,21 @@ pub(super) async fn update_cache(
     // post-exec hash.
     let empty_path_reads = HashMap::default();
     let path_reads = fspy_outcome.as_ref().map_or(&empty_path_reads, |o| &o.path_reads);
-    let post_run_fingerprint =
-        match PostRunFingerprint::create(path_reads, workspace_root, &globbed_inputs, tracked_envs)
-        {
-            Ok(fingerprint) => fingerprint,
-            Err(err) => {
-                return (
-                    CacheUpdateStatus::NotUpdated(CacheNotUpdatedReason::CacheDisabled),
-                    Some(ExecutionError::PostRunFingerprint(err)),
-                );
-            }
-        };
+    let post_run_fingerprint = match PostRunFingerprint::create(
+        path_reads,
+        workspace_root,
+        &globbed_inputs,
+        tracked_envs,
+        tracked_env_globs,
+    ) {
+        Ok(fingerprint) => fingerprint,
+        Err(err) => {
+            return (
+                CacheUpdateStatus::NotUpdated(CacheNotUpdatedReason::CacheDisabled),
+                Some(ExecutionError::PostRunFingerprint(err)),
+            );
+        }
+    };
 
     let output_archive = match collect_and_archive_outputs(metadata, workspace_root, cache_dir) {
         Ok(archive) => archive,
@@ -183,17 +190,24 @@ fn observe_fspy(
 fn collect_tracked_reports(
     reports: Option<&Reports>,
     metadata: &CacheMetadata,
-) -> anyhow::Result<BTreeMap<Str, Option<EnvValueHash>>> {
-    reports.map(|r| collect_tracked_envs(r, metadata)).transpose().map(Option::unwrap_or_default)
+) -> anyhow::Result<(TrackedEnvValues, TrackedEnvGlobValues)> {
+    reports
+        .map(|reports| {
+            let tracked_envs = collect_tracked_envs(reports, metadata)?;
+            let tracked_env_globs = collect_tracked_env_globs(reports)?;
+            Ok::<_, anyhow::Error>((tracked_envs, tracked_env_globs))
+        })
+        .transpose()
+        .map(Option::unwrap_or_default)
 }
 
 /// Select tool-reported env records to embed in the post-run fingerprint.
-/// Only `tracked: true` records are included, and names that the user already
-/// declared as fingerprinted are skipped.
+/// Names that the user already declared as fingerprinted are skipped because
+/// their values are already in the spawn fingerprint.
 fn collect_tracked_envs(
     reports: &Reports,
     metadata: &CacheMetadata,
-) -> anyhow::Result<BTreeMap<Str, Option<EnvValueHash>>> {
+) -> anyhow::Result<TrackedEnvValues> {
     let fingerprinted = &metadata.spawn_fingerprint.env_fingerprints().fingerprinted_envs;
     let mut tracked_envs = BTreeMap::new();
 
@@ -216,6 +230,28 @@ fn collect_tracked_envs(
     }
 
     Ok(tracked_envs)
+}
+
+/// Select tool-reported env-glob records to embed in the post-run
+/// fingerprint. The full match-set is stored as value hashes.
+fn collect_tracked_env_globs(reports: &Reports) -> anyhow::Result<TrackedEnvGlobValues> {
+    let mut tracked_env_globs = BTreeMap::new();
+
+    for (pattern, record) in &reports.env_glob_records {
+        let mut matches = BTreeMap::new();
+        for (name, value) in &record.matches {
+            let name_str = name
+                .to_str()
+                .ok_or_else(|| anyhow::anyhow!("tracked env match name is not valid UTF-8"))?;
+            let value_str = value.to_str().ok_or_else(|| {
+                anyhow::anyhow!("tracked env match value for {name_str} is not valid UTF-8")
+            })?;
+            matches.insert(Str::from(name_str), EnvValueHash::new(value_str));
+        }
+        tracked_env_globs.insert(Str::from(pattern.as_ref()), matches);
+    }
+
+    Ok(tracked_env_globs)
 }
 
 /// Collect output files matching the configured globs and create a tar.zst

--- a/crates/vite_task/src/session/execute/fingerprint.rs
+++ b/crates/vite_task/src/session/execute/fingerprint.rs
@@ -188,7 +188,15 @@ impl PostRunFingerprint {
         }
 
         for (pattern, stored_matches) in &self.tracked_env_globs {
-            let current_matches = match_env_glob(pattern.as_str(), unfiltered_envs)?;
+            let current_matches = match match_env_glob(pattern.as_str(), unfiltered_envs)? {
+                EnvGlobValidation::Matches(matches) => matches,
+                EnvGlobValidation::NonUtf8Value(mismatch) => {
+                    return Ok(Some(PostRunMismatch::TrackedEnvGlob {
+                        pattern: pattern.clone(),
+                        mismatch,
+                    }));
+                }
+            };
             if let Some(mismatch) = first_env_glob_mismatch(stored_matches, &current_matches) {
                 return Ok(Some(PostRunMismatch::TrackedEnvGlob {
                     pattern: pattern.clone(),
@@ -202,24 +210,35 @@ impl PostRunFingerprint {
 }
 
 /// Build the current match-set for `pattern` by enumerating the given env
-/// snapshot and keeping UTF-8 names whose representation matches the glob.
+/// snapshot and keeping UTF-8 names whose representation matches the glob. If
+/// a matching env has a non-UTF-8 value, return a changed mismatch so the stale
+/// cache entry is not replayed.
 fn match_env_glob(
     pattern: &str,
     envs: &FxHashMap<Arc<OsStr>, Arc<OsStr>>,
-) -> anyhow::Result<BTreeMap<Str, EnvValueHash>> {
+) -> anyhow::Result<EnvGlobValidation> {
     let glob = vite_glob::env::EnvGlob::new(pattern)?;
-    Ok(envs
-        .iter()
-        .filter_map(|(name, value)| {
-            let name_str = name.to_str()?;
-            let value_str = value.to_str()?;
-            if glob.is_match(name_str) {
-                Some((Str::from(name_str), EnvValueHash::new(value_str)))
-            } else {
-                None
-            }
-        })
-        .collect())
+    let mut matches = BTreeMap::new();
+    for (name, value) in envs {
+        let Some(name_str) = name.to_str() else {
+            continue;
+        };
+        if !glob.is_match(name_str) {
+            continue;
+        }
+        let Some(value_str) = value.to_str() else {
+            return Ok(EnvGlobValidation::NonUtf8Value(EnvMismatch::Changed {
+                name: Str::from(name_str),
+            }));
+        };
+        matches.insert(Str::from(name_str), EnvValueHash::new(value_str));
+    }
+    Ok(EnvGlobValidation::Matches(matches))
+}
+
+enum EnvGlobValidation {
+    Matches(BTreeMap<Str, EnvValueHash>),
+    NonUtf8Value(EnvMismatch),
 }
 
 /// Find the first deterministic difference between stored and current env
@@ -486,5 +505,33 @@ mod tests {
             .expect_err("non-UTF-8 tracked env values must error");
 
         assert!(err.to_string().contains("tracked env value for PROBE_ENV is not valid UTF-8"));
+    }
+
+    #[test]
+    fn validate_reports_current_non_utf8_tracked_env_glob_value_as_changed() {
+        let mut tracked_env_globs = BTreeMap::new();
+        tracked_env_globs.insert(Str::from("PROBE_*"), BTreeMap::new());
+        let fingerprint = PostRunFingerprint { tracked_env_globs, ..PostRunFingerprint::default() };
+
+        let mut unfiltered_envs = FxHashMap::default();
+        unfiltered_envs.insert(
+            Arc::<OsStr>::from(OsStr::new("PROBE_BAD")),
+            Arc::<OsStr>::from(non_utf8_os_string()),
+        );
+
+        let workspace_root = vite_path::current_dir().expect("cwd");
+        let mismatch =
+            fingerprint.validate(&workspace_root, &unfiltered_envs).expect("validation succeeds");
+
+        match mismatch {
+            Some(PostRunMismatch::TrackedEnvGlob {
+                pattern,
+                mismatch: EnvMismatch::Changed { name },
+            }) => {
+                assert_eq!(pattern.as_str(), "PROBE_*");
+                assert_eq!(name.as_str(), "PROBE_BAD");
+            }
+            other => panic!("expected changed tracked env glob mismatch, got {other:?}"),
+        }
     }
 }

--- a/crates/vite_task/src/session/execute/fingerprint.rs
+++ b/crates/vite_task/src/session/execute/fingerprint.rs
@@ -43,15 +43,24 @@ pub struct PostRunFingerprint {
     /// `None` if unset. Validated at cache lookup against the same plan env
     /// context that served the original request.
     pub tracked_envs: BTreeMap<Str, Option<EnvValueHash>>,
+
+    /// Glob-pattern env queries (`getEnvs`) made with `tracked: true`.
+    /// Outer key is the glob pattern, inner map is the match-set at execution
+    /// time (name -> value hash). Validated at cache lookup by re-matching
+    /// against the current env context and comparing the resulting set.
+    pub tracked_env_globs: BTreeMap<Str, BTreeMap<Str, EnvValueHash>>,
 }
 
 /// A mismatch between the stored post-run fingerprint and the current state.
 #[derive(Debug, Clone)]
 pub enum PostRunMismatch {
     /// An inferred input file or directory changed.
-    InputChanged { kind: InputChangeKind, path: RelativePathBuf },
+    Input { kind: InputChangeKind, path: RelativePathBuf },
     /// A tool-tracked env var changed value, appeared, or disappeared.
-    TrackedEnvChanged(EnvMismatch),
+    TrackedEnv(EnvMismatch),
+    /// A tool-tracked env glob's match-set changed between runs. Carries the
+    /// first differing entry in env-name order.
+    TrackedEnvGlob { pattern: Str, mismatch: EnvMismatch },
 }
 
 /// Fingerprint for a single path (file or directory)
@@ -91,12 +100,14 @@ impl PostRunFingerprint {
     /// * `base_dir` - Workspace root for resolving relative paths
     /// * `globbed_inputs` - Prerun glob fingerprint; paths here are skipped
     /// * `tracked_envs` - Tool-requested env vars (name -> value hash), validated on lookup
+    /// * `tracked_env_globs` - Tool-requested env globs (pattern -> match-set hashes)
     #[tracing::instrument(level = "debug", skip_all, name = "create_post_run_fingerprint")]
     pub fn create(
         inferred_path_reads: &HashMap<RelativePathBuf, PathRead>,
         base_dir: &AbsolutePath,
         globbed_inputs: &BTreeMap<RelativePathBuf, u64>,
         tracked_envs: BTreeMap<Str, Option<EnvValueHash>>,
+        tracked_env_globs: BTreeMap<Str, BTreeMap<Str, EnvValueHash>>,
     ) -> anyhow::Result<Self> {
         let inferred_inputs = inferred_path_reads
             .par_iter()
@@ -108,7 +119,7 @@ impl PostRunFingerprint {
             })
             .collect::<anyhow::Result<HashMap<_, _>>>()?;
 
-        Ok(Self { inferred_inputs, tracked_envs })
+        Ok(Self { inferred_inputs, tracked_envs, tracked_env_globs })
     }
 
     /// Validates the fingerprint against current filesystem state and the
@@ -151,7 +162,7 @@ impl PostRunFingerprint {
                     } else {
                         input_relative_path.clone()
                     };
-                    Some(Ok(PostRunMismatch::InputChanged { kind, path }))
+                    Some(Ok(PostRunMismatch::Input { kind, path }))
                 }
             },
         );
@@ -172,11 +183,75 @@ impl PostRunFingerprint {
             if let Some(mismatch) =
                 EnvMismatch::compare(name, stored_value.as_ref(), current_value.as_ref())
             {
-                return Ok(Some(PostRunMismatch::TrackedEnvChanged(mismatch)));
+                return Ok(Some(PostRunMismatch::TrackedEnv(mismatch)));
+            }
+        }
+
+        for (pattern, stored_matches) in &self.tracked_env_globs {
+            let current_matches = match_env_glob(pattern.as_str(), unfiltered_envs)?;
+            if let Some(mismatch) = first_env_glob_mismatch(stored_matches, &current_matches) {
+                return Ok(Some(PostRunMismatch::TrackedEnvGlob {
+                    pattern: pattern.clone(),
+                    mismatch,
+                }));
             }
         }
 
         Ok(None)
+    }
+}
+
+/// Build the current match-set for `pattern` by enumerating the given env
+/// snapshot and keeping UTF-8 names whose representation matches the glob.
+fn match_env_glob(
+    pattern: &str,
+    envs: &FxHashMap<Arc<OsStr>, Arc<OsStr>>,
+) -> anyhow::Result<BTreeMap<Str, EnvValueHash>> {
+    let glob = vite_glob::env::EnvGlob::new(pattern)?;
+    Ok(envs
+        .iter()
+        .filter_map(|(name, value)| {
+            let name_str = name.to_str()?;
+            let value_str = value.to_str()?;
+            if glob.is_match(name_str) {
+                Some((Str::from(name_str), EnvValueHash::new(value_str)))
+            } else {
+                None
+            }
+        })
+        .collect())
+}
+
+/// Find the first deterministic difference between stored and current env
+/// glob match-sets.
+fn first_env_glob_mismatch(
+    stored: &BTreeMap<Str, EnvValueHash>,
+    current: &BTreeMap<Str, EnvValueHash>,
+) -> Option<EnvMismatch> {
+    let mut stored_iter = stored.iter();
+    let mut current_iter = current.iter();
+    let mut s = stored_iter.next();
+    let mut c = current_iter.next();
+
+    loop {
+        match (s, c) {
+            (None, None) => return None,
+            (Some((name, _)), None) => return Some(EnvMismatch::Removed { name: name.clone() }),
+            (None, Some((name, _))) => return Some(EnvMismatch::Added { name: name.clone() }),
+            (Some((sn, sv)), Some((cn, cv))) => match sn.cmp(cn) {
+                std::cmp::Ordering::Equal => {
+                    if sv != cv {
+                        return Some(EnvMismatch::Changed { name: sn.clone() });
+                    }
+                    s = stored_iter.next();
+                    c = current_iter.next();
+                }
+                std::cmp::Ordering::Less => return Some(EnvMismatch::Removed { name: sn.clone() }),
+                std::cmp::Ordering::Greater => {
+                    return Some(EnvMismatch::Added { name: cn.clone() });
+                }
+            },
+        }
     }
 }
 

--- a/crates/vite_task/src/session/execute/fingerprint.rs
+++ b/crates/vite_task/src/session/execute/fingerprint.rs
@@ -48,6 +48,13 @@ pub struct PostRunFingerprint {
     /// Outer key is the glob pattern, inner map is the match-set at execution
     /// time (name -> value hash). Validated at cache lookup by re-matching
     /// against the current env context and comparing the resulting set.
+    ///
+    /// Non-UTF-8 env names are never matched, saved, or treated as errors:
+    /// they are not returned to the client, so their existence cannot affect
+    /// task behavior. Values are stricter. A matched env must have a UTF-8
+    /// value; the JS client errors when querying a matched non-UTF-8 value,
+    /// and cache-hit validation treats a currently matched non-UTF-8 value as
+    /// a changed mismatch so stale cached output is not replayed.
     pub tracked_env_globs: BTreeMap<Str, BTreeMap<Str, EnvValueHash>>,
 }
 
@@ -533,5 +540,24 @@ mod tests {
             }
             other => panic!("expected changed tracked env glob mismatch, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn validate_ignores_non_utf8_tracked_env_glob_names() {
+        let mut tracked_env_globs = BTreeMap::new();
+        tracked_env_globs.insert(Str::from("PROBE_*"), BTreeMap::new());
+        let fingerprint = PostRunFingerprint { tracked_env_globs, ..PostRunFingerprint::default() };
+
+        let mut unfiltered_envs = FxHashMap::default();
+        unfiltered_envs.insert(
+            Arc::<OsStr>::from(non_utf8_os_string()),
+            Arc::<OsStr>::from(OsStr::new("value")),
+        );
+
+        let workspace_root = vite_path::current_dir().expect("cwd");
+        let mismatch =
+            fingerprint.validate(&workspace_root, &unfiltered_envs).expect("validation succeeds");
+
+        assert!(mismatch.is_none());
     }
 }

--- a/crates/vite_task/src/session/reporter/summary.rs
+++ b/crates/vite_task/src/session/reporter/summary.rs
@@ -137,6 +137,9 @@ pub enum SavedCacheMissReason {
     InputChanged { kind: InputChangeKind, path: Str },
     /// A runner-aware tool reported a tracked env var that changed between runs.
     TrackedEnvChanged(EnvMismatch),
+    /// A runner-aware tool reported a tracked env glob whose match-set changed
+    /// between runs. Carries the first differing entry.
+    TrackedEnvGlobChanged { pattern: Str, mismatch: EnvMismatch },
 }
 
 /// An execution error, serializable for persistence.
@@ -282,6 +285,12 @@ impl SavedCacheMissReason {
                 }
                 FingerprintMismatch::TrackedEnvChanged(mismatch) => {
                     Self::TrackedEnvChanged(mismatch.clone())
+                }
+                FingerprintMismatch::TrackedEnvGlobChanged { pattern, mismatch } => {
+                    Self::TrackedEnvGlobChanged {
+                        pattern: pattern.clone(),
+                        mismatch: mismatch.clone(),
+                    }
                 }
             },
         }
@@ -572,7 +581,8 @@ impl TaskResult {
                         let desc = format_input_change_str(*kind, path.as_str());
                         vite_str::format!("→ Cache miss: {desc}")
                     }
-                    SavedCacheMissReason::TrackedEnvChanged(mismatch) => {
+                    SavedCacheMissReason::TrackedEnvChanged(mismatch)
+                    | SavedCacheMissReason::TrackedEnvGlobChanged { mismatch, .. } => {
                         vite_str::format!("→ Cache miss: {mismatch}")
                     }
                 },

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots.toml
@@ -198,3 +198,104 @@ steps = [
     ],
   ], comment = "runner serves only envs matching PROBE_*" },
 ]
+
+[[e2e]]
+name = "fetch_envs_tracks_glob_match_set"
+comment = """
+Exercises `getEnvs(pattern, { tracked: true })`. The glob `PROBE_*` and its match-set snapshot enter the post-run fingerprint: later runs miss on changed, added, or removed matching envs, but hit when only non-matching envs differ.
+"""
+ignore = true
+steps = [
+  { argv = [
+    "vt",
+    "run",
+    "fetch-envs",
+  ], envs = [
+    [
+      "PROBE_A",
+      "a",
+    ],
+    [
+      "PROBE_B",
+      "b",
+    ],
+  ], comment = "populate: first run captures {PROBE_A, PROBE_B} under the glob" },
+  { argv = [
+    "vt",
+    "run",
+    "fetch-envs",
+  ], envs = [
+    [
+      "PROBE_A",
+      "a",
+    ],
+    [
+      "PROBE_B",
+      "b",
+    ],
+  ], comment = "unchanged: same match-set -> cache hit" },
+  { argv = [
+    "vt",
+    "run",
+    "fetch-envs",
+  ], envs = [
+    [
+      "PROBE_A",
+      "changed",
+    ],
+    [
+      "PROBE_B",
+      "b",
+    ],
+  ], comment = "change: PROBE_A value differs -> cache miss" },
+  { argv = [
+    "vt",
+    "run",
+    "fetch-envs",
+  ], envs = [
+    [
+      "PROBE_A",
+      "changed",
+    ],
+    [
+      "PROBE_B",
+      "b",
+    ],
+    [
+      "PROBE_C",
+      "c",
+    ],
+  ], comment = "add: PROBE_C is new under the glob -> cache miss" },
+  { argv = [
+    "vt",
+    "run",
+    "fetch-envs",
+  ], envs = [
+    [
+      "PROBE_B",
+      "b",
+    ],
+    [
+      "PROBE_C",
+      "c",
+    ],
+  ], comment = "remove: PROBE_A dropped from the match-set -> cache miss" },
+  { argv = [
+    "vt",
+    "run",
+    "fetch-envs",
+  ], envs = [
+    [
+      "PROBE_B",
+      "b",
+    ],
+    [
+      "PROBE_C",
+      "c",
+    ],
+    [
+      "UNRELATED",
+      "noise",
+    ],
+  ], comment = "non-matching noise: UNRELATED does not match PROBE_* -> cache hit" },
+]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/fetch_envs_tracks_glob_match_set.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/fetch_envs_tracks_glob_match_set.md
@@ -40,7 +40,7 @@ PROBE_B=b
 add: PROBE_C is new under the glob -> cache miss
 
 ```
-$ node scripts/fetch_envs.mjs ○ cache miss: env 'PROBE_C' changed, executing
+$ node scripts/fetch_envs.mjs ○ cache miss: env 'PROBE_C' added, executing
 PROBE_A=changed
 PROBE_B=b
 PROBE_C=c
@@ -51,7 +51,7 @@ PROBE_C=c
 remove: PROBE_A dropped from the match-set -> cache miss
 
 ```
-$ node scripts/fetch_envs.mjs ○ cache miss: env 'PROBE_A' changed, executing
+$ node scripts/fetch_envs.mjs ○ cache miss: env 'PROBE_A' removed, executing
 PROBE_B=b
 PROBE_C=c
 ```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/fetch_envs_tracks_glob_match_set.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/fetch_envs_tracks_glob_match_set.md
@@ -1,0 +1,70 @@
+# fetch_envs_tracks_glob_match_set
+
+Exercises `getEnvs(pattern, { tracked: true })`. The glob `PROBE_*` and its match-set snapshot enter the post-run fingerprint: later runs miss on changed, added, or removed matching envs, but hit when only non-matching envs differ.
+
+## `PROBE_A=a PROBE_B=b vt run fetch-envs`
+
+populate: first run captures {PROBE_A, PROBE_B} under the glob
+
+```
+$ node scripts/fetch_envs.mjs
+PROBE_A=a
+PROBE_B=b
+```
+
+## `PROBE_A=a PROBE_B=b vt run fetch-envs`
+
+unchanged: same match-set -> cache hit
+
+```
+$ node scripts/fetch_envs.mjs ◉ cache hit, replaying
+PROBE_A=a
+PROBE_B=b
+
+---
+vt run: cache hit.
+```
+
+## `PROBE_A=changed PROBE_B=b vt run fetch-envs`
+
+change: PROBE_A value differs -> cache miss
+
+```
+$ node scripts/fetch_envs.mjs ○ cache miss: env 'PROBE_A' changed, executing
+PROBE_A=changed
+PROBE_B=b
+```
+
+## `PROBE_A=changed PROBE_B=b PROBE_C=c vt run fetch-envs`
+
+add: PROBE_C is new under the glob -> cache miss
+
+```
+$ node scripts/fetch_envs.mjs ○ cache miss: env 'PROBE_C' changed, executing
+PROBE_A=changed
+PROBE_B=b
+PROBE_C=c
+```
+
+## `PROBE_B=b PROBE_C=c vt run fetch-envs`
+
+remove: PROBE_A dropped from the match-set -> cache miss
+
+```
+$ node scripts/fetch_envs.mjs ○ cache miss: env 'PROBE_A' changed, executing
+PROBE_B=b
+PROBE_C=c
+```
+
+## `PROBE_B=b PROBE_C=c UNRELATED=noise vt run fetch-envs`
+
+non-matching noise: UNRELATED does not match PROBE_* -> cache hit
+
+```
+$ node scripts/fetch_envs.mjs ◉ cache hit, replaying
+PROBE_B=b
+PROBE_C=c
+
+---
+vt run: cache hit.
+```

--- a/crates/vite_task_client/src/lib.rs
+++ b/crates/vite_task_client/src/lib.rs
@@ -81,8 +81,6 @@ impl Client {
     ///
     /// Returns an error if the request or response fails, or if the server
     /// rejects the pattern as an invalid glob.
-    // TODO(env-track): A later PR in this stack adds a tracked flag so matched
-    // env sets can participate in cache fingerprints instead of being IPC-only.
     pub fn get_envs(&self, pattern: &str) -> io::Result<FxHashMap<Arc<OsStr>, Arc<OsStr>>> {
         self.send(&Request::GetEnvs { pattern })?;
         let response: GetEnvsResponse = self.recv()?;

--- a/crates/vite_task_server/src/lib.rs
+++ b/crates/vite_task_server/src/lib.rs
@@ -60,9 +60,19 @@ pub struct InvalidGlob {
 pub struct Recorder {
     cache_disabled: bool,
     env_records: FxHashMap<Arc<OsStr>, Option<Arc<OsStr>>>,
+    env_glob_records: FxHashMap<Arc<str>, EnvGlobRecord>,
     /// The envs `get_env` resolves against. The runner supplies these for the
     /// spawned task; the server never re-reads the live process env.
     envs: Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>,
+}
+
+/// A record of a glob-pattern env query made via `get_envs`.
+///
+/// `matches` is captured on the first call and reused on repeat queries; the server's
+/// env map is immutable for a task's lifetime.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnvGlobRecord {
+    pub matches: FxHashMap<Arc<OsStr>, Arc<OsStr>>,
 }
 
 /// The data collected by a [`Recorder`] over the server's lifetime.
@@ -70,17 +80,27 @@ pub struct Recorder {
 pub struct Reports {
     pub cache_disabled: bool,
     pub env_records: FxHashMap<Arc<OsStr>, Option<Arc<OsStr>>>,
+    pub env_glob_records: FxHashMap<Arc<str>, EnvGlobRecord>,
 }
 
 impl Recorder {
     #[must_use]
     pub fn new(envs: Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>) -> Self {
-        Self { cache_disabled: false, env_records: FxHashMap::default(), envs }
+        Self {
+            cache_disabled: false,
+            env_records: FxHashMap::default(),
+            env_glob_records: FxHashMap::default(),
+            envs,
+        }
     }
 
     #[must_use]
     pub fn into_reports(self) -> Reports {
-        Reports { cache_disabled: self.cache_disabled, env_records: self.env_records }
+        Reports {
+            cache_disabled: self.cache_disabled,
+            env_records: self.env_records,
+            env_glob_records: self.env_glob_records,
+        }
     }
 }
 
@@ -104,8 +124,11 @@ impl Handler for Recorder {
         &mut self,
         pattern: &str,
     ) -> Result<FxHashMap<Arc<OsStr>, Arc<OsStr>>, vite_glob::env::EnvGlobError> {
+        if let Some(existing) = self.env_glob_records.get(pattern) {
+            return Ok(existing.matches.clone());
+        }
         let glob = vite_glob::env::EnvGlob::new(pattern)?;
-        Ok(self
+        let matches: FxHashMap<Arc<OsStr>, Arc<OsStr>> = self
             .envs
             .iter()
             .filter_map(|(name, value)| {
@@ -116,7 +139,10 @@ impl Handler for Recorder {
                     None
                 }
             })
-            .collect())
+            .collect();
+        self.env_glob_records
+            .insert(Arc::from(pattern), EnvGlobRecord { matches: matches.clone() });
+        Ok(matches)
     }
 }
 

--- a/crates/vite_task_server/tests/integration.rs
+++ b/crates/vite_task_server/tests/integration.rs
@@ -134,6 +134,8 @@ fn get_envs_returns_matching_entries() {
     .expect("driver returned error");
 
     assert!(!reports.cache_disabled);
+    let glob = reports.env_glob_records.get("PROBE_*").expect("glob recorded");
+    assert_eq!(glob.matches.len(), 2);
 }
 
 #[test]
@@ -146,6 +148,8 @@ fn get_envs_empty_match_set_is_returned() {
     .expect("driver returned error");
 
     assert!(!reports.cache_disabled);
+    let glob = reports.env_glob_records.get("PROBE_*").expect("glob recorded");
+    assert!(glob.matches.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

Bulk env reads are only cache-safe if the cache remembers the entire matched env set. Without match-set fingerprinting, changing a matching env value, adding a new matching name, or removing one could replay stale output.

## Scope

Record every `getEnvs` match set in IPC reports, store SHA-256 hashes for the matched env values in the post-run fingerprint, validate changed/added/removed matches during cache lookup, and render env-specific miss messages without exposing values. This follows the env hashing model from #455 and raises a post-run fingerprint error instead of silently dropping non-UTF-8 matched env names or values.

This PR intentionally does not add the `tracked` option; every `getEnvs` request is fingerprinted here. The opt-out for both `getEnv` and `getEnvs` is split into the next PR. This PR also does not add the real Vite fixture.

## Verification

- `cargo check -p vite_task`
- `cargo test -p vite_task_server --test integration`
- `cargo test -p vite_task_bin --test e2e_snapshots fetch_envs_tracks_glob_match_set -- --ignored`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`