### PR TITLE
refactor(path): normalize AbsolutePath strip_prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,13 +1354,13 @@ dependencies = [
  "bytemuck",
  "ctor",
  "native_str",
- "os_str_bytes",
  "rustc-hash",
  "shared_memory",
  "subprocess_test",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
+ "vite_path",
  "winapi",
  "wincode",
 ]
@@ -4182,6 +4182,7 @@ version = "0.1.0"
 dependencies = [
  "assert2",
  "diff-struct",
+ "os_str_bytes",
  "path-clean",
  "ref-cast",
  "serde",

--- a/crates/fspy_shared/Cargo.toml
+++ b/crates/fspy_shared/Cargo.toml
@@ -16,10 +16,10 @@ shared_memory = { workspace = true, features = ["logging"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
+vite_path = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 bytemuck = { workspace = true }
-os_str_bytes = { workspace = true }
 winapi = { workspace = true, features = ["std"] }
 
 [dev-dependencies]

--- a/crates/fspy_shared/src/ipc/native_path.rs
+++ b/crates/fspy_shared/src/ipc/native_path.rs
@@ -1,7 +1,8 @@
 #[cfg(unix)]
+use std::ffi::OsStr;
+#[cfg(unix)]
 use std::os::unix::ffi::OsStrExt as _;
 use std::{
-    ffi::OsStr,
     fmt::Debug,
     mem::MaybeUninit,
     path::{Path, StripPrefixError},
@@ -70,41 +71,8 @@ impl NativePath {
         base: P,
         f: F,
     ) -> R {
-        /// Strip the `\\?\`, `\\.\`, `\??\` prefix from a Windows path, if present.
-        /// Does nothing on non-Windows platforms.
-        ///
-        /// \\?\ and \\.\ are used to enable long paths and access to device paths.
-        /// \??\ is used in Nt* calls.
-        /// The resulting path is not necessarily valid or points to the same location,
-        /// but it's good enough for sanitizing paths in `NativePath::strip_path_prefix`.
-        #[cfg_attr(
-            not(windows),
-            expect(
-                clippy::missing_const_for_fn,
-                reason = "uses non-const for loop and strip_prefix on Windows"
-            )
-        )]
-        fn strip_windows_path_prefix(p: &OsStr) -> &OsStr {
-            #[cfg(windows)]
-            {
-                use os_str_bytes::OsStrBytesExt as _;
-                for prefix in [r"\\?\", r"\\.\", r"\??\"] {
-                    if let Some(stripped) = p.strip_prefix(prefix) {
-                        return stripped;
-                    }
-                }
-                p
-            }
-            #[cfg(not(windows))]
-            {
-                p
-            }
-        }
-
         let me = self.inner.to_cow_os_str();
-        let me = strip_windows_path_prefix(&me);
-        let base = strip_windows_path_prefix(base.as_ref().as_os_str());
-        f(Path::new(me).strip_prefix(base))
+        f(vite_path::strip_path_prefix(&me, base.as_ref().as_os_str()))
     }
 }
 

--- a/crates/vite_path/Cargo.toml
+++ b/crates/vite_path/Cargo.toml
@@ -17,6 +17,9 @@ thiserror = { workspace = true }
 ts-rs = { workspace = true, optional = true }
 vite_str = { workspace = true }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+os_str_bytes = { workspace = true }
+
 [features]
 absolute-redaction = []
 ts-rs = ["dep:ts-rs", "vite_str/ts-rs"]

--- a/crates/vite_path/src/absolute/mod.rs
+++ b/crates/vite_path/src/absolute/mod.rs
@@ -148,6 +148,11 @@ impl AbsolutePath {
 
     /// Returns a path that, when joined onto base, yields self.
     ///
+    /// On Windows, path namespace prefixes (`\\?\`, `\\.\`, and `\??\`) are
+    /// ignored before matching. In that case the returned path round-trips
+    /// against the prefix-normalized paths rather than necessarily preserving
+    /// the original namespace prefix.
+    ///
     /// If `base` is not a prefix of `self`, returns [`None`].
     ///
     /// If the stripped path is not a valid `RelativePath`. Returns an error with the reason and the stripped path.
@@ -160,7 +165,9 @@ impl AbsolutePath {
         base: P,
     ) -> Result<Option<RelativePathBuf>, StripPrefixError<'_>> {
         let base = base.as_ref();
-        let Ok(stripped_path) = self.0.strip_prefix(&base.0) else {
+        let Ok(stripped_path) =
+            crate::strip_path_prefix(self.as_path().as_os_str(), base.as_path().as_os_str())
+        else {
             return Ok(None);
         };
         match RelativePathBuf::new(stripped_path) {
@@ -395,6 +402,17 @@ mod tests {
 
         let rel_path = abs_path.strip_prefix(prefix).unwrap();
         assert!(rel_path.is_none());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn strip_prefix_ignores_windows_namespace_prefixes() {
+        let abs_path = AbsolutePath::new(Path::new(r"\\?\C:\Users\foo\bar")).unwrap();
+        let prefix = AbsolutePath::new(Path::new(r"C:\Users")).unwrap();
+
+        let rel_path = abs_path.strip_prefix(prefix).unwrap().unwrap();
+
+        assert_eq!(rel_path.as_str(), "foo/bar");
     }
 
     #[cfg(unix)]

--- a/crates/vite_path/src/lib.rs
+++ b/crates/vite_path/src/lib.rs
@@ -3,7 +3,11 @@
 pub mod absolute;
 pub mod relative;
 
-use std::io;
+use std::{
+    ffi::OsStr,
+    io,
+    path::{Path, StripPrefixError},
+};
 
 #[cfg(feature = "absolute-redaction")]
 pub use absolute::redaction;
@@ -30,4 +34,94 @@ pub fn current_dir() -> io::Result<AbsolutePathBuf> {
     // `std::env::current_dir` should always return a absolute path but its documentation doesn't guarantee that.
     // Do a runtime check just in case.
     Ok(AbsolutePathBuf::new(cwd).unwrap())
+}
+
+/// Strips `base` from `path`, after normalizing Windows path namespace prefixes.
+///
+/// On Windows, the `\\?\`, `\\.\`, and `\??\` prefixes are ignored before
+/// matching. On other platforms this is equivalent to [`Path::strip_prefix`].
+///
+/// This is purely lexical and does not access the filesystem.
+///
+/// # Errors
+///
+/// Returns an error if `base` is not a path prefix of `path` after applying the
+/// platform-specific prefix normalization above.
+pub fn strip_path_prefix<'a>(path: &'a OsStr, base: &OsStr) -> Result<&'a Path, StripPrefixError> {
+    let path = strip_windows_path_prefix(path);
+    let base = strip_windows_path_prefix(base);
+    Path::new(path).strip_prefix(base)
+}
+
+/// Strip the `\\?\`, `\\.\`, `\??\` prefix from a Windows path, if present.
+/// Does nothing on non-Windows platforms.
+///
+/// `\\?\` and `\\.\` are used to enable long paths and access to device paths.
+/// `\??\` is used in Nt* calls.
+/// The resulting path is not necessarily valid or points to the same location,
+/// but it is enough for lexical path-prefix comparisons.
+#[cfg_attr(
+    not(windows),
+    expect(
+        clippy::missing_const_for_fn,
+        reason = "uses non-const for loop and strip_prefix on Windows"
+    )
+)]
+fn strip_windows_path_prefix(p: &OsStr) -> &OsStr {
+    #[cfg(windows)]
+    {
+        use os_str_bytes::OsStrBytesExt as _;
+
+        for prefix in [r"\\?\", r"\\.\", r"\??\"] {
+            if let Some(stripped) = p.strip_prefix(prefix) {
+                return stripped;
+            }
+        }
+        p
+    }
+    #[cfg(not(windows))]
+    {
+        p
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+
+    use super::*;
+
+    #[test]
+    fn strip_path_prefix_strips_base() {
+        let path =
+            OsStr::new(if cfg!(windows) { r"C:\repo\pkg\file.txt" } else { "/repo/pkg/file.txt" });
+        let base = OsStr::new(if cfg!(windows) { r"C:\repo" } else { "/repo" });
+
+        let stripped = strip_path_prefix(path, base).unwrap();
+
+        assert_eq!(
+            stripped,
+            Path::new(if cfg!(windows) { r"pkg\file.txt" } else { "pkg/file.txt" })
+        );
+    }
+
+    #[test]
+    fn strip_path_prefix_reports_mismatch() {
+        let path =
+            OsStr::new(if cfg!(windows) { r"C:\repo\pkg\file.txt" } else { "/repo/pkg/file.txt" });
+        let base = OsStr::new(if cfg!(windows) { r"C:\other" } else { "/other" });
+
+        assert!(strip_path_prefix(path, base).is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn strip_path_prefix_ignores_windows_namespace_prefixes() {
+        let path = OsStr::new(r"\??\C:\repo\pkg\file.txt");
+        let base = OsStr::new(r"\\?\C:\repo");
+
+        let stripped = strip_path_prefix(path, base).unwrap();
+
+        assert_eq!(stripped, Path::new(r"pkg\file.txt"));
+    }
 }


### PR DESCRIPTION
## Motivation

The auto-output stack needs to compare runner-reported absolute paths with fspy paths even when Windows namespace prefixes differ. Keeping that OsStr-based prefix handling in fspy made the cache update fix duplicate platform-specific code.

This PR moves the shared prefix stripping into `vite_path` and folds that normalization into `AbsolutePath::strip_prefix`, so existing absolute-path prefix stripping handles Windows namespace prefixes consistently without adding a parallel `AbsolutePath` API.
