### PR TITLE
docs: require AI co-author disclosure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ If `gt` (Graphite CLI) is available in PATH, use it instead of `gh` to create pu
 
 PR titles must use [Conventional Commits](https://www.conventionalcommits.org) format: `type(scope): summary` (scope is optional), e.g. `feat(cache): add LRU eviction`, `fix: handle symlink loops`, `test(e2e): add ctrl-c propagation test`.
 
+Commit messages for AI-assisted changes must always include a `Co-authored-by:` trailer that discloses the AI model and version used, e.g. `Co-authored-by: GPT-5 Codex <codex@openai.com>`.
+
 PR descriptions must include a `Motivation` section. If the motivation is not clear from the request or surrounding context, ask the user before creating the PR. Do not add `Validation`, `Test plan`, or similar testing/verification sections.
 
 ## Tests


### PR DESCRIPTION
Motivation

Future AI-assisted changes should disclose the model and version used in commit metadata, so the repository history clearly records AI authorship context.

Co-authored-by: GPT-5 Codex <codex@openai.com>