### PR TITLE
feat(pty): expose child pid on ChildHandle for process-group reaping

### DIFF
--- a/crates/pty_terminal/src/terminal.rs
+++ b/crates/pty_terminal/src/terminal.rs
@@ -35,6 +35,10 @@ pub struct PtyWriter {
 pub struct ChildHandle {
     child_killer: Box<dyn ChildKiller + Send + Sync>,
     exit_status: Arc<OnceLock<ChildWaitResult>>,
+    /// The child's process id, captured at spawn. The child is a session (and
+    /// thus process-group) leader (portable-pty `setsid`s it), so callers can
+    /// signal its whole group to reap grandchildren it left behind.
+    pid: Option<u32>,
 }
 
 impl Clone for ChildHandle {
@@ -42,6 +46,7 @@ impl Clone for ChildHandle {
         Self {
             child_killer: self.child_killer.clone_killer(),
             exit_status: Arc::clone(&self.exit_status),
+            pid: self.pid,
         }
     }
 }
@@ -295,6 +300,16 @@ impl ChildHandle {
         self.child_killer.kill()?;
         Ok(())
     }
+
+    /// The child's process id, or `None` if it was unavailable at spawn.
+    ///
+    /// The child is a session/process-group leader, so `kill(-pid, …)` on Unix
+    /// signals the whole group — useful for reaping grandchildren that inherited
+    /// the PTY slave fd and would otherwise keep the master from reaching EOF.
+    #[must_use]
+    pub fn pid(&self) -> Option<u32> {
+        self.pid
+    }
 }
 
 impl Terminal {
@@ -325,6 +340,7 @@ impl Terminal {
         let writer: Arc<Mutex<Option<Box<dyn Write + Send>>>> =
             Arc::new(Mutex::new(Some(pty_pair.master.take_writer()?)));
         let mut child = pty_pair.slave.spawn_command(cmd)?;
+        let pid = child.process_id();
         let child_killer = child.clone_killer();
         let master = Arc::new(Mutex::new(Some(pty_pair.master)));
         let exit_status: Arc<OnceLock<ChildWaitResult>> = Arc::new(OnceLock::new());
@@ -380,7 +396,7 @@ impl Terminal {
         Ok(Self {
             pty_reader: PtyReader { reader, parser: Arc::clone(&parser) },
             pty_writer: PtyWriter { writer, parser, master },
-            child_handle: ChildHandle { child_killer, exit_status },
+            child_handle: ChildHandle { child_killer, exit_status, pid },
         })
     }
 }


### PR DESCRIPTION
Expose the child PID on `ChildHandle` so callers can signal the child's whole process group.

## Why

The process spawned into a PTY is a session / process-group leader (portable-pty `setsid`s it), but `ChildHandle` only exposed a single-process killer. A caller that needs to reap grandchildren the command left behind, e.g. a managed-runtime or package-manager helper that inherited the PTY slave fd and keeps the master from ever reaching EOF, had no way to target the group.

## What

Add `ChildHandle::pid() -> Option<u32>`, captured at spawn. Additive; no behavior change for existing callers.

## Consumer

vite-plus's PTY snapshot suite: once a step's command exits, it `killpg`s the group so a lingering grandchild can't wedge the exit-wait (`read_to_end`, which only returns at PTY EOF) on the Namespace Linux runner (macOS reaps fast enough to hit EOF).
