### PR TITLE
fix(cache): hash env fingerprint values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- **Changed** Tracked environment values in task cache fingerprints are now stored only as SHA-256 digests, and env-related cache miss details report names without values.
 - **Added** Runner-aware tools can now opt the current task run out of caching through the new IPC channel; Vite dev server integration uses this automatically ([#441](https://github.com/voidzero-dev/vite-task/pull/441))
 - **Fixed** Prefix environment assignments like `PATH=... command` now affect executable lookup during task planning, so tools provided only by the prefixed `PATH` can be resolved correctly ([#440](https://github.com/voidzero-dev/vite-task/pull/440))
 - **Changed** Cache misses caused by a tracked env var now name the env var inline, for example `cache miss: env 'NODE_ENV' changed`, instead of the generic `envs changed` message ([#438](https://github.com/voidzero-dev/vite-task/pull/438))

--- a/crates/vite_task/docs/task-cache.md
+++ b/crates/vite_task/docs/task-cache.md
@@ -109,9 +109,11 @@ pub struct SpawnFingerprint {
 }
 
 pub struct EnvFingerprints {
-    pub fingerprinted_envs: BTreeMap<Str, Arc<str>>,
+    pub fingerprinted_envs: BTreeMap<Str, EnvValueHash>,
     pub untracked_env_config: Arc<[Str]>,
 }
+
+pub struct EnvValueHash([u8; 32]);
 
 enum ProgramFingerprint {
     OutsideWorkspace { program_name: Str },
@@ -132,7 +134,7 @@ The `fingerprinted_envs` field in `EnvFingerprints` is crucial for cache correct
 
 - Only includes env vars explicitly declared in the task's `env` array
 - Does NOT include untracked envs (PATH, CI, etc.)
-- These env vars become part of the cache key
+- These env var names and SHA-256 value hashes become part of the cache key
 
 When a task runs:
 

--- a/crates/vite_task/docs/wildcard-env-patterns.md
+++ b/crates/vite_task/docs/wildcard-env-patterns.md
@@ -105,7 +105,7 @@ The implementation must ensure:
 1. Environment variables are sorted alphabetically before inclusion in fingerprint
 2. The same wildcard pattern always produces the same set of variables (for the same environment)
 3. Cache keys remain stable across runs
-4. **Sensitive values are hashed, never stored in plaintext**
+4. **Fingerprint values are hashed, never stored in plaintext**
 
 **Security-First Fingerprint Implementation:**
 
@@ -114,22 +114,13 @@ use sha2::{Sha256, Digest};
 
 impl TaskEnvs {
     /// Create a secure fingerprint for environment variables
-    pub fn create_fingerprint(&self) -> HashMap<Str, Str> {
+    pub fn create_fingerprint(&self) -> HashMap<Str, [u8; 32]> {
         let mut fingerprint = HashMap::new();
 
         for (name, value) in &self.envs_without_pass_through {
-            let fingerprint_value = if is_sensitive_env_name(name) {
-                // Hash sensitive values - never store them in plaintext
-                let mut hasher = Sha256::new();
-                hasher.update(value.as_bytes());
-                format!("sha256:{:x}", hasher.finalize())
-            } else {
-                // Non-sensitive values can optionally be hashed too for consistency
-                // Or stored as-is if needed for debugging
-                value.clone()
-            };
-
-            fingerprint.insert(name.clone(), fingerprint_value);
+            let mut hasher = Sha256::new();
+            hasher.update(value.as_bytes());
+            fingerprint.insert(name.clone(), hasher.finalize().into());
         }
 
         fingerprint
@@ -141,17 +132,17 @@ impl TaskEnvs {
 pub struct CommandFingerprint {
     pub cwd: Str,
     pub command: TaskCommand,
-    /// Environment variable fingerprints (names + hashed values for sensitive vars)
-    /// NEVER contains actual sensitive values
-    pub envs_fingerprint: HashMap<Str, Str>,
+    /// Environment variable fingerprints (names + hashed values).
+    /// NEVER contains actual env values.
+    pub envs_fingerprint: HashMap<Str, [u8; 32]>,
 }
 ```
 
 **Key Security Principles:**
 
-- Sensitive environment values are ALWAYS hashed before storage
+- Fingerprinted environment values are ALWAYS hashed before storage
 - Use cryptographic hash (SHA-256) for one-way transformation
-- Hash includes a prefix (e.g., "sha256:") to identify the method
+- Persist fixed-size digests in the cache key; use a `sha256:` prefix only in human-readable output
 - Cache entries never contain plaintext secrets
 - Fingerprint comparison still works (same value = same hash)
 
@@ -287,7 +278,7 @@ fn display_env_value(name: &str, value: &str) -> String {
 
 **Principles for Secure Cache Storage:**
 
-1. **Never Store Sensitive Values in Cache**:
+1. **Never Store Env Values in Cache**:
 
    ```rust
    // BAD - Never do this
@@ -298,9 +289,9 @@ fn display_env_value(name: &str, value: &str) -> String {
    ```
 
 2. **Use One-Way Hashing**:
-   - SHA-256 for sensitive values (irreversible)
+   - SHA-256 for every fingerprinted env value (irreversible)
    - Consistent hashing ensures cache hits work correctly
-   - Different secrets produce different hashes
+   - Different values produce different hashes
 
 3. **Cache File Protection**:
    - Store cache files with restricted permissions (0600)
@@ -312,7 +303,7 @@ fn display_env_value(name: &str, value: &str) -> String {
    {
      "task_id": "build_abc123",
      "env_fingerprint": {
-       "NODE_ENV": "production",
+       "NODE_ENV": "sha256:ab8e18ef4ebebeddc0b3152ce9c9006e14fc05242e3fc9ce32246ea6a9543074",
        "API_KEY": "sha256:a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
        "DATABASE_URL": "sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
      },

--- a/crates/vite_task/src/session/cache/display.rs
+++ b/crates/vite_task/src/session/cache/display.rs
@@ -67,27 +67,18 @@ pub fn detect_spawn_fingerprint_changes(
     for (key, old_value) in &old_env.fingerprinted_envs {
         if let Some(new_value) = new_env.fingerprinted_envs.get(key) {
             if old_value != new_value {
-                changes.push(SpawnFingerprintChange::Env(EnvMismatch::Changed {
-                    name: key.clone(),
-                    old_value: Str::from(old_value.as_ref()),
-                    new_value: Str::from(new_value.as_ref()),
-                }));
+                changes
+                    .push(SpawnFingerprintChange::Env(EnvMismatch::Changed { name: key.clone() }));
             }
         } else {
-            changes.push(SpawnFingerprintChange::Env(EnvMismatch::Removed {
-                name: key.clone(),
-                value: Str::from(old_value.as_ref()),
-            }));
+            changes.push(SpawnFingerprintChange::Env(EnvMismatch::Removed { name: key.clone() }));
         }
     }
 
     // Check for added envs
-    for (key, new_value) in &new_env.fingerprinted_envs {
+    for key in new_env.fingerprinted_envs.keys() {
         if !old_env.fingerprinted_envs.contains_key(key) {
-            changes.push(SpawnFingerprintChange::Env(EnvMismatch::Added {
-                name: key.clone(),
-                value: Str::from(new_value.as_ref()),
-            }));
+            changes.push(SpawnFingerprintChange::Env(EnvMismatch::Added { name: key.clone() }));
         }
     }
 
@@ -220,5 +211,34 @@ pub fn format_input_change_str(kind: InputChangeKind, path: &str) -> Str {
                 |dir| vite_str::format!("'{filename}' removed from '{dir}'"),
             )
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_spawn_changes_report_names_only() {
+        let added = SpawnFingerprintChange::Env(EnvMismatch::Added { name: Str::from("MY_ENV") });
+        let removed =
+            SpawnFingerprintChange::Env(EnvMismatch::Removed { name: Str::from("MY_ENV") });
+        let changed =
+            SpawnFingerprintChange::Env(EnvMismatch::Changed { name: Str::from("MY_ENV") });
+
+        assert_eq!(format_spawn_change(&added).as_str(), "env 'MY_ENV' added");
+        assert_eq!(format_spawn_change(&removed).as_str(), "env 'MY_ENV' removed");
+        assert_eq!(format_spawn_change(&changed).as_str(), "env 'MY_ENV' changed");
+    }
+
+    #[test]
+    fn inline_env_change_reason_reports_names_only() {
+        let first = Str::from("API_KEY");
+        let second = Str::from("NODE_ENV");
+
+        assert_eq!(
+            format_env_changed_inline(&[&first, &second]).as_str(),
+            "envs 'API_KEY', 'NODE_ENV' changed"
+        );
     }
 }

--- a/crates/vite_task/src/session/cache/mod.rs
+++ b/crates/vite_task/src/session/cache/mod.rs
@@ -119,7 +119,7 @@ pub struct ExecutionCache {
     conn: Mutex<Connection>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[expect(
     clippy::large_enum_variant,
     reason = "FingerprintMismatch contains SpawnFingerprint which is intentionally large; boxing would add unnecessary indirection for a short-lived enum"
@@ -148,11 +148,11 @@ pub enum InputChangeKind {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EnvMismatch {
     /// Set now, but absent from the stored fingerprint.
-    Added { name: Str, value: Str },
+    Added { name: Str },
     /// In the stored fingerprint, but unset now.
-    Removed { name: Str, value: Str },
+    Removed { name: Str },
     /// Present on both sides with different values.
-    Changed { name: Str, old_value: Str, new_value: Str },
+    Changed { name: Str },
 }
 
 impl EnvMismatch {
@@ -160,9 +160,7 @@ impl EnvMismatch {
     #[must_use]
     pub const fn name(&self) -> &Str {
         match self {
-            Self::Added { name, .. } | Self::Removed { name, .. } | Self::Changed { name, .. } => {
-                name
-            }
+            Self::Added { name } | Self::Removed { name } | Self::Changed { name } => name,
         }
     }
 }
@@ -170,16 +168,14 @@ impl EnvMismatch {
 impl Display for EnvMismatch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Added { name, value } => write!(f, "env {name}={value} added"),
-            Self::Removed { name, value } => write!(f, "env {name}={value} removed"),
-            Self::Changed { name, old_value, new_value } => {
-                write!(f, "env {name} value changed from '{old_value}' to '{new_value}'")
-            }
+            Self::Added { name } => write!(f, "env '{name}' added"),
+            Self::Removed { name } => write!(f, "env '{name}' removed"),
+            Self::Changed { name } => write!(f, "env '{name}' changed"),
         }
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub enum FingerprintMismatch {
     /// Found a previous cache entry key for the same task, but the spawn fingerprint differs.
     /// This happens when the command itself or an env changes.
@@ -234,15 +230,15 @@ pub fn split_path(path: &str) -> (Option<&str>, &str) {
 /// format, or fingerprint semantics) changes in an incompatible way.
 ///
 /// The version is encoded *only* in the cache directory name (see
-/// [`cache_schema_dir_name`], e.g. `v13`); there is no in-database version
+/// [`cache_schema_dir_name`], e.g. `v14`); there is no in-database version
 /// marker. Keying the storage location on this version means Vite+ builds that
 /// pin different schema versions never open each other's database: each keeps
 /// its own cache warm across branch switches, and a cache from a different
 /// version is simply ignored (it lives in a directory this build never looks
 /// at) rather than aborting the run. Bumping the version starts a fresh cache.
-const CACHE_SCHEMA_VERSION: u32 = 13;
+const CACHE_SCHEMA_VERSION: u32 = 14;
 
-/// Name of the per-version subdirectory (e.g. `v13`) under the task-cache
+/// Name of the per-version subdirectory (e.g. `v14`) under the task-cache
 /// directory that holds the database and output archives for the current
 /// [`CACHE_SCHEMA_VERSION`].
 pub fn cache_schema_dir_name() -> Str {

--- a/crates/vite_task_plan/src/cache_metadata.rs
+++ b/crates/vite_task_plan/src/cache_metadata.rs
@@ -1,7 +1,7 @@
 use std::{ffi::OsStr, sync::Arc};
 
 use rustc_hash::FxHashMap;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use vite_path::RelativePathBuf;
 use vite_str::{self, Str};
 use vite_task_graph::config::ResolvedGlobConfig;
@@ -84,7 +84,7 @@ pub struct CacheMetadata {
 /// - The resolver provides envs which become part of the fingerprint
 /// - If resolver provides different envs between runs, cache breaks
 /// - Each built-in task type must have unique task name to avoid cache collision
-#[derive(SchemaWrite, SchemaRead, Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(SchemaWrite, SchemaRead, Debug, Serialize, PartialEq, Eq, Clone)]
 pub struct SpawnFingerprint {
     pub(crate) cwd: RelativePathBuf,
     pub(crate) program_fingerprint: ProgramFingerprint,
@@ -119,7 +119,7 @@ impl SpawnFingerprint {
 }
 
 /// The program fingerprint used in `SpawnFingerprint`
-#[derive(SchemaWrite, SchemaRead, Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(SchemaWrite, SchemaRead, Debug, Serialize, PartialEq, Eq, Clone)]
 pub(crate) enum ProgramFingerprint {
     /// If the program is outside the workspace, fingerprint by its name only (like `node`, `npm`, etc)
     OutsideWorkspace { program_name: Str },

--- a/crates/vite_task_plan/src/envs.rs
+++ b/crates/vite_task_plan/src/envs.rs
@@ -1,57 +1,72 @@
-use std::{collections::BTreeMap, ffi::OsStr, fmt::Write as _, mem::MaybeUninit, sync::Arc};
+use std::{collections::BTreeMap, ffi::OsStr, fmt, sync::Arc};
 
 use rustc_hash::FxHashMap;
-use serde::{Deserialize, Serialize};
+use serde::{Serialize, Serializer};
 use sha2::{Digest as _, Sha256};
 use vite_glob::env::EnvGlobSet;
 use vite_str::Str;
 use vite_task_graph::config::EnvConfig;
-use wincode::{
-    SchemaRead, SchemaWrite,
-    config::Config,
-    error::{ReadResult, WriteResult},
-    io::{Reader, Writer},
-};
+use wincode::{SchemaRead, SchemaWrite};
 
-/// wincode schema adapter for `Arc<str>`, which is a foreign type with unsized inner.
-struct ArcStrSchema;
+const SHA256_DIGEST_LEN: usize = 32;
+const SHA256_PREFIX: &str = "sha256:";
 
-// SAFETY: Delegates to `str`'s SchemaWrite impl, preserving its size/write invariants.
-unsafe impl<C: Config> SchemaWrite<C> for ArcStrSchema {
-    type Src = Arc<str>;
+/// SHA-256 digest of a fingerprinted environment variable value.
+#[derive(SchemaWrite, SchemaRead, PartialEq, Eq, Clone, Copy)]
+pub struct EnvValueHash([u8; SHA256_DIGEST_LEN]);
 
-    fn size_of(src: &Self::Src) -> WriteResult<usize> {
-        <str as SchemaWrite<C>>::size_of(src)
-    }
-
-    fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
-        <str as SchemaWrite<C>>::write(writer, src)
+impl EnvValueHash {
+    #[must_use]
+    pub fn new(value: &str) -> Self {
+        let digest = Sha256::digest(value.as_bytes());
+        let mut bytes = [0; SHA256_DIGEST_LEN];
+        bytes.copy_from_slice(&digest);
+        Self(bytes)
     }
 }
 
-// SAFETY: Delegates to `&str`'s SchemaRead impl; dst is initialized on Ok.
-unsafe impl<'de, C: Config> SchemaRead<'de, C> for ArcStrSchema {
-    type Dst = Arc<str>;
-
-    fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let s: &str = <&str as SchemaRead<'de, C>>::get(&mut reader)?;
-        dst.write(Arc::from(s));
+impl fmt::LowerHex for EnvValueHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
         Ok(())
+    }
+}
+
+impl fmt::Display for EnvValueHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{SHA256_PREFIX}{self:x}")
+    }
+}
+
+impl fmt::Debug for EnvValueHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+// Serialization is only for plan snapshot testing; cache storage uses wincode.
+impl Serialize for EnvValueHash {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(&format_args!("{SHA256_PREFIX}{self:x}"))
     }
 }
 
 /// Environment variable fingerprints for a task execution.
 ///
-/// Contents of this struct are only for fingerprinting and cache key computation (some of envs may be hashed for security).
+/// Contents of this struct are only for fingerprinting and cache key computation.
 /// The actual environment variables to be passed to the execution are in
 /// `SpawnCommand::spawn_envs`.
-#[derive(Debug, SchemaWrite, SchemaRead, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, SchemaWrite, SchemaRead, Serialize, PartialEq, Eq, Clone)]
 pub struct EnvFingerprints {
     /// Environment variables that should be fingerprinted for this execution.
     ///
     /// Use `BTreeMap` to ensure stable order.
-    #[wincode(with = "BTreeMap<Str, ArcStrSchema>")]
-    pub fingerprinted_envs: BTreeMap<Str, Arc<str>>,
+    pub fingerprinted_envs: BTreeMap<Str, EnvValueHash>,
 
     /// Environment variable names that should be passed through without values being fingerprinted.
     ///
@@ -105,10 +120,9 @@ impl EnvFingerprints {
             .or_insert_with(|| Arc::<OsStr>::from(OsStr::new("1")));
 
         // Resolve fingerprinted envs
-        let mut fingerprinted_envs = BTreeMap::<Str, Arc<str>>::new();
+        let mut fingerprinted_envs = BTreeMap::<Str, EnvValueHash>::new();
         if !env_config.fingerprinted_envs.is_empty() {
             let fingerprinted_env_patterns = EnvGlobSet::new(env_config.fingerprinted_envs.iter())?;
-            let sensitive_patterns = EnvGlobSet::new(SENSITIVE_PATTERNS.iter())?;
             for (name, value) in envs.iter() {
                 let Some(name) = name.to_str() else {
                     continue;
@@ -122,25 +136,7 @@ impl EnvFingerprints {
                         value: Arc::clone(value),
                     });
                 };
-                // Hash sensitive env values
-                let value: Arc<str> = if sensitive_patterns.is_match(name) {
-                    let mut hasher = Sha256::new();
-                    hasher.update(value.as_bytes());
-                    let digest = hasher.finalize();
-                    #[expect(
-                        clippy::disallowed_types,
-                        reason = "result is converted to Arc<str>, not Str"
-                    )]
-                    let mut hex = std::string::String::with_capacity(7 + digest.len() * 2);
-                    hex.push_str("sha256:");
-                    for b in digest {
-                        write!(&mut hex, "{b:02x}").unwrap();
-                    }
-                    hex.into()
-                } else {
-                    value.into()
-                };
-                fingerprinted_envs.insert(name.into(), value);
+                fingerprinted_envs.insert(name.into(), EnvValueHash::new(value));
             }
         }
 
@@ -174,29 +170,6 @@ fn resolve_envs_with_patterns<'a>(
     Ok(envs)
 }
 
-const SENSITIVE_PATTERNS: &[&str] = &[
-    "*_KEY",
-    "*_SECRET",
-    "*_TOKEN",
-    "*_PASSWORD",
-    "*_PASS",
-    "*_PWD",
-    "*_CREDENTIAL*",
-    "*_API_KEY",
-    "*_PRIVATE_*",
-    "AWS_*",
-    "GITHUB_*",
-    "NPM_*TOKEN",
-    "DATABASE_URL",
-    "MONGODB_URI",
-    "REDIS_URL",
-    "*_CERT*",
-    // Exact matches for known sensitive names
-    "PASSWORD",
-    "SECRET",
-    "TOKEN",
-];
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -213,6 +186,10 @@ mod tests {
             fingerprinted_envs: fingerprinted.iter().map(|s| Str::from(*s)).collect(),
             untracked_env: untracked.iter().map(|s| Str::from(*s)).collect(),
         }
+    }
+
+    fn hash(value: &str) -> EnvValueHash {
+        EnvValueHash::new(value)
     }
 
     #[test]
@@ -267,10 +244,7 @@ mod tests {
         let result = EnvFingerprints::resolve(&mut envs, &env_config).unwrap();
 
         assert_eq!(envs.get(OsStr::new("FORCE_COLOR")).unwrap().to_str().unwrap(), "3");
-        assert_eq!(
-            result.fingerprinted_envs.get("FORCE_COLOR").map(std::convert::AsRef::as_ref),
-            Some("3")
-        );
+        assert_eq!(result.fingerprinted_envs.get("FORCE_COLOR").copied(), Some(hash("3")));
     }
 
     #[test]
@@ -285,10 +259,7 @@ mod tests {
         let result = EnvFingerprints::resolve(&mut envs, &env_config).unwrap();
 
         assert_eq!(envs.get(OsStr::new("FORCE_COLOR")).unwrap().to_str().unwrap(), "1");
-        assert_eq!(
-            result.fingerprinted_envs.get("FORCE_COLOR").map(std::convert::AsRef::as_ref),
-            Some("1")
-        );
+        assert_eq!(result.fingerprinted_envs.get("FORCE_COLOR").copied(), Some(hash("1")));
     }
 
     #[test]
@@ -347,12 +318,11 @@ mod tests {
         assert!(fingerprinted_envs1.iter().any(|(k, _)| k.as_str() == "APP1_TOKEN"));
         assert!(fingerprinted_envs1.iter().any(|(k, _)| k.as_str() == "APP2_TOKEN"));
 
-        // APP1_PASSWORD should be hashed
+        // All fingerprinted env values should be hashed.
         let password = result1.fingerprinted_envs.get("APP1_PASSWORD").unwrap();
-        assert_eq!(
-            password.as_ref(),
-            "sha256:17f1ef795d5663faa129f6fe3e5335e67ac7a701d1a70533a5f4b1635413a1aa"
-        );
+        assert_eq!(*password, hash("app1_password"));
+        let app_name = result1.fingerprinted_envs.get("APP1_NAME").unwrap();
+        assert_eq!(*app_name, hash("app1_value"));
 
         // Verify untracked envs are present in envs
         assert!(envs1.contains_key(OsStr::new("VSCODE_VAR")));
@@ -385,18 +355,9 @@ mod tests {
             "Unix should treat different cases as different variables"
         );
 
-        assert_eq!(
-            fingerprinted_envs.get("TEST_VAR").map(std::convert::AsRef::as_ref),
-            Some("uppercase")
-        );
-        assert_eq!(
-            fingerprinted_envs.get("test_var").map(std::convert::AsRef::as_ref),
-            Some("lowercase")
-        );
-        assert_eq!(
-            fingerprinted_envs.get("Test_Var").map(std::convert::AsRef::as_ref),
-            Some("mixed")
-        );
+        assert_eq!(fingerprinted_envs.get("TEST_VAR").copied(), Some(hash("uppercase")));
+        assert_eq!(fingerprinted_envs.get("test_var").copied(), Some(hash("lowercase")));
+        assert_eq!(fingerprinted_envs.get("Test_Var").copied(), Some(hash("mixed")));
     }
 
     #[test]
@@ -541,8 +502,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sensitive_env_hashing() {
-        // Test various sensitive patterns
+    fn test_all_fingerprinted_envs_are_hashed() {
         let env_config = create_env_config(
             &["API_KEY", "MY_SECRET", "AUTH_TOKEN", "DB_PASSWORD", "NORMAL_VAR"],
             &[],
@@ -558,14 +518,17 @@ mod tests {
 
         let result = EnvFingerprints::resolve(&mut envs, &env_config).unwrap();
 
-        // Sensitive envs should be hashed
-        assert!(result.fingerprinted_envs.get("API_KEY").unwrap().starts_with("sha256:"));
-        assert!(result.fingerprinted_envs.get("MY_SECRET").unwrap().starts_with("sha256:"));
-        assert!(result.fingerprinted_envs.get("AUTH_TOKEN").unwrap().starts_with("sha256:"));
-        assert!(result.fingerprinted_envs.get("DB_PASSWORD").unwrap().starts_with("sha256:"));
-
-        // Non-sensitive env should NOT be hashed
-        assert_eq!(result.fingerprinted_envs.get("NORMAL_VAR").unwrap().as_ref(), "normal_value");
+        assert_eq!(result.fingerprinted_envs.get("API_KEY").copied(), Some(hash("secret_key_123")));
+        assert_eq!(result.fingerprinted_envs.get("MY_SECRET").copied(), Some(hash("secret_value")));
+        assert_eq!(result.fingerprinted_envs.get("AUTH_TOKEN").copied(), Some(hash("token_abc")));
+        assert_eq!(
+            result.fingerprinted_envs.get("DB_PASSWORD").copied(),
+            Some(hash("password123"))
+        );
+        assert_eq!(
+            result.fingerprinted_envs.get("NORMAL_VAR").copied(),
+            Some(hash("normal_value"))
+        );
     }
 
     #[test]

--- a/crates/vite_task_plan/src/plan.rs
+++ b/crates/vite_task_plan/src/plan.rs
@@ -31,7 +31,7 @@ use crate::{
     ExecutionItem, ExecutionItemDisplay, ExecutionItemKind, LeafExecutionKind, PlanContext,
     SpawnCommand, SpawnExecution, TaskExecution,
     cache_metadata::{CacheMetadata, ExecutionCacheKey, ProgramFingerprint, SpawnFingerprint},
-    envs::EnvFingerprints,
+    envs::{EnvFingerprints, EnvValueHash},
     error::{CdCommandError, Error, PathFingerprintError, PathFingerprintErrorKind, PathType},
     execution_graph::{ExecutionGraph, ExecutionNodeIndex, InnerExecutionGraph},
     in_process::InProcessExecution,
@@ -622,9 +622,11 @@ fn plan_spawn_execution(
                 .map_err(Error::ResolveEnv)?;
 
         // Add prefix envs to fingerprinted envs
-        env_fingerprints
-            .fingerprinted_envs
-            .extend(prefix_envs.iter().map(|(name, value)| (name.clone(), value.as_str().into())));
+        env_fingerprints.fingerprinted_envs.extend(
+            prefix_envs
+                .iter()
+                .map(|(name, value)| (name.clone(), EnvValueHash::new(value.as_str()))),
+        );
 
         let program_fingerprint = match strip_prefix_for_cache(&program_path, workspace_path) {
             Ok(relative_program_path) => {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/additional_env/snapshots/query_tool_synthetic_task_in_user_task.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/additional_env/snapshots/query_tool_synthetic_task_in_user_task.jsonc
@@ -40,7 +40,7 @@
                       ],
                       "env_fingerprints": {
                         "fingerprinted_envs": {
-                          "TEST_VAR": "hello_world"
+                          "TEST_VAR": "sha256:35072c1ae546350e0bfa7ab11d49dc6f129e72ccd57ec7eb671225bbd197c8f1"
                         },
                         "untracked_env_config": [
                           "<default untracked envs>"


### PR DESCRIPTION
## Motivation

Tracked env values currently become part of cache metadata, snapshots, and cache-miss diagnostics. Even when a variable name looks harmless, its value can still contain credentials, hostnames, tokens, or other context we should not persist or echo back. Hashing all tracked values makes the cache safer by default: cache keys still change when env values change, but stored cache data and user-facing miss details no longer reveal the values themselves.

## Summary

- hash every tracked env value in cache fingerprints as a fixed-size SHA-256 digest
- keep spawned process env values raw while making cache miss details name-only
- bump the cache schema directory to v14 and refresh the affected plan snapshot

## 