### PR TITLE
fix: clarify task process wait errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- **Fixed** Failures while waiting for a started task process to exit no longer incorrectly say the process failed to spawn ([#515](https://github.com/voidzero-dev/vite-task/pull/515)).
 - **Fixed** Missing env vars requested through `@voidzero-dev/vite-task-client` now return `undefined` instead of `null`, preserving Vite production `NODE_ENV` semantics when builds run through `vp run` ([#508](https://github.com/voidzero-dev/vite-task/pull/508)).
 - **Fixed** Windows builds no longer hang on CI when a `node_modules/.bin` `.cmd` shim is routed through PowerShell: the npm/pnpm/yarn `.ps1` wrappers read stdin and block forever on a non-TTY pipe, so the PowerShell rewrite is now skipped when stdin is not an interactive terminal, falling back to the `.cmd` (which never reads stdin) ([#491](https://github.com/voidzero-dev/vite-task/pull/491)).
 - **Added** First-party support for caching `vite build` with zero cache config, giving Vite projects correct cache hits out of the box ([vitejs/vite#22453](https://github.com/vitejs/vite/pull/22453)).

--- a/crates/vite_task/src/session/event.rs
+++ b/crates/vite_task/src/session/event.rs
@@ -41,6 +41,10 @@ pub enum ExecutionError {
     #[error("Failed to spawn process")]
     Spawn(#[source] anyhow::Error),
 
+    /// The child process started, but the runner failed while waiting for it to exit.
+    #[error("Failed to wait for task process to exit")]
+    WaitForTaskProcessExit(#[source] anyhow::Error),
+
     /// Creating the post-run fingerprint failed after successful execution.
     #[error("Failed to create post-run fingerprint")]
     PostRunFingerprint(#[source] anyhow::Error),

--- a/crates/vite_task/src/session/execute/mod.rs
+++ b/crates/vite_task/src/session/execute/mod.rs
@@ -446,7 +446,7 @@ async fn run(
         let child_work = Box::pin(run_child(child, sinks, None, fast_fail_token.clone()));
         (child_work.await, None)
     };
-    let outcome = wait_result.map_err(|err| Report::failed(ExecutionError::Spawn(err)))?;
+    let outcome = wait_result.map_err(Report::failed)?;
     let duration = start.elapsed();
 
     // Extract reports, or short-circuit when the IPC server failed. An Err
@@ -580,18 +580,17 @@ fn replay_cache_hit(
     Report::CacheHit
 }
 
-/// Phase 6: drain the child's pipes (if piped) and wait for exit, with a
-/// single error sink — a pipe failure cancels (so the wait kills the child
-/// instead of orphaning it) and surfaces through the same returned result as
-/// a wait failure. After the child exits (on every path), `stop_accepting`
-/// is signalled so the IPC server stops accepting and starts draining.
+/// Phase 6: drain the child's pipes (if piped) and wait for exit. A pipe
+/// failure cancels the child so the wait future kills it instead of orphaning
+/// it. After the child exits (on every path), `stop_accepting` is signalled so
+/// the IPC server stops accepting and starts draining.
 async fn run_child(
     mut child: ChildHandle,
     sinks: Option<PipeSinks<'_>>,
     stop_accepting: Option<&StopAccepting>,
     fast_fail_token: CancellationToken,
-) -> anyhow::Result<ChildOutcome> {
-    let pipe_result: anyhow::Result<()> = if let Some(sinks) = sinks {
+) -> Result<ChildOutcome, ExecutionError> {
+    let pipe_result: Result<(), ExecutionError> = if let Some(sinks) = sinks {
         let stdout = child.stdout.take().expect("SpawnStdio::Piped yields a stdout pipe");
         let stderr = child.stderr.take().expect("SpawnStdio::Piped yields a stderr pipe");
         #[expect(
@@ -599,13 +598,15 @@ async fn run_child(
             reason = "pipe_stdio streams child I/O and creates a large future"
         )]
         let r = pipe_stdio(stdout, stderr, sinks, fast_fail_token.clone()).await;
-        r.map_err(anyhow::Error::from)
+        r.map_err(|err| ExecutionError::Spawn(err.into()))
     } else {
         Ok(())
     };
 
     let wait_result = match pipe_result {
-        Ok(()) => child.wait.await.map_err(anyhow::Error::from),
+        Ok(()) => {
+            child.wait.await.map_err(|err| ExecutionError::WaitForTaskProcessExit(err.into()))
+        }
         Err(err) => {
             // Pipe failed — cancel so `child.wait` kills the child instead of
             // orphaning it. Still signal the server below so it can drain.

--- a/crates/vite_task/src/session/reporter/summary.rs
+++ b/crates/vite_task/src/session/reporter/summary.rs
@@ -152,6 +152,7 @@ pub enum SavedCacheMissReason {
 pub enum SavedExecutionError {
     Cache { kind: SavedCacheErrorKind, message: Str },
     Spawn { message: Str },
+    WaitForTaskProcessExit { message: Str },
     PostRunFingerprint { message: Str },
     IpcServerBind { message: Str },
 }
@@ -238,6 +239,9 @@ impl SavedExecutionError {
             ExecutionError::Spawn(source) => {
                 Self::Spawn { message: vite_str::format!("{source:#}") }
             }
+            ExecutionError::WaitForTaskProcessExit(source) => {
+                Self::WaitForTaskProcessExit { message: vite_str::format!("{source:#}") }
+            }
             ExecutionError::PostRunFingerprint(source) => {
                 Self::PostRunFingerprint { message: vite_str::format!("{source:#}") }
             }
@@ -259,6 +263,9 @@ impl SavedExecutionError {
             }
             Self::Spawn { message } => {
                 vite_str::format!("Failed to spawn process: {message}")
+            }
+            Self::WaitForTaskProcessExit { message } => {
+                vite_str::format!("Failed to wait for task process to exit: {message}")
             }
             Self::PostRunFingerprint { message } => {
                 vite_str::format!("Failed to create post-run fingerprint: {message}")


### PR DESCRIPTION
Motivation

The original spawn error was inaccurate and vague, making the failure in https://github.com/voidzero-dev/vite-task/issues/506 confusing to investigate. The task had already started; the runner failed while waiting for the task process to exit, so the message should describe that lifecycle point.

Changes

- Report wait failures as `Failed to wait for task process to exit`.
- Preserve `Failed to spawn process` for actual spawn/start and pipe failures.