### PR TITLE
chore: bump vite-task-client to 0.2.0

### DIFF
--- a/packages/vite-task-client/package.json
+++ b/packages/vite-task-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voidzero-dev/vite-task-client",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Hand the Vite+ task runner (vp run) precise cache-correctness information from inside your tool.",
   "keywords": [
     "cache",


### PR DESCRIPTION
## Motivation

Release `@voidzero-dev/vite-task-client` 0.2.0 so the newly merged `getEnvs({ prefix: "..." }, ...)` support is available from npm as a backwards-compatible minor feature. Merging this to `main` triggers `release-vite-task-client.yml`, which detects that the package version is newer than npm `latest` and publishes with trusted OIDC provenance from GitHub Actions.