### PR TITLE
feat(cache): default outputs to automatic tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - **Added** Runner-aware tools can now call `ignoreInput(path)` to exclude non-semantic reads from auto-inferred task cache inputs.
 - **Added** Runner-aware tools can now call `ignoreOutput(path)` to exclude non-semantic writes from read/write overlap checks.
 - **Added** Cached tasks can opt into automatic output restoration with `output: [{ auto: true }]`.
+- **Changed** Cached tasks now automatically restore written output files when `output` is omitted; use `output: []` to disable output restoration.
 - **Changed** Tracked environment values in task cache fingerprints are now stored only as SHA-256 digests, and env-related cache miss details report names without values.
 - **Added** Runner-aware `getEnvs` match sets can now participate in task cache fingerprints, so changing, adding, or removing a matching env var invalidates the cache ([#450](https://github.com/voidzero-dev/vite-task/pull/450)).
 - **Added** Runner-aware `getEnvs` calls now return env values served by the runner for matching env glob patterns ([#449](https://github.com/voidzero-dev/vite-task/pull/449)).

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots.toml
@@ -233,10 +233,10 @@ steps = [
 [[e2e]]
 name = "fspy_env___not_set_when_auto_inference_disabled"
 comment = """
-When auto-inference is disabled (explicit globs only), the task process should not see `FSPY` set.
+When both input and output auto-inference are disabled, the task process should not see `FSPY` set.
 """
 steps = [
-  # Run task without auto inference - should see (undefined)
+  # Run task without input or output auto inference - should see (undefined)
   ["vt", "run", "check-fspy-env-without-auto"],
 ]
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/fspy_env___not_set_when_auto_inference_disabled.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/snapshots/fspy_env___not_set_when_auto_inference_disabled.md
@@ -1,6 +1,6 @@
 # fspy_env___not_set_when_auto_inference_disabled
 
-When auto-inference is disabled (explicit globs only), the task process should not see `FSPY` set.
+When both input and output auto-inference are disabled, the task process should not see `FSPY` set.
 
 ## `vt run check-fspy-env-without-auto`
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/vite-task.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_cache_test/vite-task.json
@@ -62,6 +62,7 @@
     "check-fspy-env-without-auto": {
       "command": "vtt print-env FSPY",
       "input": ["src/**/*.ts"],
+      "output": [],
       "cache": true
     },
     "folder-input": {

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/packages/normal-pkg/vite-task.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/packages/normal-pkg/vite-task.json
@@ -1,8 +1,7 @@
 {
   "tasks": {
     "task": {
-      "command": "vtt print hello",
-      "output": [{ "auto": true }]
+      "command": "vtt print hello"
     }
   }
 }

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/packages/rw-pkg/vite-task.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/packages/rw-pkg/vite-task.json
@@ -1,8 +1,7 @@
 {
   "tasks": {
     "task": {
-      "command": "vtt replace-file-content src/data.txt i !",
-      "output": [{ "auto": true }]
+      "command": "vtt replace-file-content src/data.txt i !"
     }
   }
 }

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/packages/touch-pkg/vite-task.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/input_read_write_not_cached/packages/touch-pkg/vite-task.json
@@ -1,8 +1,7 @@
 {
   "tasks": {
     "task": {
-      "command": "vtt touch-file src/data.txt",
-      "output": [{ "auto": true }]
+      "command": "vtt touch-file src/data.txt"
     }
   }
 }

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots.toml
@@ -196,6 +196,35 @@ steps = [
 ]
 
 [[e2e]]
+name = "default_auto_output_restores_written_files"
+comment = """
+Exercises the default output behavior. When `output` is omitted, the runner automatically tracks writes, archives the generated file, and restores it on cache hit.
+"""
+ignore = true
+steps = [
+  { argv = [
+    "vt",
+    "run",
+    "auto-output-default",
+  ], comment = "first run writes dist/default.txt and archives fspy-tracked outputs" },
+  { argv = [
+    "vtt",
+    "rm",
+    "dist/default.txt",
+  ], comment = "remove the output so restoration is observable" },
+  { argv = [
+    "vt",
+    "run",
+    "auto-output-default",
+  ], comment = "cache hit: default auto output is restored" },
+  { argv = [
+    "vtt",
+    "print-file",
+    "dist/default.txt",
+  ], comment = "restored from the default auto output archive" },
+]
+
+[[e2e]]
 name = "disable_cache_forces_reexecution"
 comment = """
 Exercises `disableCache`. The tool asks the runner not to cache this run,

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/default_auto_output_restores_written_files.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/snapshots/default_auto_output_restores_written_files.md
@@ -1,0 +1,37 @@
+# default_auto_output_restores_written_files
+
+Exercises the default output behavior. When `output` is omitted, the runner automatically tracks writes, archives the generated file, and restores it on cache hit.
+
+## `vt run auto-output-default`
+
+first run writes dist/default.txt and archives fspy-tracked outputs
+
+```
+$ vtt write-file dist/default.txt ok
+```
+
+## `vtt rm dist/default.txt`
+
+remove the output so restoration is observable
+
+```
+```
+
+## `vt run auto-output-default`
+
+cache hit: default auto output is restored
+
+```
+$ vtt write-file dist/default.txt ok ◉ cache hit, replaying
+
+---
+vt run: cache hit.
+```
+
+## `vtt print-file dist/default.txt`
+
+restored from the default auto output archive
+
+```
+ok
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/vite-task.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/ipc_client_test/vite-task.json
@@ -39,6 +39,11 @@
       "output": [{ "auto": true }, "!scratch/**"],
       "cache": true
     },
+    "auto-output-default": {
+      "command": "vtt write-file dist/default.txt ok",
+      "input": [],
+      "cache": true
+    },
     "disable-cache": {
       "command": "node scripts/disable_cache.mjs",
       "cache": true

--- a/crates/vite_task_graph/run-config.ts
+++ b/crates/vite_task_graph/run-config.ts
@@ -57,9 +57,10 @@ untrackedEnv?: Array<string>,
  */
 input?: Array<string | GlobWithBase | AutoTracking>,
 /**
- * Output files to archive after a successful run and restore on cache hit.
+ * Output files to archive and restore on cache hit.
  *
- * - Omitted or `[]` (empty): no output archiving (default)
+ * - Omitted: automatically tracks which files the task writes
+ * - `[]` (empty): disables output restoration entirely
  * - Glob patterns (e.g. `"dist/**"`) select specific output files, relative to the package directory
  * - `{pattern: "...", base: "workspace" | "package"}` specifies a glob with an explicit base directory
  * - `{auto: true}` enables automatic output tracking

--- a/crates/vite_task_graph/src/config/mod.rs
+++ b/crates/vite_task_graph/src/config/mod.rs
@@ -198,8 +198,8 @@ impl ResolvedGlobConfig {
 
     /// Resolve from user output configuration, making glob patterns workspace-root-relative.
     ///
-    /// Unlike [`Self::from_user_config`], `None` and `Some([])` both produce an
-    /// empty config with `includes_auto = false` (no output archiving).
+    /// Unlike [`Self::from_user_config`], `None` defaults to automatic output
+    /// tracking while `Some([])` disables output archiving.
     ///
     /// # Errors
     ///
@@ -215,7 +215,7 @@ impl ResolvedGlobConfig {
         let mut includes_auto = false;
 
         let Some(entries) = user_outputs else {
-            return Ok(Self { includes_auto: false, positive_globs, negative_globs });
+            return Ok(Self::default_auto());
         };
 
         for entry in entries {

--- a/crates/vite_task_graph/src/config/user.rs
+++ b/crates/vite_task_graph/src/config/user.rs
@@ -145,9 +145,10 @@ pub struct EnabledCacheConfig {
     #[cfg_attr(all(test, not(clippy)), ts(inline))]
     pub input: Option<UserInputsConfig>,
 
-    /// Output files to archive after a successful run and restore on cache hit.
+    /// Output files to archive and restore on cache hit.
     ///
-    /// - Omitted or `[]` (empty): no output archiving (default)
+    /// - Omitted: automatically tracks which files the task writes
+    /// - `[]` (empty): disables output restoration entirely
     /// - Glob patterns (e.g. `"dist/**"`) select specific output files, relative to the package directory
     /// - `{pattern: "...", base: "workspace" | "package"}` specifies a glob with an explicit base directory
     /// - `{auto: true}` enables automatic output tracking

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/additional_env/snapshots/query_tool_synthetic_task_in_user_task.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/additional_env/snapshots/query_tool_synthetic_task_in_user_task.jsonc
@@ -62,7 +62,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/additional_env/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/additional_env/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_enables_script_caching.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_enables_script_caching.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_enables_task_caching_even_when_cache_tasks_is_false.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_enables_task_caching_even_when_cache_tasks_is_false.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_on_task_with_per_task_cache_true_enables_caching.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_on_task_with_per_task_cache_true_enables_caching.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -136,7 +136,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -177,7 +177,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_echo_and_lint_with_extra_args.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_echo_and_lint_with_extra_args.jsonc
@@ -88,7 +88,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_lint_and_echo_with_extra_args.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_lint_and_echo_with_extra_args.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_normal_task_with_extra_args.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_normal_task_with_extra_args.jsonc
@@ -62,7 +62,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_synthetic_task_in_user_task.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_synthetic_task_in_user_task.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_synthetic_task_in_user_task_with_cwd.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_synthetic_task_in_user_task_with_cwd.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_synthetic_task_with_extra_args_in_user_task.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_synthetic_task_with_extra_args_in_user_task.jsonc
@@ -63,7 +63,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -112,7 +112,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -153,7 +153,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_default/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_default/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_enabled/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_enabled/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_task_override/snapshots/query_another_task_cached_by_default.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_task_override/snapshots/query_another_task_cached_by_default.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_task_override/snapshots/query_task_cached_by_default.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_task_override/snapshots/query_task_cached_by_default.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_task_override/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_task_override/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -112,7 +112,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_sharing/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_sharing/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -112,7 +112,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_subcommand/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_subcommand/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_tasks_disabled/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_tasks_disabled/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -112,7 +112,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_true_no_force_enable/snapshots/query_script_cached_when_global_cache_true.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_true_no_force_enable/snapshots/query_script_cached_when_global_cache_true.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_true_no_force_enable/snapshots/query_task_cached_when_global_cache_true.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_true_no_force_enable/snapshots/query_task_cached_when_global_cache_true.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_true_no_force_enable/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_true_no_force_enable/snapshots/task_graph.jsonc
@@ -54,7 +54,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -95,7 +95,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cd_in_scripts/snapshots/query_cd_before_vt_lint_should_put_synthetic_task_under_cwd.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cd_in_scripts/snapshots/query_cd_before_vt_lint_should_put_synthetic_task_under_cwd.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cd_in_scripts/snapshots/query_cd_before_vt_run_should_not_affect_expanded_task_cwd.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cd_in_scripts/snapshots/query_cd_before_vt_run_should_not_affect_expanded_task_cwd.jsonc
@@ -85,7 +85,7 @@
                                     "negative_globs": []
                                   },
                                   "output_config": {
-                                    "includes_auto": false,
+                                    "includes_auto": true,
                                     "positive_globs": [],
                                     "negative_globs": []
                                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cd_in_scripts/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cd_in_scripts/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -112,7 +112,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/comprehensive_task_graph/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/comprehensive_task_graph/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -112,7 +112,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -153,7 +153,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -194,7 +194,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -235,7 +235,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -276,7 +276,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -317,7 +317,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -358,7 +358,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -399,7 +399,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -440,7 +440,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -481,7 +481,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -522,7 +522,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -563,7 +563,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -604,7 +604,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -645,7 +645,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -686,7 +686,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -727,7 +727,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -768,7 +768,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -809,7 +809,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -850,7 +850,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -891,7 +891,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -932,7 +932,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/conflict_test/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/conflict_test/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -112,7 +112,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cycle_dependency/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cycle_dependency/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -76,7 +76,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/dependency_both_topo_and_explicit/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/dependency_both_topo_and_explicit/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -76,7 +76,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/duplicate_package_names/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/duplicate_package_names/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/empty_package_test/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/empty_package_test/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -113,7 +113,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -154,7 +154,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -195,7 +195,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -241,7 +241,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -282,7 +282,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -323,7 +323,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -364,7 +364,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/explicit_deps_workspace/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/explicit_deps_workspace/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -108,7 +108,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -149,7 +149,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -190,7 +190,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -231,7 +231,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -272,7 +272,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -318,7 +318,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -359,7 +359,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -400,7 +400,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -450,7 +450,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/extra_args_not_forwarded_to_depends_on/snapshots/query_extra_args_only_reach_requested_task.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/extra_args_not_forwarded_to_depends_on/snapshots/query_extra_args_only_reach_requested_task.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }
@@ -147,7 +147,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/extra_args_not_forwarded_to_depends_on/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/extra_args_not_forwarded_to_depends_on/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/filter_workspace/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/filter_workspace/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -112,7 +112,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -153,7 +153,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -194,7 +194,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -235,7 +235,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -276,7 +276,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -317,7 +317,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -358,7 +358,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -399,7 +399,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -440,7 +440,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -481,7 +481,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -522,7 +522,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/input_trailing_slash/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/input_trailing_slash/snapshots/task_graph.jsonc
@@ -34,7 +34,7 @@
               ]
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/input_workspace_base/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/input_workspace_base/snapshots/task_graph.jsonc
@@ -35,7 +35,7 @@
               ]
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_nested___cache_enables_inner_task_caching.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_nested___cache_enables_inner_task_caching.jsonc
@@ -85,7 +85,7 @@
                                     "negative_globs": []
                                   },
                                   "output_config": {
-                                    "includes_auto": false,
+                                    "includes_auto": true,
                                     "positive_globs": [],
                                     "negative_globs": []
                                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_outer___cache_propagates_to_nested_run_without_flags.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_outer___cache_propagates_to_nested_run_without_flags.jsonc
@@ -85,7 +85,7 @@
                                     "negative_globs": []
                                   },
                                   "output_config": {
-                                    "includes_auto": false,
+                                    "includes_auto": true,
                                     "positive_globs": [],
                                     "negative_globs": []
                                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_outer___no_cache_does_not_propagate_into_nested___cache.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_outer___no_cache_does_not_propagate_into_nested___cache.jsonc
@@ -85,7 +85,7 @@
                                     "negative_globs": []
                                   },
                                   "output_config": {
-                                    "includes_auto": false,
+                                    "includes_auto": true,
                                     "positive_globs": [],
                                     "negative_globs": []
                                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -112,7 +112,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -153,7 +153,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_tasks/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_tasks/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/package_self_dependency/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/package_self_dependency/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/parallel_and_concurrency/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/parallel_and_concurrency/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -112,7 +112,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -153,7 +153,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -194,7 +194,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/pnpm_workspace_packages_optional/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/pnpm_workspace_packages_optional/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/prefix_env_path_lookup/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/prefix_env_path_lookup/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/recursive_topological_workspace/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/recursive_topological_workspace/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -112,7 +112,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -153,7 +153,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -194,7 +194,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -235,7 +235,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -276,7 +276,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -317,7 +317,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -112,7 +112,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -153,7 +153,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -194,7 +194,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -235,7 +235,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks_disabled/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks_disabled/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -112,7 +112,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks_nested_run/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks_nested_run/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -112,7 +112,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -153,7 +153,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks_task_no_hook/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/script_hooks_task_no_hook/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/shell_fallback/snapshots/query_shell_fallback_for_pipe_command.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/shell_fallback/snapshots/query_shell_fallback_for_pipe_command.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/shell_fallback/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/shell_fallback/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_parent_cache_false_does_not_affect_expanded_query_tasks.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_parent_cache_false_does_not_affect_expanded_query_tasks.jsonc
@@ -85,7 +85,7 @@
                                     "negative_globs": []
                                   },
                                   "output_config": {
-                                    "includes_auto": false,
+                                    "includes_auto": true,
                                     "positive_globs": [],
                                     "negative_globs": []
                                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_script_cache_false_does_not_affect_expanded_synthetic_cache.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_script_cache_false_does_not_affect_expanded_synthetic_cache.jsonc
@@ -85,7 +85,7 @@
                                     "negative_globs": []
                                   },
                                   "output_config": {
-                                    "includes_auto": false,
+                                    "includes_auto": true,
                                     "positive_globs": [],
                                     "negative_globs": []
                                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_task_untrackedEnv_inherited_by_synthetic.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_task_untrackedEnv_inherited_by_synthetic.jsonc
@@ -61,7 +61,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_task_with_cache_true_enables_synthetic_cache.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_task_with_cache_true_enables_synthetic_cache.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -136,7 +136,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -178,7 +178,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -219,7 +219,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_in_subpackage/snapshots/query_synthetic_in_subpackage.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_in_subpackage/snapshots/query_synthetic_in_subpackage.jsonc
@@ -85,7 +85,7 @@
                                     "negative_globs": []
                                   },
                                   "output_config": {
-                                    "includes_auto": false,
+                                    "includes_auto": true,
                                     "positive_globs": [],
                                     "negative_globs": []
                                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_in_subpackage/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_in_subpackage/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_array_cd.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_array_cd.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }
@@ -128,7 +128,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }
@@ -196,7 +196,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_array_shorthand.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_array_shorthand.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }
@@ -128,7 +128,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }
@@ -196,7 +196,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_array_unbalanced_quotes.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_array_unbalanced_quotes.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }
@@ -128,7 +128,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_array_with_and.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_array_with_and.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }
@@ -128,7 +128,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }
@@ -196,7 +196,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_nested_vt_array.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_nested_vt_array.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }
@@ -153,7 +153,7 @@
                                     "negative_globs": []
                                   },
                                   "output_config": {
-                                    "includes_auto": false,
+                                    "includes_auto": true,
                                     "positive_globs": [],
                                     "negative_globs": []
                                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_object_array_depends_on.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_object_array_depends_on.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }
@@ -128,7 +128,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }
@@ -196,7 +196,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }
@@ -285,7 +285,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_string_shorthand.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_string_shorthand.jsonc
@@ -60,7 +60,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/task_graph.jsonc
@@ -32,7 +32,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -75,7 +75,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -117,7 +117,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -159,7 +159,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -201,7 +201,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -244,7 +244,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -290,7 +290,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/transitive_skip_intermediate/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/transitive_skip_intermediate/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -112,7 +112,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/vpr_shorthand/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/vpr_shorthand/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/windows_cmd_shim_rewrite/snapshots/query_dev_filter_from_root.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/windows_cmd_shim_rewrite/snapshots/query_dev_filter_from_root.jsonc
@@ -66,7 +66,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/windows_cmd_shim_rewrite/snapshots/query_dev_in_subpackage.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/windows_cmd_shim_rewrite/snapshots/query_dev_in_subpackage.jsonc
@@ -66,7 +66,7 @@
                       "negative_globs": []
                     },
                     "output_config": {
-                      "includes_auto": false,
+                      "includes_auto": true,
                       "positive_globs": [],
                       "negative_globs": []
                     }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/windows_cmd_shim_rewrite/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/windows_cmd_shim_rewrite/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/workspace_root_cd_no_skip/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/workspace_root_cd_no_skip/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/workspace_root_depends_on_passthrough/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/workspace_root_depends_on_passthrough/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -76,7 +76,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -117,7 +117,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -158,7 +158,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/workspace_root_multi_command/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/workspace_root_multi_command/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/workspace_root_mutual_recursion/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/workspace_root_mutual_recursion/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -112,7 +112,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -153,7 +153,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/workspace_root_no_package_json/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/workspace_root_no_package_json/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/workspace_root_self_reference/snapshots/task_graph.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/workspace_root_self_reference/snapshots/task_graph.jsonc
@@ -30,7 +30,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -71,7 +71,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }
@@ -112,7 +112,7 @@
               "negative_globs": []
             },
             "output_config": {
-              "includes_auto": false,
+              "includes_auto": true,
               "positive_globs": [],
               "negative_globs": []
             }


### PR DESCRIPTION
## Motivation

Automatic output restoration should be the default for cached tasks so users do not need to manually list generated files in every package.

## Scope

Change omitted `output` to mean automatic output tracking, while preserving `output: []` as the opt-out that disables restoration. Update the generated plan snapshots for the default semantic change and add an e2e proving an omitted `output` field restores a written file on cache hit.