### PR TITLE
docs: allow musl-specific test skips

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ The test suite has no known pre-existing failures or flaky tests. If a test fail
 
 ### Cross-Platform Testing
 
-**CRITICAL**: This project must work on both Unix (macOS/Linux) and Windows. Skipping tests on either platform is **UNACCEPTABLE**.
+**CRITICAL**: This project must work on both Unix (macOS/Linux) and Windows. Skipping tests on either platform is **UNACCEPTABLE**, except on musl targets when an essential dependency or required platform capability is unavailable. Document the unavailable requirement and keep the skip scoped to musl.
 
 - Use `#[cfg(unix)]` and `#[cfg(windows)]` for platform-specific code within tests
 - Both platforms must execute the test and verify the feature works correctly
@@ -146,7 +146,7 @@ Enforced by `.clippy.toml`:
 
 ### Cross-Platform Requirements
 
-All code must work on both Unix and Windows without platform skipping:
+All code must work on both Unix and Windows without platform skipping. The only exception is for tests on musl targets when an essential dependency or required platform capability is unavailable; document the reason and scope the skip to musl.
 
 - Use `#[cfg(unix)]` / `#[cfg(windows)]` for platform-specific implementations
 - Platform differences should be handled gracefully, not skipped

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ See `playground/README.md` for the full task list and dependency structure.
 
 ## Cross-Platform Development
 
-This project must work on macOS, Linux, and Windows. Skipping tests on any platform is not acceptable.
+This project must work on macOS, Linux, and Windows. Skipping tests on any platform is not acceptable, except on musl targets when an essential dependency or required platform capability is unavailable. Document the unavailable requirement and keep the skip scoped to musl.
 
 - Use `#[cfg(unix)]` / `#[cfg(windows)]` for platform-specific code
 - Use cross-platform libraries where possible (e.g., `terminal_size` instead of raw ioctl/ConPTY)


### PR DESCRIPTION
## Motivation

An upcoming Vitest browser-mode test uses `@playwright/browser-chromium`, which does not support Linux musl. The current cross-platform testing guidance prohibits every platform-specific test skip, leaving no documented exception for this unavailable dependency.

Clarify that this test may be skipped on musl while keeping the broader macOS, Linux, and Windows testing expectations unchanged. The exception remains limited to musl targets where an essential dependency or required platform capability is unavailable and documented.
