### PR TITLE
feat(cache): add replayLogs option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,6 @@
 # Changelog
 
-- **Fixed** Vite+ diagnostics now display individual paths and working directories without Rust debug formatting such as quoted paths or escaped Windows backslashes ([#534](https://github.com/voidzero-dev/vite-task/pull/534)).
-- **Fixed** Automatic file-access tracking now works inside the default Codex CLI and Claude Code sandboxes ([#562](https://github.com/voidzero-dev/vite-task/issues/562), [#563](https://github.com/voidzero-dev/vite-task/issues/563), [#576](https://github.com/voidzero-dev/vite-task/pull/576), [#569](https://github.com/voidzero-dev/vite-task/pull/569)).
-- **Fixed** Broad workspace globs no longer discover and run package scripts inside `node_modules` ([#539](https://github.com/voidzero-dev/vite-task/pull/539)).
-- **Added** Tasks now run with `VP_RUN=1` set, so tools can tell they are running under `vp run` instead of being invoked directly ([#570](https://github.com/voidzero-dev/vite-task/pull/570)).
-- **Fixed** The task cache now supports much larger automatically tracked input sets without hitting wincode's default 4 MiB sequence preallocation limit ([#554](https://github.com/voidzero-dev/vite-task/pull/554)).
-- **Fixed** npm workspace patterns beginning with `./` now discover matching packages correctly ([vite-plus#2201](https://github.com/voidzero-dev/vite-plus/issues/2201), [#547](https://github.com/voidzero-dev/vite-task/pull/547)).
-- **Fixed** Failures while forwarding output from a started task process no longer incorrectly say the process failed to spawn ([#506](https://github.com/voidzero-dev/vite-task/issues/506)).
-- **Fixed** An issue where Bun tasks on macOS did not rerun when files they read, wrote, or listed changed ([#532](https://github.com/voidzero-dev/vite-task/issues/532), [#542](https://github.com/voidzero-dev/vite-task/pull/542)).
-- **Improved** Windows file-access tracking now uses sparse temporary backing files where supported, avoiding upfront allocation of the full backing file on disk ([#524](https://github.com/voidzero-dev/vite-task/pull/524)).
-- **Fixed** Automatic file-access tracking on Linux now works in containers and Kubernetes runners with limited `/dev/shm` space ([#353](https://github.com/voidzero-dev/vite-task/issues/353), [#523](https://github.com/voidzero-dev/vite-task/pull/523)).
-- **Fixed** Windows automatic input tracking now records executable image reads when process creation performs the lookup inside `NtCreateUserProcess` ([#518](https://github.com/voidzero-dev/vite-task/pull/518)).
-- **Fixed** Failures while waiting for a started task process to exit no longer incorrectly say the process failed to spawn ([#515](https://github.com/voidzero-dev/vite-task/pull/515)).
+- **Added** `replayLogs: false` for cached tasks that should restore outputs and report cache hits without replaying cached stdout/stderr.
 - **Fixed** Missing env vars requested through `@voidzero-dev/vite-task-client` now return `undefined` instead of `null`, preserving Vite production `NODE_ENV` semantics when builds run through `vp run` ([#508](https://github.com/voidzero-dev/vite-task/pull/508)).
 - **Fixed** Windows builds no longer hang on CI when a `node_modules/.bin` `.cmd` shim is routed through PowerShell: the npm/pnpm/yarn `.ps1` wrappers read stdin and block forever on a non-TTY pipe, so the PowerShell rewrite is now skipped when stdin is not an interactive terminal, falling back to the `.cmd` (which never reads stdin) ([#491](https://github.com/voidzero-dev/vite-task/pull/491)).
 - **Added** First-party support for caching `vite build` with zero cache config, giving Vite projects correct cache hits out of the box ([vitejs/vite#22453](https://github.com/vitejs/vite/pull/22453)).

--- a/crates/vt/src/session/cache/display.rs
+++ b/crates/vt/src/session/cache/display.rs
@@ -149,9 +149,13 @@ fn format_env_changed_inline(names: &[&Str]) -> Str {
 /// Note: Returns plain text without styling. The reporter applies colors.
 pub fn format_cache_status_inline(cache_status: &CacheStatus) -> Option<Str> {
     match cache_status {
-        CacheStatus::Hit { .. } => {
-            // Show "cache hit" indicator when replaying from cache
-            Some(Str::from("◉ cache hit, replaying"))
+        CacheStatus::Hit { logs_replayed, .. } => {
+            if *logs_replayed {
+                // Show "cache hit" indicator when replaying from cache
+                Some(Str::from("◉ cache hit, replaying"))
+            } else {
+                Some(Str::from("◉ cache hit"))
+            }
         }
         CacheStatus::Miss(CacheMiss::NotFound) => {
             // No inline message for "not found" case - just show command

--- a/crates/vt/src/session/event.rs
+++ b/crates/vt/src/session/event.rs
@@ -119,7 +119,7 @@ pub enum CacheUpdateStatus {
 pub enum CacheStatus {
     Disabled(CacheDisabledReason),
     Miss(CacheMiss),
-    Hit { replayed_duration: Duration },
+    Hit { replayed_duration: Duration, logs_replayed: bool },
 }
 
 /// Convert `ExitStatus` to an i32 exit code.

--- a/crates/vt/src/session/execute/mod.rs
+++ b/crates/vt/src/session/execute/mod.rs
@@ -385,7 +385,7 @@ async fn run(
     //    to execute the command — or carry the globbed inputs into the run.
     let (stdio_config, globbed_inputs) = match lookup {
         CacheLookup::Hit(cached) => {
-            let replay_logs = cache_metadata.map_or(true, |metadata| metadata.replay_logs);
+            let replay_logs = cache_metadata.is_none_or(|metadata| metadata.replay_logs);
             let mut stdio_config = reporter.start(CacheStatus::Hit {
                 replayed_duration: cached.duration,
                 logs_replayed: replay_logs,

--- a/crates/vt/src/session/execute/mod.rs
+++ b/crates/vt/src/session/execute/mod.rs
@@ -385,14 +385,18 @@ async fn run(
     //    to execute the command — or carry the globbed inputs into the run.
     let (stdio_config, globbed_inputs) = match lookup {
         CacheLookup::Hit(cached) => {
-            let mut stdio_config =
-                reporter.start(CacheStatus::Hit { replayed_duration: cached.duration });
+            let replay_logs = cache_metadata.map_or(true, |metadata| metadata.replay_logs);
+            let mut stdio_config = reporter.start(CacheStatus::Hit {
+                replayed_duration: cached.duration,
+                logs_replayed: replay_logs,
+            });
             return Ok(replay_cache_hit(
                 &mut stdio_config,
                 &cached,
                 workspace_root,
                 cache_dir,
                 program_name,
+                replay_logs,
             ));
         }
         CacheLookup::Miss { miss, globbed_inputs } => {
@@ -547,14 +551,17 @@ fn replay_cache_hit(
     workspace_root: &Arc<AbsolutePath>,
     cache_dir: &AbsolutePath,
     program_name: &str,
+    replay_logs: bool,
 ) -> Report {
-    for output in cached.std_outputs.iter() {
-        let writer: &mut dyn std::io::Write = match output.kind {
-            pipe::OutputKind::StdOut => &mut stdio_config.writers.stdout_writer,
-            pipe::OutputKind::StdErr => &mut stdio_config.writers.stderr_writer,
-        };
-        let _ = writer.write_all(&output.content);
-        let _ = writer.flush();
+    if replay_logs {
+        for output in cached.std_outputs.iter() {
+            let writer: &mut dyn std::io::Write = match output.kind {
+                pipe::OutputKind::StdOut => &mut stdio_config.writers.stdout_writer,
+                pipe::OutputKind::StdErr => &mut stdio_config.writers.stderr_writer,
+            };
+            let _ = writer.write_all(&output.content);
+            let _ = writer.flush();
+        }
     }
 
     // Restore output files from the cached archive. Failure here means the

--- a/crates/vt/src/session/reporter/summary.rs
+++ b/crates/vt/src/session/reporter/summary.rs
@@ -63,8 +63,12 @@ pub struct TaskSummary {
 /// making invalid combinations unrepresentable.
 #[derive(Serialize, Deserialize)]
 pub enum TaskResult {
-    /// Cache hit — output was replayed from cache. Always successful.
-    CacheHit { saved_duration_ms: u64 },
+    /// Cache hit. Always successful.
+    CacheHit {
+        saved_duration_ms: u64,
+        #[serde(default = "default_logs_replayed")]
+        logs_replayed: bool,
+    },
 
     /// In-process execution (built-in command like echo). Always successful.
     InProcess,
@@ -90,6 +94,10 @@ pub enum SpawnedCacheStatus {
     Miss(SavedCacheMissReason),
     /// No cache configuration for this task.
     Disabled,
+}
+
+const fn default_logs_replayed() -> bool {
+    true
 }
 
 /// Outcome of a spawned process.
@@ -121,7 +129,7 @@ pub enum SpawnOutcome {
     /// No `infra_error` field: cache operations are skipped on non-zero exit.
     Failed { exit_code: NonZeroI32 },
 
-    /// Execution failed without a usable process exit status.
+    /// Could not start the process (e.g., command not found).
     SpawnError(SavedExecutionError),
 }
 
@@ -152,8 +160,6 @@ pub enum SavedCacheMissReason {
 pub enum SavedExecutionError {
     Cache { kind: SavedCacheErrorKind, message: Str },
     Spawn { message: Str },
-    ForwardTaskProcessOutput { message: Str },
-    WaitForTaskProcessExit { message: Str },
     PostRunFingerprint { message: Str },
     IpcServerBind { message: Str },
 }
@@ -193,7 +199,7 @@ impl SummaryStats {
 
         for task in tasks {
             match &task.result {
-                TaskResult::CacheHit { saved_duration_ms } => {
+                TaskResult::CacheHit { saved_duration_ms, .. } => {
                     stats.cache_hits += 1;
                     stats.total_saved += Duration::from_millis(*saved_duration_ms);
                 }
@@ -237,12 +243,8 @@ impl SavedExecutionError {
                 },
                 message: vt_str::format!("{source:#}"),
             },
-            ExecutionError::Spawn(source) => Self::Spawn { message: vt_str::format!("{source:#}") },
-            ExecutionError::ForwardTaskProcessOutput(source) => {
-                Self::ForwardTaskProcessOutput { message: vt_str::format!("{source:#}") }
-            }
-            ExecutionError::WaitForTaskProcessExit(source) => {
-                Self::WaitForTaskProcessExit { message: vt_str::format!("{source:#}") }
+            ExecutionError::Spawn(source) => {
+                Self::Spawn { message: vt_str::format!("{source:#}") }
             }
             ExecutionError::PostRunFingerprint(source) => {
                 Self::PostRunFingerprint { message: vt_str::format!("{source:#}") }
@@ -265,12 +267,6 @@ impl SavedExecutionError {
             }
             Self::Spawn { message } => {
                 vt_str::format!("Failed to spawn process: {message}")
-            }
-            Self::ForwardTaskProcessOutput { message } => {
-                vt_str::format!("Failed to forward task process output: {message}")
-            }
-            Self::WaitForTaskProcessExit { message } => {
-                vt_str::format!("Failed to wait for task process to exit: {message}")
             }
             Self::PostRunFingerprint { message } => {
                 vt_str::format!("Failed to create post-run fingerprint: {message}")
@@ -345,9 +341,10 @@ impl TaskResult {
         );
 
         match cache_status {
-            CacheStatus::Hit { replayed_duration } => {
-                Self::CacheHit { saved_duration_ms: duration_to_ms(*replayed_duration) }
-            }
+            CacheStatus::Hit { replayed_duration, logs_replayed } => Self::CacheHit {
+                saved_duration_ms: duration_to_ms(*replayed_duration),
+                logs_replayed: *logs_replayed,
+            },
             CacheStatus::Disabled(CacheDisabledReason::InProcessExecution) => Self::InProcess,
             CacheStatus::Disabled(CacheDisabledReason::NoCacheMetadata) => Self::Spawned {
                 cache_status: SpawnedCacheStatus::Disabled,
@@ -565,10 +562,14 @@ impl TaskResult {
         }
 
         match self {
-            Self::CacheHit { saved_duration_ms } => {
+            Self::CacheHit { saved_duration_ms, logs_replayed } => {
                 let d = Duration::from_millis(*saved_duration_ms);
                 let formatted_duration = format_summary_duration(d);
-                vt_str::format!("→ Cache hit - output replayed - {formatted_duration} saved")
+                if *logs_replayed {
+                    vt_str::format!("→ Cache hit - output replayed - {formatted_duration} saved")
+                } else {
+                    vt_str::format!("→ Cache hit - logs skipped - {formatted_duration} saved")
+                }
             }
             Self::InProcess => Str::from("→ Cache disabled for built-in command"),
             Self::Spawned { cache_status, .. } => match cache_status {
@@ -667,7 +668,9 @@ pub fn format_full_summary(summary: &LastRunSummary) -> Vec<u8> {
     let cache_disabled_str = if stats.cache_disabled > 0 {
         let n = stats.cache_disabled;
         Str::from(
-            vt_str::format!("• {n} cache disabled").style(Style::new().bright_black()).to_string(),
+            vt_str::format!("• {n} cache disabled")
+                .style(Style::new().bright_black())
+                .to_string(),
         )
     } else {
         Str::default()
@@ -917,29 +920,5 @@ fn format_input_modified_notice(buf: &mut Vec<u8>, task_names: &[Str]) {
         let _ = write!(buf, " not cached because it modified its input.");
     } else {
         let _ = write!(buf, " not cached because they modified their inputs.");
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn output_forwarding_error_has_distinct_message() {
-        let error = ExecutionError::ForwardTaskProcessOutput(anyhow::anyhow!(
-            "Resource temporarily unavailable (os error 11)"
-        ));
-
-        let saved = SavedExecutionError::from_execution_error(&error);
-
-        assert!(matches!(
-            &saved,
-            SavedExecutionError::ForwardTaskProcessOutput { message }
-                if message.as_str() == "Resource temporarily unavailable (os error 11)"
-        ));
-        assert_eq!(
-            saved.display_message().as_str(),
-            "Failed to forward task process output: Resource temporarily unavailable (os error 11)"
-        );
     }
 }

--- a/crates/vt/src/session/reporter/summary.rs
+++ b/crates/vt/src/session/reporter/summary.rs
@@ -160,6 +160,8 @@ pub enum SavedCacheMissReason {
 pub enum SavedExecutionError {
     Cache { kind: SavedCacheErrorKind, message: Str },
     Spawn { message: Str },
+    ForwardTaskProcessOutput { message: Str },
+    WaitForTaskProcessExit { message: Str },
     PostRunFingerprint { message: Str },
     IpcServerBind { message: Str },
 }
@@ -243,8 +245,12 @@ impl SavedExecutionError {
                 },
                 message: vt_str::format!("{source:#}"),
             },
-            ExecutionError::Spawn(source) => {
-                Self::Spawn { message: vt_str::format!("{source:#}") }
+            ExecutionError::Spawn(source) => Self::Spawn { message: vt_str::format!("{source:#}") },
+            ExecutionError::ForwardTaskProcessOutput(source) => {
+                Self::ForwardTaskProcessOutput { message: vt_str::format!("{source:#}") }
+            }
+            ExecutionError::WaitForTaskProcessExit(source) => {
+                Self::WaitForTaskProcessExit { message: vt_str::format!("{source:#}") }
             }
             ExecutionError::PostRunFingerprint(source) => {
                 Self::PostRunFingerprint { message: vt_str::format!("{source:#}") }
@@ -267,6 +273,12 @@ impl SavedExecutionError {
             }
             Self::Spawn { message } => {
                 vt_str::format!("Failed to spawn process: {message}")
+            }
+            Self::ForwardTaskProcessOutput { message } => {
+                vt_str::format!("Failed to forward task process output: {message}")
+            }
+            Self::WaitForTaskProcessExit { message } => {
+                vt_str::format!("Failed to wait for task process to exit: {message}")
             }
             Self::PostRunFingerprint { message } => {
                 vt_str::format!("Failed to create post-run fingerprint: {message}")
@@ -668,9 +680,7 @@ pub fn format_full_summary(summary: &LastRunSummary) -> Vec<u8> {
     let cache_disabled_str = if stats.cache_disabled > 0 {
         let n = stats.cache_disabled;
         Str::from(
-            vt_str::format!("• {n} cache disabled")
-                .style(Style::new().bright_black())
-                .to_string(),
+            vt_str::format!("• {n} cache disabled").style(Style::new().bright_black()).to_string(),
         )
     } else {
         Str::default()
@@ -920,5 +930,29 @@ fn format_input_modified_notice(buf: &mut Vec<u8>, task_names: &[Str]) {
         let _ = write!(buf, " not cached because it modified its input.");
     } else {
         let _ = write!(buf, " not cached because they modified their inputs.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_forwarding_error_has_distinct_message() {
+        let error = ExecutionError::ForwardTaskProcessOutput(anyhow::anyhow!(
+            "Resource temporarily unavailable (os error 11)"
+        ));
+
+        let saved = SavedExecutionError::from_execution_error(&error);
+
+        assert!(matches!(
+            &saved,
+            SavedExecutionError::ForwardTaskProcessOutput { message }
+                if message.as_str() == "Resource temporarily unavailable (os error 11)"
+        ));
+        assert_eq!(
+            saved.display_message().as_str(),
+            "Failed to forward task process output: Resource temporarily unavailable (os error 11)"
+        );
     }
 }

--- a/crates/vt_bin/src/lib.rs
+++ b/crates/vt_bin/src/lib.rs
@@ -95,6 +95,7 @@ impl vt::CommandHandler for CommandHandler {
                     program,
                     args: args.into_iter().filter(|a| a.as_str() != "--").collect(),
                     cache_config: UserCacheConfig::with_config(EnabledCacheConfig {
+                        replay_logs: None,
                         env: None,
                         untracked_env: None,
                         input: None,

--- a/crates/vt_bin/tests/e2e_snapshots/fixtures/replay_logs/package.json
+++ b/crates/vt_bin/tests/e2e_snapshots/fixtures/replay_logs/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "replay-logs-test"
+}

--- a/crates/vt_bin/tests/e2e_snapshots/fixtures/replay_logs/snapshots.toml
+++ b/crates/vt_bin/tests/e2e_snapshots/fixtures/replay_logs/snapshots.toml
@@ -1,0 +1,28 @@
+[[e2e]]
+name = "cache_hit_skips_log_replay_but_restores_outputs"
+comment = """
+`replayLogs: false` should keep cache hits and output restoration, while suppressing cached stdout/stderr replay.
+"""
+steps = [
+  { argv = [
+    "vt",
+    "run",
+    "build",
+  ], comment = "first run — cache miss, prints logs and writes dist/output.txt" },
+  { argv = [
+    "vtt",
+    "rm",
+    "-rf",
+    "dist",
+  ], comment = "delete dist/ to prove cache-hit output restoration still happens" },
+  { argv = [
+    "vt",
+    "run",
+    "build",
+  ], comment = "second run — cache hit, skips cached log replay" },
+  { argv = [
+    "vtt",
+    "print-file",
+    "dist/output.txt",
+  ], comment = "output file restored from cache" },
+]

--- a/crates/vt_bin/tests/e2e_snapshots/fixtures/replay_logs/snapshots/cache_hit_skips_log_replay_but_restores_outputs.md
+++ b/crates/vt_bin/tests/e2e_snapshots/fixtures/replay_logs/snapshots/cache_hit_skips_log_replay_but_restores_outputs.md
@@ -1,0 +1,38 @@
+# cache_hit_skips_log_replay_but_restores_outputs
+
+`replayLogs: false` should keep cache hits and output restoration, while suppressing cached stdout/stderr replay.
+
+## `vt run build`
+
+first run — cache miss, prints logs and writes dist/output.txt
+
+```
+$ vtt print fresh logs; vtt write-file dist/output.txt artifact
+fresh logs
+```
+
+## `vtt rm -rf dist`
+
+delete dist/ to prove cache-hit output restoration still happens
+
+```
+```
+
+## `vt run build`
+
+second run — cache hit, skips cached log replay
+
+```
+$ vtt print fresh logs; vtt write-file dist/output.txt artifact ◉ cache hit
+
+---
+vt run: cache hit.
+```
+
+## `vtt print-file dist/output.txt`
+
+output file restored from cache
+
+```
+artifact
+```

--- a/crates/vt_bin/tests/e2e_snapshots/fixtures/replay_logs/snapshots/cache_hit_skips_log_replay_but_restores_outputs.md
+++ b/crates/vt_bin/tests/e2e_snapshots/fixtures/replay_logs/snapshots/cache_hit_skips_log_replay_but_restores_outputs.md
@@ -7,8 +7,13 @@
 first run — cache miss, prints logs and writes dist/output.txt
 
 ```
-$ vtt print fresh logs; vtt write-file dist/output.txt artifact
+$ vtt print fresh logs
 fresh logs
+
+$ vtt write-file dist/output.txt artifact
+
+---
+vt run: 0/2 cache hit (0%). (Run `vt run --last-details` for full details)
 ```
 
 ## `vtt rm -rf dist`
@@ -23,10 +28,12 @@ delete dist/ to prove cache-hit output restoration still happens
 second run — cache hit, skips cached log replay
 
 ```
-$ vtt print fresh logs; vtt write-file dist/output.txt artifact ◉ cache hit
+$ vtt print fresh logs ◉ cache hit
+
+$ vtt write-file dist/output.txt artifact ◉ cache hit
 
 ---
-vt run: cache hit.
+vt run: 2/2 cache hit (100%). (Run `vt run --last-details` for full details)
 ```
 
 ## `vtt print-file dist/output.txt`

--- a/crates/vt_bin/tests/e2e_snapshots/fixtures/replay_logs/vite-task.json
+++ b/crates/vt_bin/tests/e2e_snapshots/fixtures/replay_logs/vite-task.json
@@ -1,7 +1,7 @@
 {
   "tasks": {
     "build": {
-      "command": "vtt print fresh logs; vtt write-file dist/output.txt artifact",
+      "command": "vtt print fresh logs && vtt write-file dist/output.txt artifact",
       "cache": true,
       "replayLogs": false,
       "input": [],

--- a/crates/vt_bin/tests/e2e_snapshots/fixtures/replay_logs/vite-task.json
+++ b/crates/vt_bin/tests/e2e_snapshots/fixtures/replay_logs/vite-task.json
@@ -1,0 +1,11 @@
+{
+  "tasks": {
+    "build": {
+      "command": "vtt print fresh logs; vtt write-file dist/output.txt artifact",
+      "cache": true,
+      "replayLogs": false,
+      "input": [],
+      "output": ["dist/**"]
+    }
+  }
+}

--- a/crates/vt_graph/run-config.ts
+++ b/crates/vt_graph/run-config.ts
@@ -51,6 +51,10 @@ dependsOn?: Array<DependsOnEntry>, } & ({
  */
 cache?: true,
 /**
+ * Whether to replay cached stdout/stderr on cache hits.
+ */
+replayLogs?: boolean,
+/**
  * Environment variable names to be fingerprinted and passed to the task.
  */
 env?: Array<string>,

--- a/crates/vt_graph/src/config/mod.rs
+++ b/crates/vt_graph/src/config/mod.rs
@@ -102,10 +102,6 @@ impl ResolvedTaskOptions {
 }
 
 #[derive(Debug, Clone, Serialize)]
-#[expect(
-    clippy::struct_field_names,
-    reason = "env_config, input_config, output_config are distinct config categories, not a naming smell"
-)]
 pub struct CacheConfig {
     #[serde(skip_serializing_if = "is_true")]
     pub replay_logs: bool,
@@ -114,6 +110,10 @@ pub struct CacheConfig {
     pub output_config: ResolvedGlobConfig,
 }
 
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde's skip_serializing_if callback receives the field by reference"
+)]
 const fn is_true(value: &bool) -> bool {
     *value
 }

--- a/crates/vt_graph/src/config/mod.rs
+++ b/crates/vt_graph/src/config/mod.rs
@@ -66,6 +66,7 @@ impl ResolvedTaskOptions {
         let cache_config = match user_options.cache_config {
             UserCacheConfig::Disabled { cache: MustBe!(false) } => None,
             UserCacheConfig::Enabled { cache: _, enabled_cache_config } => {
+                let replay_logs = enabled_cache_config.replay_logs.unwrap_or(true);
                 let mut untracked_env: FxHashSet<Str> =
                     enabled_cache_config.untracked_env.unwrap_or_default().into_iter().collect();
                 untracked_env.extend(DEFAULT_UNTRACKED_ENV.iter().copied().map(Str::from));
@@ -83,6 +84,7 @@ impl ResolvedTaskOptions {
                 )?;
 
                 Some(CacheConfig {
+                    replay_logs,
                     env_config: EnvConfig {
                         fingerprinted_envs: enabled_cache_config
                             .env
@@ -105,9 +107,15 @@ impl ResolvedTaskOptions {
     reason = "env_config, input_config, output_config are distinct config categories, not a naming smell"
 )]
 pub struct CacheConfig {
+    #[serde(skip_serializing_if = "is_true")]
+    pub replay_logs: bool,
     pub env_config: EnvConfig,
     pub input_config: ResolvedGlobConfig,
     pub output_config: ResolvedGlobConfig,
+}
+
+const fn is_true(value: &bool) -> bool {
+    *value
 }
 
 /// Resolved input configuration for cache fingerprinting.

--- a/crates/vt_graph/src/config/user.rs
+++ b/crates/vt_graph/src/config/user.rs
@@ -192,6 +192,9 @@ impl UserCacheConfig {
 #[cfg_attr(all(test, not(clippy)), derive(TS), ts(optional_fields))]
 #[serde(rename_all = "camelCase")]
 pub struct EnabledCacheConfig {
+    /// Whether to replay cached stdout/stderr on cache hits.
+    pub replay_logs: Option<bool>,
+
     /// Environment variable names to be fingerprinted and passed to the task.
     pub env: Option<Box<[Str]>>,
 
@@ -260,6 +263,7 @@ impl Default for UserTaskOptions {
             cache_config: UserCacheConfig::Enabled {
                 cache: None,
                 enabled_cache_config: EnabledCacheConfig {
+                    replay_logs: None,
                     env: None,
                     untracked_env: None,
                     input: None,
@@ -702,8 +706,30 @@ mod tests {
             UserCacheConfig::Enabled {
                 cache: Some(MustBe!(true)),
                 enabled_cache_config: EnabledCacheConfig {
+                    replay_logs: None,
                     env: Some(std::iter::once("NODE_ENV".into()).collect()),
                     untracked_env: Some(std::iter::once("FOO".into()).collect()),
+                    input: None,
+                    output: None,
+                }
+            },
+        );
+    }
+
+    #[test]
+    fn test_replay_logs_can_be_disabled() {
+        let user_config_json = json!({
+            "cache": true,
+            "replayLogs": false,
+        });
+        assert_eq!(
+            serde_json::from_value::<UserCacheConfig>(user_config_json).unwrap(),
+            UserCacheConfig::Enabled {
+                cache: Some(MustBe!(true)),
+                enabled_cache_config: EnabledCacheConfig {
+                    replay_logs: Some(false),
+                    env: None,
+                    untracked_env: None,
                     input: None,
                     output: None,
                 }

--- a/crates/vt_plan/src/cache_metadata.rs
+++ b/crates/vt_plan/src/cache_metadata.rs
@@ -70,6 +70,10 @@ pub struct CacheMetadata {
     pub unfiltered_envs: Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>,
 }
 
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde's skip_serializing_if callback receives the field by reference"
+)]
 const fn is_true(value: &bool) -> bool {
     *value
 }

--- a/crates/vt_plan/src/cache_metadata.rs
+++ b/crates/vt_plan/src/cache_metadata.rs
@@ -55,6 +55,10 @@ pub struct CacheMetadata {
     /// Used at execution time to determine what output files to archive.
     pub output_config: ResolvedGlobConfig,
 
+    /// Whether cached stdout/stderr should be replayed on cache hits.
+    #[serde(skip_serializing_if = "is_true")]
+    pub replay_logs: bool,
+
     /// The unfiltered env context for runner-aware APIs. This is the planning
     /// context's envs before spawn-env filtering, including command prefix envs
     /// from this command and enclosing nested `vp run` expansions.
@@ -64,6 +68,10 @@ pub struct CacheMetadata {
     /// mirrors the ambient environment and would make snapshots noisy.
     #[serde(skip)]
     pub unfiltered_envs: Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>,
+}
+
+const fn is_true(value: &bool) -> bool {
+    *value
 }
 
 /// Fingerprint for spawn execution that affects caching.

--- a/crates/vt_plan/src/plan.rs
+++ b/crates/vt_plan/src/plan.rs
@@ -489,7 +489,7 @@ fn resolve_synthetic_cache_config(
             Ok(match synthetic_cache_config {
                 UserCacheConfig::Disabled { .. } => Option::None,
                 UserCacheConfig::Enabled { enabled_cache_config, .. } => {
-                    let EnabledCacheConfig { env, untracked_env, input, output } =
+                    let EnabledCacheConfig { replay_logs: _, env, untracked_env, input, output } =
                         enabled_cache_config;
                     parent_config.env_config.fingerprinted_envs.extend(env.unwrap_or_default());
                     parent_config
@@ -672,6 +672,7 @@ fn plan_spawn_execution(
                 execution_cache_key,
                 input_config: cache_config.input_config.clone(),
                 output_config: cache_config.output_config.clone(),
+                replay_logs: cache_config.replay_logs,
                 unfiltered_envs: Arc::clone(envs),
             });
         }
@@ -939,6 +940,7 @@ mod tests {
 
     fn parent_config(includes_auto: bool, positive_globs: &[&str]) -> CacheConfig {
         CacheConfig {
+            replay_logs: true,
             env_config: EnvConfig {
                 fingerprinted_envs: FxHashSet::default(),
                 untracked_env: FxHashSet::default(),
@@ -967,6 +969,7 @@ mod tests {
         let result = resolve_synthetic_cache_config(
             ParentCacheConfig::Inherited(parent),
             UserCacheConfig::with_config(EnabledCacheConfig {
+                replay_logs: None,
                 env: None,
                 untracked_env: None,
                 input: None,
@@ -989,6 +992,7 @@ mod tests {
         let result = resolve_synthetic_cache_config(
             ParentCacheConfig::Inherited(parent),
             UserCacheConfig::with_config(EnabledCacheConfig {
+                replay_logs: None,
                 env: None,
                 untracked_env: None,
                 input: Some(vec![UserInputEntry::Glob("config/**".into())]),
@@ -1011,6 +1015,7 @@ mod tests {
         let result = resolve_synthetic_cache_config(
             ParentCacheConfig::Inherited(parent),
             UserCacheConfig::with_config(EnabledCacheConfig {
+                replay_logs: None,
                 env: None,
                 untracked_env: None,
                 input: Some(vec![UserInputEntry::Glob("config/**".into())]),
@@ -1036,6 +1041,7 @@ mod tests {
         let result = resolve_synthetic_cache_config(
             ParentCacheConfig::Inherited(parent),
             UserCacheConfig::with_config(EnabledCacheConfig {
+                replay_logs: None,
                 env: None,
                 untracked_env: None,
                 input: Some(vec![
@@ -1065,6 +1071,7 @@ mod tests {
         let result = resolve_synthetic_cache_config(
             ParentCacheConfig::Inherited(parent),
             UserCacheConfig::with_config(EnabledCacheConfig {
+                replay_logs: None,
                 env: None,
                 untracked_env: None,
                 input: Some(vec![UserInputEntry::Glob("config/**".into())]),
@@ -1089,6 +1096,7 @@ mod tests {
         let result = resolve_synthetic_cache_config(
             ParentCacheConfig::Disabled,
             UserCacheConfig::with_config(EnabledCacheConfig {
+                replay_logs: None,
                 env: None,
                 untracked_env: None,
                 input: Some(vec![UserInputEntry::Glob("config/**".into())]),
@@ -1122,6 +1130,7 @@ mod tests {
         let result = resolve_synthetic_cache_config(
             ParentCacheConfig::Inherited(parent),
             UserCacheConfig::with_config(EnabledCacheConfig {
+                replay_logs: None,
                 env: None,
                 untracked_env: None,
                 input: Some(vec![UserInputEntry::Glob("!dist/**".into())]),


### PR DESCRIPTION
## Motivation

Cache hits currently replay captured stdout/stderr every time. Some tasks produce noisy logs even when their useful cached result is restored output files, so users need a per-task option to keep cache hits quiet without disabling caching.

## Changes

- Add `replayLogs` to cache config, defaulting to `true`.
- Skip cached stdout/stderr replay on cache hits when `replayLogs: false` while still restoring output files.
- Update cache-hit display/summary text and add e2e coverage for quiet cache hits.