### PR TITLE
test(e2e): verify Vite auto output restoration

### DIFF
--- a/crates/vite_task_bin/src/vtt/main.rs
+++ b/crates/vite_task_bin/src/vtt/main.rs
@@ -23,6 +23,7 @@ mod print_file;
 mod read_stdin;
 mod replace_file_content;
 mod rm;
+mod stat_file;
 mod touch_file;
 mod write_file;
 
@@ -31,7 +32,7 @@ fn main() {
     if args.len() < 2 {
         eprintln!("Usage: vtt <subcommand> [args...]");
         eprintln!(
-            "Subcommands: barrier, check-tty, cp, exit, exit-on-ctrlc, grep-file, list-dir, mkdir, pipe-stdin, print, print-color, print-cwd, print-env, print-file, read-stdin, replace-file-content, rm, touch-file, write-file"
+            "Subcommands: barrier, check-tty, cp, exit, exit-on-ctrlc, grep-file, list-dir, mkdir, pipe-stdin, print, print-color, print-cwd, print-env, print-file, read-stdin, replace-file-content, rm, stat-file, touch-file, write-file"
         );
         std::process::exit(1);
     }
@@ -63,6 +64,10 @@ fn main() {
         "read-stdin" => read_stdin::run(),
         "replace-file-content" => replace_file_content::run(&args[2..]),
         "rm" => rm::run(&args[2..]),
+        "stat-file" => {
+            stat_file::run(&args[2..]);
+            Ok(())
+        }
         "touch-file" => touch_file::run(&args[2..]),
         "write-file" => write_file::run(&args[2..]),
         other => {

--- a/crates/vite_task_bin/src/vtt/stat_file.rs
+++ b/crates/vite_task_bin/src/vtt/stat_file.rs
@@ -1,0 +1,9 @@
+pub fn run(args: &[String]) {
+    for file in args {
+        if std::fs::metadata(file).is_ok() {
+            println!("{file}: exists");
+        } else {
+            println!("{file}: missing");
+        }
+    }
+}

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/snapshots.toml
@@ -1,4 +1,40 @@
 [[e2e]]
+name = "vite_build_caches_and_restores_outputs"
+comment = """
+`vt run --cache build` must produce a cache hit on the second run without any manual input/output configuration. Vite reports non-semantic reads and writes through `@voidzero-dev/vite-task-client`, so fspy can infer real inputs and outputs while the cache restores `dist/` on hit.
+"""
+ignore = true
+steps = [
+  { argv = [
+    "vt",
+    "run",
+    "--cache",
+    "build",
+  ], comment = "first run: cache miss, emits dist/" },
+  { argv = [
+    "vtt",
+    "stat-file",
+    "dist/assets/main.js",
+  ], comment = "existence check — content can drift across Vite versions" },
+  { argv = [
+    "vtt",
+    "rm",
+    "dist/assets/main.js",
+  ], comment = "remove the artefact so the cache-hit restore is observable" },
+  { argv = [
+    "vt",
+    "run",
+    "--cache",
+    "build",
+  ], comment = "cache hit: outputs restored without manual config" },
+  { argv = [
+    "vtt",
+    "stat-file",
+    "dist/assets/main.js",
+  ], comment = "restored from the cache archive" },
+]
+
+[[e2e]]
 name = "vite_prefix_env_change_invalidates_cache"
 comment = """
 `VITE_CACHE_LABEL` is picked up by Vite's patched `loadEnv`, which asks the runner for every `VITE_*` env via `getEnvs(pattern, { tracked: true })`. Flipping its value between runs must invalidate the cache AND change the build output because Vite substitutes `import.meta.env.VITE_CACHE_LABEL` at build time.

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/snapshots/vite_build_caches_and_restores_outputs.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/snapshots/vite_build_caches_and_restores_outputs.md
@@ -1,0 +1,45 @@
+# vite_build_caches_and_restores_outputs
+
+`vt run --cache build` must produce a cache hit on the second run without any manual input/output configuration. Vite reports non-semantic reads and writes through `@voidzero-dev/vite-task-client`, so fspy can infer real inputs and outputs while the cache restores `dist/` on hit.
+
+## `vt run --cache build`
+
+first run: cache miss, emits dist/
+
+```
+$ vite build
+```
+
+## `vtt stat-file dist/assets/main.js`
+
+existence check — content can drift across Vite versions
+
+```
+dist/assets/main.js: exists
+```
+
+## `vtt rm dist/assets/main.js`
+
+remove the artefact so the cache-hit restore is observable
+
+```
+```
+
+## `vt run --cache build`
+
+cache hit: outputs restored without manual config
+
+```
+$ vite build ◉ cache hit, replaying
+
+---
+vt run: cache hit.
+```
+
+## `vtt stat-file dist/assets/main.js`
+
+restored from the cache archive
+
+```
+dist/assets/main.js: exists
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/vite-task.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vite_build_cache/vite-task.json
@@ -5,15 +5,6 @@
       // No `"env": [...]` — vite's patched `loadEnv` asks the runner for
       // every `VITE_*` env via `getEnvs`, so the glob + match-set are
       // fingerprinted automatically.
-      //
-      // TODO(env-track): A later PR in this stack removes these manual
-      // exclusions once output tracking stops Vite's own writes from becoming
-      // inferred inputs.
-      //
-      // Excluding Vite's build output and config-timestamp temp files from
-      // auto input inference keeps this env-focused fixture cacheable without
-      // turning reads of files Vite just wrote into inferred inputs.
-      "input": ["!dist/**", "!node_modules/.vite-temp/**", { "auto": true }],
       "cache": true
     }
   }


### PR DESCRIPTION
## Motivation

The lower stack slices prove the runner behavior with focused fixtures, but reviewers also need a real Vite build fixture showing the integration no longer needs manual input/output exclusions.

## Scope

Remove the temporary manual exclusions from the Vite build fixture, add a `vtt stat-file` helper for stable existence checks, and add an e2e proving `vite build` hits the cache and restores `dist/assets/main.js` through automatic output tracking.