### PR TITLE
test(e2e): verify real Vite env cache tracking

### DIFF
--- a/crates/vite_task_bin/src/vtt/grep_file.rs
+++ b/crates/vite_task_bin/src/vtt/grep_file.rs
@@ -1,0 +1,16 @@
+pub fn run(args: &[String]) {
+    let [path, pattern] = args else {
+        eprintln!("Usage: vtt grep-file <path> <pattern>");
+        std::process::exit(2);
+    };
+    match std::fs::read_to_string(path) {
+        Ok(content) => {
+            if content.contains(pattern.as_str()) {
+                println!("{path}: found {pattern:?}");
+            } else {
+                println!("{path}: missing {pattern:?}");
+            }
+        }
+        Err(_) => println!("{path}: not found"),
+    }
+}

--- a/crates/vite_task_bin/src/vtt/main.rs
+++ b/crates/vite_task_bin/src/vtt/main.rs
@@ -11,6 +11,7 @@ mod check_tty;
 mod cp;
 mod exit;
 mod exit_on_ctrlc;
+mod grep_file;
 mod list_dir;
 mod mkdir;
 mod pipe_stdin;
@@ -30,7 +31,7 @@ fn main() {
     if args.len() < 2 {
         eprintln!("Usage: vtt <subcommand> [args...]");
         eprintln!(
-            "Subcommands: barrier, check-tty, cp, exit, exit-on-ctrlc, list-dir, mkdir, pipe-stdin, print, print-color, print-cwd, print-env, print-file, read-stdin, replace-file-content, rm, touch-file, write-file"
+            "Subcommands: barrier, check-tty, cp, exit, exit-on-ctrlc, grep-file, list-dir, mkdir, pipe-stdin, print, print-color, print-cwd, print-env, print-file, read-stdin, replace-file-content, rm, touch-file, write-file"
         );
         std::process::exit(1);
     }
@@ -44,6 +45,10 @@ fn main() {
         "cp" => cp::run(&args[2..]),
         "exit" => exit::run(&args[2..]),
         "exit-on-ctrlc" => exit_on_ctrlc::run(),
+        "grep-file" => {
+            grep_file::run(&args[2..]);
+            Ok(())
+        }
         "list-dir" => list_dir::run(&args[2..]),
         "mkdir" => mkdir::run(&args[2..]),
         "pipe-stdin" => pipe_stdin::run(&args[2..]),

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/index.html
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+    <title>vp-run-vite-cache</title>
+  </head>
+  <body>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/package.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "vite-build-cache-fixture",
+  "private": true,
+  "type": "module"
+}

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/snapshots.toml
@@ -1,7 +1,7 @@
 [[e2e]]
 name = "vite_prefix_env_change_invalidates_cache"
 comment = """
-`VITE_MODE` is picked up by Vite's patched `loadEnv`, which asks the runner for every `VITE_*` env via `getEnvs(pattern, { tracked: true })`. Flipping its value between runs must invalidate the cache AND change the build output — Vite's `define` plugin substitutes `import.meta.env.VITE_MODE` at build time, so dead-code elimination leaves only the branch matching the value.
+`VITE_CACHE_LABEL` is picked up by Vite's patched `loadEnv`, which asks the runner for every `VITE_*` env via `getEnvs(pattern, { tracked: true })`. Flipping its value between runs must invalidate the cache AND change the build output because Vite substitutes `import.meta.env.VITE_CACHE_LABEL` at build time.
 """
 ignore = true
 steps = [
@@ -12,22 +12,22 @@ steps = [
     "build",
   ], envs = [
     [
-      "VITE_MODE",
-      "production",
+      "VITE_CACHE_LABEL",
+      "cache-alpha",
     ],
-  ], comment = "first run: production build" },
+  ], comment = "first run: cache-alpha label" },
   { argv = [
     "vtt",
     "grep-file",
     "dist/assets/main.js",
-    "BUILD_MODE_PROD",
-  ], comment = "production build: PROD marker survived DCE" },
+    "cache-alpha",
+  ], comment = "cache-alpha label is in the bundle" },
   { argv = [
     "vtt",
     "grep-file",
     "dist/assets/main.js",
-    "BUILD_MODE_DEV",
-  ], comment = "dev branch is gone" },
+    "cache-bravo",
+  ], comment = "cache-bravo label is not in the bundle yet" },
   { argv = [
     "vt",
     "run",
@@ -35,10 +35,10 @@ steps = [
     "build",
   ], envs = [
     [
-      "VITE_MODE",
-      "production",
+      "VITE_CACHE_LABEL",
+      "cache-alpha",
     ],
-  ], comment = "cache hit: VITE_MODE unchanged" },
+  ], comment = "cache hit: VITE_CACHE_LABEL unchanged" },
   { argv = [
     "vt",
     "run",
@@ -46,22 +46,22 @@ steps = [
     "build",
   ], envs = [
     [
-      "VITE_MODE",
-      "development",
+      "VITE_CACHE_LABEL",
+      "cache-bravo",
     ],
-  ], comment = "cache miss: envs changed — VITE_MODE value changed" },
+  ], comment = "cache miss: envs changed — VITE_CACHE_LABEL value changed" },
   { argv = [
     "vtt",
     "grep-file",
     "dist/assets/main.js",
-    "BUILD_MODE_PROD",
-  ], comment = "PROD marker gone after the dev rebuild" },
+    "cache-alpha",
+  ], comment = "cache-alpha label is gone after the rebuild" },
   { argv = [
     "vtt",
     "grep-file",
     "dist/assets/main.js",
-    "BUILD_MODE_DEV",
-  ], comment = "DEV marker now in the bundle" },
+    "cache-bravo",
+  ], comment = "cache-bravo label is now in the bundle" },
 ]
 
 [[e2e]]
@@ -105,4 +105,3 @@ steps = [
     ],
   ], comment = "cache miss: envs changed (NODE_ENV changed)" },
 ]
-

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/snapshots.toml
@@ -1,0 +1,108 @@
+[[e2e]]
+name = "vite_prefix_env_change_invalidates_cache"
+comment = """
+`VITE_MODE` is picked up by Vite's patched `loadEnv`, which asks the runner for every `VITE_*` env via `getEnvs(pattern, { tracked: true })`. Flipping its value between runs must invalidate the cache AND change the build output — Vite's `define` plugin substitutes `import.meta.env.VITE_MODE` at build time, so dead-code elimination leaves only the branch matching the value.
+"""
+ignore = true
+steps = [
+  { argv = [
+    "vt",
+    "run",
+    "--cache",
+    "build",
+  ], envs = [
+    [
+      "VITE_MODE",
+      "production",
+    ],
+  ], comment = "first run: production build" },
+  { argv = [
+    "vtt",
+    "grep-file",
+    "dist/assets/main.js",
+    "BUILD_MODE_PROD",
+  ], comment = "production build: PROD marker survived DCE" },
+  { argv = [
+    "vtt",
+    "grep-file",
+    "dist/assets/main.js",
+    "BUILD_MODE_DEV",
+  ], comment = "dev branch is gone" },
+  { argv = [
+    "vt",
+    "run",
+    "--cache",
+    "build",
+  ], envs = [
+    [
+      "VITE_MODE",
+      "production",
+    ],
+  ], comment = "cache hit: VITE_MODE unchanged" },
+  { argv = [
+    "vt",
+    "run",
+    "--cache",
+    "build",
+  ], envs = [
+    [
+      "VITE_MODE",
+      "development",
+    ],
+  ], comment = "cache miss: envs changed — VITE_MODE value changed" },
+  { argv = [
+    "vtt",
+    "grep-file",
+    "dist/assets/main.js",
+    "BUILD_MODE_PROD",
+  ], comment = "PROD marker gone after the dev rebuild" },
+  { argv = [
+    "vtt",
+    "grep-file",
+    "dist/assets/main.js",
+    "BUILD_MODE_DEV",
+  ], comment = "DEV marker now in the bundle" },
+]
+
+[[e2e]]
+name = "vite_node_env_change_invalidates_cache"
+comment = """
+`NODE_ENV` enters the build's cache fingerprint via Vite's `getEnv('NODE_ENV')` call in `resolveConfig`. Same value → cache hit; different value → cache miss with `envs changed`.
+"""
+ignore = true
+steps = [
+  { argv = [
+    "vt",
+    "run",
+    "--cache",
+    "build",
+  ], envs = [
+    [
+      "NODE_ENV",
+      "production",
+    ],
+  ], comment = "first run: NODE_ENV=production" },
+  { argv = [
+    "vt",
+    "run",
+    "--cache",
+    "build",
+  ], envs = [
+    [
+      "NODE_ENV",
+      "production",
+    ],
+  ], comment = "cache hit: NODE_ENV unchanged" },
+  { argv = [
+    "vt",
+    "run",
+    "--cache",
+    "build",
+  ], envs = [
+    [
+      "NODE_ENV",
+      "development",
+    ],
+  ], comment = "cache miss: envs changed (NODE_ENV changed)" },
+]
+

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/snapshots/vite_node_env_change_invalidates_cache.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/snapshots/vite_node_env_change_invalidates_cache.md
@@ -1,0 +1,30 @@
+# vite_node_env_change_invalidates_cache
+
+`NODE_ENV` enters the build's cache fingerprint via Vite's `getEnv('NODE_ENV')` call in `resolveConfig`. Same value → cache hit; different value → cache miss with `envs changed`.
+
+## `NODE_ENV=production vt run --cache build`
+
+first run: NODE_ENV=production
+
+```
+$ vite build
+```
+
+## `NODE_ENV=production vt run --cache build`
+
+cache hit: NODE_ENV unchanged
+
+```
+$ vite build ◉ cache hit, replaying
+
+---
+vt run: cache hit.
+```
+
+## `NODE_ENV=development vt run --cache build`
+
+cache miss: envs changed (NODE_ENV changed)
+
+```
+$ vite build ○ cache miss: env 'NODE_ENV' changed, executing
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/snapshots/vite_prefix_env_change_invalidates_cache.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/snapshots/vite_prefix_env_change_invalidates_cache.md
@@ -1,34 +1,34 @@
 # vite_prefix_env_change_invalidates_cache
 
-`VITE_MODE` is picked up by Vite's patched `loadEnv`, which asks the runner for every `VITE_*` env via `getEnvs(pattern, { tracked: true })`. Flipping its value between runs must invalidate the cache AND change the build output — Vite's `define` plugin substitutes `import.meta.env.VITE_MODE` at build time, so dead-code elimination leaves only the branch matching the value.
+`VITE_CACHE_LABEL` is picked up by Vite's patched `loadEnv`, which asks the runner for every `VITE_*` env via `getEnvs(pattern, { tracked: true })`. Flipping its value between runs must invalidate the cache AND change the build output because Vite substitutes `import.meta.env.VITE_CACHE_LABEL` at build time.
 
-## `VITE_MODE=production vt run --cache build`
+## `VITE_CACHE_LABEL=cache-alpha vt run --cache build`
 
-first run: production build
+first run: cache-alpha label
 
 ```
 $ vite build
 ```
 
-## `vtt grep-file dist/assets/main.js BUILD_MODE_PROD`
+## `vtt grep-file dist/assets/main.js cache-alpha`
 
-production build: PROD marker survived DCE
-
-```
-dist/assets/main.js: found "BUILD_MODE_PROD"
-```
-
-## `vtt grep-file dist/assets/main.js BUILD_MODE_DEV`
-
-dev branch is gone
+cache-alpha label is in the bundle
 
 ```
-dist/assets/main.js: missing "BUILD_MODE_DEV"
+dist/assets/main.js: found "cache-alpha"
 ```
 
-## `VITE_MODE=production vt run --cache build`
+## `vtt grep-file dist/assets/main.js cache-bravo`
 
-cache hit: VITE_MODE unchanged
+cache-bravo label is not in the bundle yet
+
+```
+dist/assets/main.js: missing "cache-bravo"
+```
+
+## `VITE_CACHE_LABEL=cache-alpha vt run --cache build`
+
+cache hit: VITE_CACHE_LABEL unchanged
 
 ```
 $ vite build ◉ cache hit, replaying
@@ -37,26 +37,26 @@ $ vite build ◉ cache hit, replaying
 vt run: cache hit.
 ```
 
-## `VITE_MODE=development vt run --cache build`
+## `VITE_CACHE_LABEL=cache-bravo vt run --cache build`
 
-cache miss: envs changed — VITE_MODE value changed
-
-```
-$ vite build ○ cache miss: env 'VITE_MODE' changed, executing
-```
-
-## `vtt grep-file dist/assets/main.js BUILD_MODE_PROD`
-
-PROD marker gone after the dev rebuild
+cache miss: envs changed — VITE_CACHE_LABEL value changed
 
 ```
-dist/assets/main.js: missing "BUILD_MODE_PROD"
+$ vite build ○ cache miss: env 'VITE_CACHE_LABEL' changed, executing
 ```
 
-## `vtt grep-file dist/assets/main.js BUILD_MODE_DEV`
+## `vtt grep-file dist/assets/main.js cache-alpha`
 
-DEV marker now in the bundle
+cache-alpha label is gone after the rebuild
 
 ```
-dist/assets/main.js: found "BUILD_MODE_DEV"
+dist/assets/main.js: missing "cache-alpha"
+```
+
+## `vtt grep-file dist/assets/main.js cache-bravo`
+
+cache-bravo label is now in the bundle
+
+```
+dist/assets/main.js: found "cache-bravo"
 ```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/snapshots/vite_prefix_env_change_invalidates_cache.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/snapshots/vite_prefix_env_change_invalidates_cache.md
@@ -1,0 +1,62 @@
+# vite_prefix_env_change_invalidates_cache
+
+`VITE_MODE` is picked up by Vite's patched `loadEnv`, which asks the runner for every `VITE_*` env via `getEnvs(pattern, { tracked: true })`. Flipping its value between runs must invalidate the cache AND change the build output — Vite's `define` plugin substitutes `import.meta.env.VITE_MODE` at build time, so dead-code elimination leaves only the branch matching the value.
+
+## `VITE_MODE=production vt run --cache build`
+
+first run: production build
+
+```
+$ vite build
+```
+
+## `vtt grep-file dist/assets/main.js BUILD_MODE_PROD`
+
+production build: PROD marker survived DCE
+
+```
+dist/assets/main.js: found "BUILD_MODE_PROD"
+```
+
+## `vtt grep-file dist/assets/main.js BUILD_MODE_DEV`
+
+dev branch is gone
+
+```
+dist/assets/main.js: missing "BUILD_MODE_DEV"
+```
+
+## `VITE_MODE=production vt run --cache build`
+
+cache hit: VITE_MODE unchanged
+
+```
+$ vite build ◉ cache hit, replaying
+
+---
+vt run: cache hit.
+```
+
+## `VITE_MODE=development vt run --cache build`
+
+cache miss: envs changed — VITE_MODE value changed
+
+```
+$ vite build ○ cache miss: env 'VITE_MODE' changed, executing
+```
+
+## `vtt grep-file dist/assets/main.js BUILD_MODE_PROD`
+
+PROD marker gone after the dev rebuild
+
+```
+dist/assets/main.js: missing "BUILD_MODE_PROD"
+```
+
+## `vtt grep-file dist/assets/main.js BUILD_MODE_DEV`
+
+DEV marker now in the bundle
+
+```
+dist/assets/main.js: found "BUILD_MODE_DEV"
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/src/main.js
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/src/main.js
@@ -1,0 +1,9 @@
+// `import.meta.env.VITE_MODE` is replaced at build time from the value vite
+// picks up for keys matching `envPrefix` (`VITE_` by default). The markers
+// let the e2e test assert that flipping VITE_MODE actually changed what was
+// built and that glob-tracking invalidates the cache.
+if (import.meta.env.VITE_MODE === 'production') {
+  document.body.append('BUILD_MODE_PROD');
+} else {
+  document.body.append('BUILD_MODE_DEV');
+}

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/src/main.js
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/src/main.js
@@ -1,9 +1,3 @@
-// `import.meta.env.VITE_MODE` is replaced at build time from the value vite
-// picks up for keys matching `envPrefix` (`VITE_` by default). The markers
-// let the e2e test assert that flipping VITE_MODE actually changed what was
-// built and that glob-tracking invalidates the cache.
-if (import.meta.env.VITE_MODE === 'production') {
-  document.body.append('BUILD_MODE_PROD');
-} else {
-  document.body.append('BUILD_MODE_DEV');
-}
+// Vite replaces this at build time from keys matching `envPrefix` (`VITE_` by
+// default), so the e2e can verify that glob-tracked env changes rebuild output.
+console.log(import.meta.env.VITE_CACHE_LABEL);

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/vite-task.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/vite-task.json
@@ -1,0 +1,20 @@
+{
+  "tasks": {
+    "build": {
+      "command": "vite build",
+      // No `"env": [...]` — vite's patched `loadEnv` asks the runner for
+      // every `VITE_*` env via `getEnvs`, so the glob + match-set are
+      // fingerprinted automatically.
+      //
+      // TODO(env-track): A later PR in this stack removes these manual
+      // exclusions once output tracking stops Vite's own writes from becoming
+      // inferred inputs.
+      //
+      // Excluding Vite's build output and config-timestamp temp files from
+      // auto input inference keeps this env-focused fixture cacheable without
+      // turning reads of files Vite just wrote into inferred inputs.
+      "input": ["!dist/**", "!node_modules/.vite-temp/**", { "auto": true }],
+      "cache": true
+    }
+  }
+}

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/vite.config.js
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  logLevel: 'silent',
+  build: {
+    rollupOptions: {
+      output: {
+        // Stable filenames make cache behaviour deterministic across runs.
+        entryFileNames: 'assets/main.js',
+        chunkFileNames: 'assets/chunk.js',
+        assetFileNames: 'assets/[name][extname]',
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Motivation

The focused IPC fixture proves runner env tracking in isolation, but reviewers also need confidence that the real Vite integration exercises `getEnv` for `NODE_ENV` and `getEnvs` for `VITE_*` prefixes. The prefix-env case should use a neutral `VITE_*` variable so it does not read like Vite mode or `NODE_ENV` behavior.

## Scope

Add a minimal Vite build fixture and a local `vtt grep-file` helper. The fixture verifies `NODE_ENV` changes invalidate through `getEnv`, and `VITE_CACHE_LABEL` changes invalidate through Vite's `getEnvs('VITE_*')` path while changing the emitted bundle. The fixture keeps manual input exclusions so this PR remains about env tracking only; it intentionally does not introduce production APIs, playground changes, or output tracking behavior.