### PR TITLE
feat(client): add tracked option for env IPC

### DIFF
--- a/crates/vite_task/src/session/execute/cache_update.rs
+++ b/crates/vite_task/src/session/execute/cache_update.rs
@@ -211,17 +211,13 @@ fn collect_tracked_envs(
     let fingerprinted = &metadata.spawn_fingerprint.env_fingerprints().fingerprinted_envs;
     let mut tracked_envs = BTreeMap::new();
 
-    for (name, record) in &reports.env_records {
-        if !record.tracked {
-            continue;
-        }
+    for (name, value) in &reports.tracked_get_env {
         let name_str =
             name.to_str().ok_or_else(|| anyhow::anyhow!("tracked env name is not valid UTF-8"))?;
         if fingerprinted.contains_key(name_str) {
             continue;
         }
-        let value = record
-            .value
+        let value = value
             .as_ref()
             .map(|value| {
                 let value_str = value.to_str().ok_or_else(|| {
@@ -237,16 +233,11 @@ fn collect_tracked_envs(
 }
 
 /// Select tool-reported env-glob records to embed in the post-run
-/// fingerprint. Only `tracked: true` records are included, and the full
-/// match-set is stored as value hashes.
+/// fingerprint. The full match-set is stored as value hashes.
 fn collect_tracked_env_globs(reports: &Reports) -> anyhow::Result<TrackedEnvGlobValues> {
     let mut tracked_env_globs = BTreeMap::new();
 
-    for (pattern, record) in &reports.env_glob_records {
-        if !record.tracked {
-            continue;
-        }
-
+    for (pattern, record) in &reports.tracked_get_envs {
         let mut matches = BTreeMap::new();
         for (name, value) in &record.matches {
             let name_str = name

--- a/crates/vite_task/src/session/execute/cache_update.rs
+++ b/crates/vite_task/src/session/execute/cache_update.rs
@@ -211,13 +211,17 @@ fn collect_tracked_envs(
     let fingerprinted = &metadata.spawn_fingerprint.env_fingerprints().fingerprinted_envs;
     let mut tracked_envs = BTreeMap::new();
 
-    for (name, value) in &reports.env_records {
+    for (name, record) in &reports.env_records {
+        if !record.tracked {
+            continue;
+        }
         let name_str =
             name.to_str().ok_or_else(|| anyhow::anyhow!("tracked env name is not valid UTF-8"))?;
         if fingerprinted.contains_key(name_str) {
             continue;
         }
-        let value = value
+        let value = record
+            .value
             .as_ref()
             .map(|value| {
                 let value_str = value.to_str().ok_or_else(|| {
@@ -233,11 +237,16 @@ fn collect_tracked_envs(
 }
 
 /// Select tool-reported env-glob records to embed in the post-run
-/// fingerprint. The full match-set is stored as value hashes.
+/// fingerprint. Only `tracked: true` records are included, and the full
+/// match-set is stored as value hashes.
 fn collect_tracked_env_globs(reports: &Reports) -> anyhow::Result<TrackedEnvGlobValues> {
     let mut tracked_env_globs = BTreeMap::new();
 
     for (pattern, record) in &reports.env_glob_records {
+        if !record.tracked {
+            continue;
+        }
+
         let mut matches = BTreeMap::new();
         for (name, value) in &record.matches {
             let name_str = name

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/scripts/fetch_env.mjs
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/scripts/fetch_env.mjs
@@ -1,12 +1,14 @@
 import { getEnv } from '@voidzero-dev/vite-task-client';
 
-const names = process.argv.slice(2);
+const args = process.argv.slice(2);
+const tracked = args[0] === '--untracked' ? false : true;
+const names = tracked ? args : args.slice(1);
 
 if (names.length === 0) {
-  throw new Error('usage: fetch_env.mjs <NAME> [...]');
+  throw new Error('usage: fetch_env.mjs [--untracked] <NAME> [...]');
 }
 
-const served = names.map((name) => `${name}=${getEnv(name) ?? '(unset)'}`);
+const served = names.map((name) => `${name}=${getEnv(name, { tracked }) ?? '(unset)'}`);
 const own = names.map((name) => `${name}=${process.env[name] ?? '(unset)'}`);
 
 console.log(`served ${served.join(' ')}`);

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/scripts/fetch_envs.mjs
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/scripts/fetch_envs.mjs
@@ -1,6 +1,7 @@
 import { getEnvs } from '@voidzero-dev/vite-task-client';
 
-const matches = getEnvs('PROBE_*');
+const tracked = process.argv[2] === '--untracked' ? false : true;
+const matches = getEnvs('PROBE_*', { tracked });
 const sorted = Object.entries(matches).sort(([a], [b]) => a.localeCompare(b));
 
 for (const [key, value] of sorted) {

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots.toml
@@ -299,3 +299,73 @@ steps = [
     ],
   ], comment = "non-matching noise: UNRELATED does not match PROBE_* -> cache hit" },
 ]
+
+[[e2e]]
+name = "fetch_env_untracked_does_not_invalidate"
+comment = """
+Exercises `getEnv(name, { tracked: false })`. The runner still serves the env value, but the value does not enter the post-run fingerprint, so changing it later replays the cached output.
+"""
+ignore = true
+steps = [
+  { argv = [
+    "vt",
+    "run",
+    "fetch-env-untracked",
+  ], envs = [
+    [
+      "PROBE_ENV",
+      "first",
+    ],
+  ], comment = "first run serves PROBE_ENV without tracking it" },
+  { argv = [
+    "vt",
+    "run",
+    "fetch-env-untracked",
+  ], envs = [
+    [
+      "PROBE_ENV",
+      "second",
+    ],
+  ], comment = "cache hit: PROBE_ENV changed but was requested with tracked: false" },
+]
+
+[[e2e]]
+name = "fetch_envs_untracked_does_not_invalidate"
+comment = """
+Exercises `getEnvs(pattern, { tracked: false })`. The runner still serves the matching envs, but the match set does not enter the post-run fingerprint, so changing it later replays the cached output.
+"""
+ignore = true
+steps = [
+  { argv = [
+    "vt",
+    "run",
+    "fetch-envs-untracked",
+  ], envs = [
+    [
+      "PROBE_A",
+      "a",
+    ],
+    [
+      "PROBE_B",
+      "b",
+    ],
+  ], comment = "first run serves the PROBE_* match set without tracking it" },
+  { argv = [
+    "vt",
+    "run",
+    "fetch-envs-untracked",
+  ], envs = [
+    [
+      "PROBE_A",
+      "changed",
+    ],
+    [
+      "PROBE_B",
+      "b",
+    ],
+    [
+      "PROBE_C",
+      "c",
+    ],
+  ], comment = "cache hit: changed match set was requested with tracked: false" },
+]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/fetch_env_untracked_does_not_invalidate.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/fetch_env_untracked_does_not_invalidate.md
@@ -1,0 +1,26 @@
+# fetch_env_untracked_does_not_invalidate
+
+Exercises `getEnv(name, { tracked: false })`. The runner still serves the env value, but the value does not enter the post-run fingerprint, so changing it later replays the cached output.
+
+## `PROBE_ENV=first vt run fetch-env-untracked`
+
+first run serves PROBE_ENV without tracking it
+
+```
+$ node scripts/fetch_env.mjs --untracked PROBE_ENV
+served PROBE_ENV=first
+process.env PROBE_ENV=(unset)
+```
+
+## `PROBE_ENV=second vt run fetch-env-untracked`
+
+cache hit: PROBE_ENV changed but was requested with tracked: false
+
+```
+$ node scripts/fetch_env.mjs --untracked PROBE_ENV ◉ cache hit, replaying
+served PROBE_ENV=first
+process.env PROBE_ENV=(unset)
+
+---
+vt run: cache hit.
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/fetch_envs_untracked_does_not_invalidate.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/fetch_envs_untracked_does_not_invalidate.md
@@ -1,0 +1,26 @@
+# fetch_envs_untracked_does_not_invalidate
+
+Exercises `getEnvs(pattern, { tracked: false })`. The runner still serves the matching envs, but the match set does not enter the post-run fingerprint, so changing it later replays the cached output.
+
+## `PROBE_A=a PROBE_B=b vt run fetch-envs-untracked`
+
+first run serves the PROBE_* match set without tracking it
+
+```
+$ node scripts/fetch_envs.mjs --untracked
+PROBE_A=a
+PROBE_B=b
+```
+
+## `PROBE_A=changed PROBE_B=b PROBE_C=c vt run fetch-envs-untracked`
+
+cache hit: changed match set was requested with tracked: false
+
+```
+$ node scripts/fetch_envs.mjs --untracked ◉ cache hit, replaying
+PROBE_A=a
+PROBE_B=b
+
+---
+vt run: cache hit.
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/vite-task.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/vite-task.json
@@ -24,6 +24,14 @@
       "command": "node scripts/fetch_envs.mjs",
       "cache": true
     },
+    "fetch-env-untracked": {
+      "command": "node scripts/fetch_env.mjs --untracked PROBE_ENV",
+      "cache": true
+    },
+    "fetch-envs-untracked": {
+      "command": "node scripts/fetch_envs.mjs --untracked",
+      "cache": true
+    },
     "fetch-prefixed-env": {
       "command": "PREFIXED_ENV=from-command node scripts/fetch_env.mjs PREFIXED_ENV",
       "cache": true

--- a/crates/vite_task_client/src/lib.rs
+++ b/crates/vite_task_client/src/lib.rs
@@ -64,10 +64,10 @@ impl Client {
     /// # Errors
     ///
     /// Returns an error if the request or response fails.
-    pub fn get_env(&self, name: &OsStr) -> io::Result<Option<Arc<OsStr>>> {
+    pub fn get_env(&self, name: &OsStr, tracked: bool) -> io::Result<Option<Arc<OsStr>>> {
         let name = Box::<NativeStr>::from(name);
 
-        self.send(&Request::GetEnv { name: &name })?;
+        self.send(&Request::GetEnv { name: &name, tracked })?;
         let response: GetEnvResponse = self.recv()?;
         Ok(response
             .env_value
@@ -81,8 +81,12 @@ impl Client {
     ///
     /// Returns an error if the request or response fails, or if the server
     /// rejects the pattern as an invalid glob.
-    pub fn get_envs(&self, pattern: &str) -> io::Result<FxHashMap<Arc<OsStr>, Arc<OsStr>>> {
-        self.send(&Request::GetEnvs { pattern })?;
+    pub fn get_envs(
+        &self,
+        pattern: &str,
+        tracked: bool,
+    ) -> io::Result<FxHashMap<Arc<OsStr>, Arc<OsStr>>> {
+        self.send(&Request::GetEnvs { pattern, tracked })?;
         let response: GetEnvsResponse = self.recv()?;
         Ok(response
             .entries

--- a/crates/vite_task_client_napi/src/lib.rs
+++ b/crates/vite_task_client_napi/src/lib.rs
@@ -93,10 +93,11 @@ impl RunnerClient {
     }
 
     #[napi]
-    pub fn get_env(&self, name: String, _options: Option<GetEnvOptions>) -> Result<Option<String>> {
+    pub fn get_env(&self, name: String, options: Option<GetEnvOptions>) -> Result<Option<String>> {
+        let tracked = options.and_then(|o| o.tracked).unwrap_or(true);
         let value = self
             .client
-            .get_env(OsStr::new(&name))
+            .get_env(OsStr::new(&name), tracked)
             .map_err(|err| err_string(vite_str::format!("{err}")))?;
         value.map_or(Ok(None), |value| {
             value.to_str().map(|s| Some(s.to_owned())).ok_or_else(|| {
@@ -109,10 +110,13 @@ impl RunnerClient {
     pub fn get_envs(
         &self,
         pattern: String,
-        _options: Option<GetEnvOptions>,
+        options: Option<GetEnvOptions>,
     ) -> Result<HashMap<String, String>> {
-        let matches =
-            self.client.get_envs(&pattern).map_err(|err| err_string(vite_str::format!("{err}")))?;
+        let tracked = options.and_then(|o| o.tracked).unwrap_or(true);
+        let matches = self
+            .client
+            .get_envs(&pattern, tracked)
+            .map_err(|err| err_string(vite_str::format!("{err}")))?;
         let mut result = HashMap::with_capacity(matches.len());
         for (name, value) in matches {
             let name = name.to_str().ok_or_else(|| {

--- a/crates/vite_task_ipc_shared/src/lib.rs
+++ b/crates/vite_task_ipc_shared/src/lib.rs
@@ -27,8 +27,8 @@ pub const NODE_CLIENT_PATH_ENV_NAME: &str = "VP_RUN_NODE_CLIENT_PATH";
 /// will still consume every buffered frame.
 #[derive(Debug, SchemaWrite, SchemaRead)]
 pub enum Request<'a> {
-    GetEnv { name: &'a NativeStr },
-    GetEnvs { pattern: &'a str },
+    GetEnv { name: &'a NativeStr, tracked: bool },
+    GetEnvs { pattern: &'a str, tracked: bool },
     DisableCache,
 }
 

--- a/crates/vite_task_server/src/lib.rs
+++ b/crates/vite_task_server/src/lib.rs
@@ -14,7 +14,7 @@ use wincode::{SchemaWrite, config::DefaultConfig};
 
 pub trait Handler {
     fn disable_cache(&mut self);
-    fn get_env(&mut self, name: &OsStr) -> Option<Arc<OsStr>>;
+    fn get_env(&mut self, name: &OsStr, tracked: bool) -> Option<Arc<OsStr>>;
     /// Returns the subset of the env map whose names match `pattern` as a glob.
     ///
     /// # Errors
@@ -23,6 +23,7 @@ pub trait Handler {
     fn get_envs(
         &mut self,
         pattern: &str,
+        tracked: bool,
     ) -> Result<FxHashMap<Arc<OsStr>, Arc<OsStr>>, vite_glob::env::EnvGlobError>;
 }
 
@@ -59,19 +60,31 @@ pub struct InvalidGlob {
 /// recover the collected [`Reports`].
 pub struct Recorder {
     cache_disabled: bool,
-    env_records: FxHashMap<Arc<OsStr>, Option<Arc<OsStr>>>,
+    env_records: FxHashMap<Arc<OsStr>, EnvRecord>,
     env_glob_records: FxHashMap<Arc<str>, EnvGlobRecord>,
     /// The envs `get_env` resolves against. The runner supplies these for the
     /// spawned task; the server never re-reads the live process env.
     envs: Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>,
 }
 
+/// A record of an env value requested via `get_env`.
+///
+/// `tracked` is the monotonic OR of every `tracked` flag sent for this name:
+/// once true, it stays true.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnvRecord {
+    pub tracked: bool,
+    pub value: Option<Arc<OsStr>>,
+}
+
 /// A record of a glob-pattern env query made via `get_envs`.
 ///
-/// `matches` is captured on the first call and reused on repeat queries; the server's
-/// env map is immutable for a task's lifetime.
+/// `matches` is captured on the first call and reused on repeat queries; the
+/// server's env map is immutable for a task's lifetime. `tracked` is the
+/// monotonic OR of every `tracked` flag sent for this pattern.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnvGlobRecord {
+    pub tracked: bool,
     pub matches: FxHashMap<Arc<OsStr>, Arc<OsStr>>,
 }
 
@@ -79,7 +92,7 @@ pub struct EnvGlobRecord {
 #[derive(Debug, Default)]
 pub struct Reports {
     pub cache_disabled: bool,
-    pub env_records: FxHashMap<Arc<OsStr>, Option<Arc<OsStr>>>,
+    pub env_records: FxHashMap<Arc<OsStr>, EnvRecord>,
     pub env_glob_records: FxHashMap<Arc<str>, EnvGlobRecord>,
 }
 
@@ -109,12 +122,16 @@ impl Handler for Recorder {
         self.cache_disabled = true;
     }
 
-    fn get_env(&mut self, name: &OsStr) -> Option<Arc<OsStr>> {
+    fn get_env(&mut self, name: &OsStr, tracked: bool) -> Option<Arc<OsStr>> {
         match self.env_records.entry(name.into()) {
-            std::collections::hash_map::Entry::Occupied(entry) => entry.get().clone(),
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                let record = entry.get_mut();
+                record.tracked |= tracked;
+                record.value.clone()
+            }
             std::collections::hash_map::Entry::Vacant(entry) => {
                 let value = self.envs.get(name).cloned();
-                entry.insert(value.clone());
+                entry.insert(EnvRecord { tracked, value: value.clone() });
                 value
             }
         }
@@ -123,8 +140,10 @@ impl Handler for Recorder {
     fn get_envs(
         &mut self,
         pattern: &str,
+        tracked: bool,
     ) -> Result<FxHashMap<Arc<OsStr>, Arc<OsStr>>, vite_glob::env::EnvGlobError> {
-        if let Some(existing) = self.env_glob_records.get(pattern) {
+        if let Some(existing) = self.env_glob_records.get_mut(pattern) {
+            existing.tracked |= tracked;
             return Ok(existing.matches.clone());
         }
         let glob = vite_glob::env::EnvGlob::new(pattern)?;
@@ -141,7 +160,7 @@ impl Handler for Recorder {
             })
             .collect();
         self.env_glob_records
-            .insert(Arc::from(pattern), EnvGlobRecord { matches: matches.clone() });
+            .insert(Arc::from(pattern), EnvGlobRecord { tracked, matches: matches.clone() });
         Ok(matches)
     }
 }
@@ -367,18 +386,19 @@ async fn handle_client<H: Handler>(mut stream: Stream, handler: &RefCell<H>) -> 
             Request::DisableCache => {
                 handler.borrow_mut().disable_cache();
             }
-            Request::GetEnv { name } => {
-                let value = handler.borrow_mut().get_env(name.to_cow_os_str().as_ref());
+            Request::GetEnv { name, tracked } => {
+                let value = handler.borrow_mut().get_env(name.to_cow_os_str().as_ref(), tracked);
                 let response = GetEnvResponse { env_value: value.as_deref().map(Into::into) };
                 write_response(&mut stream, &response).await.map_err(Error::WriteResponse)?;
             }
-            Request::GetEnvs { pattern } => {
-                let matches = handler.borrow_mut().get_envs(pattern).map_err(|source| {
-                    Error::InvalidGlob(Box::new(InvalidGlob {
-                        pattern: Box::<str>::from(pattern),
-                        source,
-                    }))
-                })?;
+            Request::GetEnvs { pattern, tracked } => {
+                let matches =
+                    handler.borrow_mut().get_envs(pattern, tracked).map_err(|source| {
+                        Error::InvalidGlob(Box::new(InvalidGlob {
+                            pattern: Box::<str>::from(pattern),
+                            source,
+                        }))
+                    })?;
                 let response = GetEnvsResponse {
                     entries: matches.iter().map(|(k, v)| ((&**k).into(), (&**v).into())).collect(),
                 };

--- a/crates/vite_task_server/src/lib.rs
+++ b/crates/vite_task_server/src/lib.rs
@@ -53,38 +53,26 @@ pub struct InvalidGlob {
     pub source: vite_glob::env::EnvGlobError,
 }
 
-/// A [`Handler`] that records every report and resolves `get_env` against
-/// provided envs.
+/// A [`Handler`] that records cache-relevant reports and resolves env requests
+/// against provided envs.
 ///
 /// Call [`Recorder::into_reports`] after the driver future completes to
 /// recover the collected [`Reports`].
 pub struct Recorder {
     cache_disabled: bool,
-    env_records: FxHashMap<Arc<OsStr>, EnvRecord>,
-    env_glob_records: FxHashMap<Arc<str>, EnvGlobRecord>,
+    tracked_get_env: FxHashMap<Arc<OsStr>, Option<Arc<OsStr>>>,
+    tracked_get_envs: FxHashMap<Arc<str>, EnvGlobRecord>,
     /// The envs `get_env` resolves against. The runner supplies these for the
     /// spawned task; the server never re-reads the live process env.
     envs: Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>,
 }
 
-/// A record of an env value requested via `get_env`.
-///
-/// `tracked` is the monotonic OR of every `tracked` flag sent for this name:
-/// once true, it stays true.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EnvRecord {
-    pub tracked: bool,
-    pub value: Option<Arc<OsStr>>,
-}
-
-/// A record of a glob-pattern env query made via `get_envs`.
+/// A record of a tracked glob-pattern env query made via `get_envs`.
 ///
 /// `matches` is captured on the first call and reused on repeat queries; the
-/// server's env map is immutable for a task's lifetime. `tracked` is the
-/// monotonic OR of every `tracked` flag sent for this pattern.
+/// server's env map is immutable for a task's lifetime.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnvGlobRecord {
-    pub tracked: bool,
     pub matches: FxHashMap<Arc<OsStr>, Arc<OsStr>>,
 }
 
@@ -92,8 +80,8 @@ pub struct EnvGlobRecord {
 #[derive(Debug, Default)]
 pub struct Reports {
     pub cache_disabled: bool,
-    pub env_records: FxHashMap<Arc<OsStr>, EnvRecord>,
-    pub env_glob_records: FxHashMap<Arc<str>, EnvGlobRecord>,
+    pub tracked_get_env: FxHashMap<Arc<OsStr>, Option<Arc<OsStr>>>,
+    pub tracked_get_envs: FxHashMap<Arc<str>, EnvGlobRecord>,
 }
 
 impl Recorder {
@@ -101,8 +89,8 @@ impl Recorder {
     pub fn new(envs: Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>) -> Self {
         Self {
             cache_disabled: false,
-            env_records: FxHashMap::default(),
-            env_glob_records: FxHashMap::default(),
+            tracked_get_env: FxHashMap::default(),
+            tracked_get_envs: FxHashMap::default(),
             envs,
         }
     }
@@ -111,8 +99,8 @@ impl Recorder {
     pub fn into_reports(self) -> Reports {
         Reports {
             cache_disabled: self.cache_disabled,
-            env_records: self.env_records,
-            env_glob_records: self.env_glob_records,
+            tracked_get_env: self.tracked_get_env,
+            tracked_get_envs: self.tracked_get_envs,
         }
     }
 }
@@ -123,18 +111,11 @@ impl Handler for Recorder {
     }
 
     fn get_env(&mut self, name: &OsStr, tracked: bool) -> Option<Arc<OsStr>> {
-        match self.env_records.entry(name.into()) {
-            std::collections::hash_map::Entry::Occupied(mut entry) => {
-                let record = entry.get_mut();
-                record.tracked |= tracked;
-                record.value.clone()
-            }
-            std::collections::hash_map::Entry::Vacant(entry) => {
-                let value = self.envs.get(name).cloned();
-                entry.insert(EnvRecord { tracked, value: value.clone() });
-                value
-            }
+        let value = self.envs.get(name).cloned();
+        if tracked {
+            self.tracked_get_env.entry(name.into()).or_insert_with(|| value.clone());
         }
+        value
     }
 
     fn get_envs(
@@ -142,8 +123,7 @@ impl Handler for Recorder {
         pattern: &str,
         tracked: bool,
     ) -> Result<FxHashMap<Arc<OsStr>, Arc<OsStr>>, vite_glob::env::EnvGlobError> {
-        if let Some(existing) = self.env_glob_records.get_mut(pattern) {
-            existing.tracked |= tracked;
+        if let Some(existing) = self.tracked_get_envs.get(pattern) {
             return Ok(existing.matches.clone());
         }
         let glob = vite_glob::env::EnvGlob::new(pattern)?;
@@ -159,8 +139,10 @@ impl Handler for Recorder {
                 }
             })
             .collect();
-        self.env_glob_records
-            .insert(Arc::from(pattern), EnvGlobRecord { tracked, matches: matches.clone() });
+        if tracked {
+            self.tracked_get_envs
+                .insert(Arc::from(pattern), EnvGlobRecord { matches: matches.clone() });
+        }
         Ok(matches)
     }
 }

--- a/crates/vite_task_server/tests/integration.rs
+++ b/crates/vite_task_server/tests/integration.rs
@@ -54,7 +54,7 @@ fn connect(envs: &[(&'static OsStr, OsString)]) -> Client {
 /// read sequentially, so once the server answers a `get_env` everything
 /// before it must already have been dispatched to the handler.
 fn flush(client: &Client) {
-    let _ = client.get_env(OsStr::new("__VP_TEST_FLUSH__")).unwrap();
+    let _ = client.get_env(OsStr::new("__VP_TEST_FLUSH__"), false).unwrap();
 }
 
 #[test]
@@ -73,19 +73,38 @@ fn single_client_fire_and_forget() {
 fn get_env_found_and_not_found() {
     let reports = run_with_server(env_map(&[("NODE_ENV", "production")]), |envs| {
         let client = connect(&envs);
-        let present = client.get_env(OsStr::new("NODE_ENV")).unwrap();
+        let present = client.get_env(OsStr::new("NODE_ENV"), true).unwrap();
         assert_eq!(present.as_deref(), Some(OsStr::new("production")));
-        let missing = client.get_env(OsStr::new("MISSING")).unwrap();
+        let missing = client.get_env(OsStr::new("MISSING"), false).unwrap();
         assert!(missing.is_none());
     })
     .expect("driver returned error");
 
     assert!(!reports.cache_disabled);
     let node = reports.env_records.get(OsStr::new("NODE_ENV")).expect("NODE_ENV recorded");
-    assert_eq!(node.as_deref(), Some(OsStr::new("production")));
+    assert!(node.tracked);
+    assert_eq!(node.value.as_deref(), Some(OsStr::new("production")));
 
     let missing = reports.env_records.get(OsStr::new("MISSING")).expect("MISSING recorded");
-    assert!(missing.is_none());
+    assert!(!missing.tracked);
+    assert!(missing.value.is_none());
+}
+
+#[test]
+fn get_env_tracked_upgrade_is_monotonic() {
+    let reports = run_with_server(env_map(&[("NODE_ENV", "production")]), |envs| {
+        let client = connect(&envs);
+        let a = client.get_env(OsStr::new("NODE_ENV"), false).unwrap();
+        let b = client.get_env(OsStr::new("NODE_ENV"), true).unwrap();
+        let c = client.get_env(OsStr::new("NODE_ENV"), false).unwrap();
+        for v in [a, b, c] {
+            assert_eq!(v.as_deref(), Some(OsStr::new("production")));
+        }
+    })
+    .expect("driver returned error");
+
+    let node = reports.env_records.get(OsStr::new("NODE_ENV")).expect("recorded");
+    assert!(node.tracked, "tracked must remain true once set");
 }
 
 #[test]
@@ -96,7 +115,7 @@ fn concurrent_clients() {
                 let envs = envs.clone();
                 thread::spawn(move || {
                     let client = connect(&envs);
-                    let value = client.get_env(OsStr::new("SHARED")).unwrap();
+                    let value = client.get_env(OsStr::new("SHARED"), true).unwrap();
                     assert_eq!(value.as_deref(), Some(OsStr::new("value")));
                 })
             })
@@ -109,7 +128,8 @@ fn concurrent_clients() {
 
     assert!(!reports.cache_disabled);
     let shared = reports.env_records.get(OsStr::new("SHARED")).expect("recorded");
-    assert_eq!(shared.as_deref(), Some(OsStr::new("value")));
+    assert!(shared.tracked);
+    assert_eq!(shared.value.as_deref(), Some(OsStr::new("value")));
 }
 
 #[test]
@@ -118,7 +138,7 @@ fn get_envs_returns_matching_entries() {
         env_map(&[("PROBE_A", "alpha"), ("PROBE_B", "beta"), ("UNRELATED", "noise")]),
         |envs| {
             let client = connect(&envs);
-            let matches = client.get_envs("PROBE_*").unwrap();
+            let matches = client.get_envs("PROBE_*", true).unwrap();
             assert_eq!(matches.len(), 2);
             assert_eq!(
                 matches.get(OsStr::new("PROBE_A")).map(AsRef::as_ref),
@@ -135,6 +155,7 @@ fn get_envs_returns_matching_entries() {
 
     assert!(!reports.cache_disabled);
     let glob = reports.env_glob_records.get("PROBE_*").expect("glob recorded");
+    assert!(glob.tracked);
     assert_eq!(glob.matches.len(), 2);
 }
 
@@ -142,21 +163,39 @@ fn get_envs_returns_matching_entries() {
 fn get_envs_empty_match_set_is_returned() {
     let reports = run_with_server(env_map(&[("FOO", "x"), ("BAR", "y")]), |envs| {
         let client = connect(&envs);
-        let matches = client.get_envs("PROBE_*").unwrap();
+        let matches = client.get_envs("PROBE_*", false).unwrap();
         assert!(matches.is_empty());
     })
     .expect("driver returned error");
 
     assert!(!reports.cache_disabled);
     let glob = reports.env_glob_records.get("PROBE_*").expect("glob recorded");
+    assert!(!glob.tracked);
     assert!(glob.matches.is_empty());
+}
+
+#[test]
+fn get_envs_tracked_upgrade_is_monotonic() {
+    let reports = run_with_server(env_map(&[("PROBE_A", "alpha")]), |envs| {
+        let client = connect(&envs);
+        let first = client.get_envs("PROBE_*", false).unwrap();
+        let second = client.get_envs("PROBE_*", true).unwrap();
+        let third = client.get_envs("PROBE_*", false).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(second, third);
+    })
+    .expect("driver returned error");
+
+    let glob = reports.env_glob_records.get("PROBE_*").expect("glob recorded");
+    assert!(glob.tracked, "tracked must remain true once set");
+    assert_eq!(glob.matches.len(), 1);
 }
 
 #[test]
 fn get_envs_invalid_pattern_surfaces_error() {
     let err = run_with_server(env_map(&[]), |envs| {
         let client = connect(&envs);
-        let send_err = client.get_envs("{unclosed").expect_err("server should reject");
+        let send_err = client.get_envs("{unclosed", true).expect_err("server should reject");
         assert_eq!(send_err.kind(), io::ErrorKind::UnexpectedEof);
     })
     .expect_err("driver should surface the protocol error");

--- a/crates/vite_task_server/tests/integration.rs
+++ b/crates/vite_task_server/tests/integration.rs
@@ -81,17 +81,17 @@ fn get_env_found_and_not_found() {
     .expect("driver returned error");
 
     assert!(!reports.cache_disabled);
-    let node = reports.env_records.get(OsStr::new("NODE_ENV")).expect("NODE_ENV recorded");
-    assert!(node.tracked);
-    assert_eq!(node.value.as_deref(), Some(OsStr::new("production")));
+    let node = reports.tracked_get_env.get(OsStr::new("NODE_ENV")).expect("NODE_ENV recorded");
+    assert_eq!(node.as_deref(), Some(OsStr::new("production")));
 
-    let missing = reports.env_records.get(OsStr::new("MISSING")).expect("MISSING recorded");
-    assert!(!missing.tracked);
-    assert!(missing.value.is_none());
+    assert!(
+        !reports.tracked_get_env.contains_key(OsStr::new("MISSING")),
+        "untracked getEnv calls are not recorded"
+    );
 }
 
 #[test]
-fn get_env_tracked_upgrade_is_monotonic() {
+fn get_env_untracked_then_tracked_records_once() {
     let reports = run_with_server(env_map(&[("NODE_ENV", "production")]), |envs| {
         let client = connect(&envs);
         let a = client.get_env(OsStr::new("NODE_ENV"), false).unwrap();
@@ -103,8 +103,8 @@ fn get_env_tracked_upgrade_is_monotonic() {
     })
     .expect("driver returned error");
 
-    let node = reports.env_records.get(OsStr::new("NODE_ENV")).expect("recorded");
-    assert!(node.tracked, "tracked must remain true once set");
+    let node = reports.tracked_get_env.get(OsStr::new("NODE_ENV")).expect("recorded");
+    assert_eq!(node.as_deref(), Some(OsStr::new("production")));
 }
 
 #[test]
@@ -127,9 +127,8 @@ fn concurrent_clients() {
     .expect("driver returned error");
 
     assert!(!reports.cache_disabled);
-    let shared = reports.env_records.get(OsStr::new("SHARED")).expect("recorded");
-    assert!(shared.tracked);
-    assert_eq!(shared.value.as_deref(), Some(OsStr::new("value")));
+    let shared = reports.tracked_get_env.get(OsStr::new("SHARED")).expect("recorded");
+    assert_eq!(shared.as_deref(), Some(OsStr::new("value")));
 }
 
 #[test]
@@ -154,8 +153,7 @@ fn get_envs_returns_matching_entries() {
     .expect("driver returned error");
 
     assert!(!reports.cache_disabled);
-    let glob = reports.env_glob_records.get("PROBE_*").expect("glob recorded");
-    assert!(glob.tracked);
+    let glob = reports.tracked_get_envs.get("PROBE_*").expect("glob recorded");
     assert_eq!(glob.matches.len(), 2);
 }
 
@@ -169,13 +167,14 @@ fn get_envs_empty_match_set_is_returned() {
     .expect("driver returned error");
 
     assert!(!reports.cache_disabled);
-    let glob = reports.env_glob_records.get("PROBE_*").expect("glob recorded");
-    assert!(!glob.tracked);
-    assert!(glob.matches.is_empty());
+    assert!(
+        !reports.tracked_get_envs.contains_key("PROBE_*"),
+        "untracked getEnvs calls are not recorded"
+    );
 }
 
 #[test]
-fn get_envs_tracked_upgrade_is_monotonic() {
+fn get_envs_untracked_then_tracked_records_once() {
     let reports = run_with_server(env_map(&[("PROBE_A", "alpha")]), |envs| {
         let client = connect(&envs);
         let first = client.get_envs("PROBE_*", false).unwrap();
@@ -186,8 +185,7 @@ fn get_envs_tracked_upgrade_is_monotonic() {
     })
     .expect("driver returned error");
 
-    let glob = reports.env_glob_records.get("PROBE_*").expect("glob recorded");
-    assert!(glob.tracked, "tracked must remain true once set");
+    let glob = reports.tracked_get_envs.get("PROBE_*").expect("glob recorded");
     assert_eq!(glob.matches.len(), 1);
 }
 


### PR DESCRIPTION
## Motivation

Some tools need to ask the runner for env values without making those reads cache dependencies. The default should stay safe, but callers need an explicit opt-out for env reads that only affect diagnostics or optional behavior.

## Scope

Add a `tracked` flag to both `getEnv` and `getEnvs` IPC requests and Rust/Node clients. The option defaults to `true`; `tracked: false` still serves the env value or match set but filters that read out of the post-run cache fingerprint. IPC records keep the tracked flag monotonic so a later tracked read of the same name or pattern wins over an earlier untracked read.

This PR is intentionally placed after the getEnvs fingerprint PR so the opt-out is implemented against both env APIs at once.

## Verification

- `cargo check -p vite_task`
- `cargo test -p vite_task_server --test integration`
- `cargo test -p vite_task_bin --test e2e_snapshots fetch_env_untracked_does_not_invalidate -- --ignored`
- `cargo test -p vite_task_bin --test e2e_snapshots fetch_envs_untracked_does_not_invalidate -- --ignored`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`