### PR TITLE
test(e2e): cover Vitest browser caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.code-changed == 'true'
     name: Test (${{ matrix.shard }})
+    env:
+      # Playwright detects the physical Apple Silicon CPU under Rosetta. Force
+      # its x64 browser for the x86_64 shard so fspy can inject its x64 preload.
+      PLAYWRIGHT_HOST_PLATFORM_OVERRIDE: ${{ matrix.target == 'x86_64-apple-darwin' && 'mac15' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -127,6 +131,13 @@ jobs:
       - uses: oxc-project/setup-node@4c588e9266bd930b6ddc34307df0659ed511d187 # v1.3.1
         with:
           architecture: ${{ matrix.target == 'x86_64-apple-darwin' && 'x64' || '' }}
+
+      - name: Install Chromium
+        run: pnpm --filter vite-task-tools rebuild @playwright/browser-chromium
+
+      - name: Install Chromium system dependencies
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        run: pnpm --filter vite-task-tools exec playwright install-deps chromium
 
       - name: Run ignored tests
         run: ${{ matrix.cargo_cmd }} test --target ${{ matrix.build_target }} -- --ignored
@@ -256,6 +267,10 @@ jobs:
       - uses: oxc-project/setup-node@4c588e9266bd930b6ddc34307df0659ed511d187 # v1.3.1
         if: matrix.mode == 'ignored'
 
+      - name: Install Chromium
+        if: matrix.mode == 'ignored'
+        run: pnpm --filter vite-task-tools rebuild @playwright/browser-chromium
+
       - name: Run ignored tests
         if: matrix.mode == 'ignored'
         run: cargo-nextest nextest run --archive-file windows-tests.tar.zst --workspace-remap . --run-ignored ignored-only
@@ -279,6 +294,9 @@ jobs:
       # On musl, concurrent PTY operations can trigger SIGSEGV in musl internals.
       # Run test threads sequentially to avoid the race.
       RUST_TEST_THREADS: 1
+      # Playwright's bundled Chromium does not support musl. The browser fixture
+      # is filtered out there, so avoid downloading an unusable glibc binary.
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     steps:
       - name: Install Alpine dependencies
         shell: sh {0}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 - [Rust](https://rustup.rs/) (see [rust-toolchain.toml](rust-toolchain.toml) for the required version)
 - [Node.js](https://nodejs.org/) (^20.19.0 || >=22.12.0)
-- [pnpm](https://pnpm.io/) (10.x)
+- [pnpm](https://pnpm.io/) (11.x)
 - [just](https://just.systems/) — task runner for build commands
 - [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) — for installing Rust tools
 
@@ -51,12 +51,13 @@ UPDATE_SNAPSHOTS=1 cargo test                           # Update snapshots
 Integration tests that need Node.js or the `packages/tools` binaries (e.g. `oxlint`) are marked `#[ignore]` — and `[[e2e]]` cases in e2e snapshots.toml can opt in with `ignore = true`. Default `cargo test` runs only the tests that need nothing beyond the Rust toolchain; to run the rest:
 
 ```bash
-pnpm install                           # at the workspace root (installs packages/tools too)
+pnpm install                           # at the workspace root (installs packages/tools and Chromium too)
 cargo test -- --include-ignored        # run everything
 cargo test -- --ignored                # run only the previously-ignored tests
 ```
 
 You don't need `pnpm install` in test fixture directories.
+Playwright's bundled Chromium is unavailable on musl, so the Vitest browser fixture is skipped there.
 
 ### Test Fixtures
 

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vitest_browser_cache/package.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vitest_browser_cache/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "vitest-browser-cache-fixture",
+  "private": true,
+  "type": "module"
+}

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vitest_browser_cache/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vitest_browser_cache/snapshots.toml
@@ -1,0 +1,57 @@
+[[e2e]]
+name = "vitest_browser_caches_inputs_and_restores_outputs"
+comment = """
+Vitest browser mode runs in headless Chromium with explicit automatic input and output tracking. A source change must invalidate the cache, while an unchanged run must restore the browser command's generated output without rerunning Vitest. Playwright's bundled Chromium is unavailable on musl, so this browser-specific case is skipped only there.
+"""
+platform = "non-musl"
+ignore = true
+steps = [
+  { argv = [
+    "vt",
+    "run",
+    "--cache",
+    "test",
+  ], comment = "first browser run: cache miss writes dist/result.json" },
+  { argv = [
+    "vtt",
+    "grep-file",
+    "dist/result.json",
+    "hello browser alpha",
+  ], comment = "Vitest's JSON report contains the initial imported value" },
+  { argv = [
+    "vtt",
+    "rm",
+    "dist/result.json",
+  ], comment = "remove the generated output so restoration is observable" },
+  { argv = [
+    "vt",
+    "run",
+    "--cache",
+    "test",
+  ], comment = "unchanged inputs: cache hit restores dist/result.json" },
+  { argv = [
+    "vtt",
+    "grep-file",
+    "dist/result.json",
+    "hello browser alpha",
+  ], comment = "the automatic output archive restored Vitest's report" },
+  { argv = [
+    "vtt",
+    "replace-file-content",
+    "src/greeting.js",
+    "hello browser alpha",
+    "hello browser bravo",
+  ], comment = "modify a module loaded by the browser" },
+  { argv = [
+    "vt",
+    "run",
+    "--cache",
+    "test",
+  ], comment = "automatic input changed: cache miss reruns the browser test" },
+  { argv = [
+    "vtt",
+    "grep-file",
+    "dist/result.json",
+    "hello browser bravo",
+  ], comment = "the rerun's JSON report contains the modified imported value" },
+]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vitest_browser_cache/snapshots/vitest_browser_caches_inputs_and_restores_outputs.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vitest_browser_cache/snapshots/vitest_browser_caches_inputs_and_restores_outputs.md
@@ -1,0 +1,83 @@
+# vitest_browser_caches_inputs_and_restores_outputs
+
+Vitest browser mode runs in headless Chromium with explicit automatic input and output tracking. A source change must invalidate the cache, while an unchanged run must restore the browser command's generated output without rerunning Vitest. Playwright's bundled Chromium is unavailable on musl, so this browser-specific case is skipped only there.
+
+## `vt run --cache test`
+
+first browser run: cache miss writes dist/result.json
+
+```
+$ vitest run
+
+ RUN  v4.1.10 <workspace>
+
+ ✓  chromium  src/greeting.test.js (1 test) <duration>
+JSON report written to <workspace>/dist/result.json
+```
+
+## `vtt grep-file dist/result.json 'hello browser alpha'`
+
+Vitest's JSON report contains the initial imported value
+
+```
+dist/result.json: found "hello browser alpha"
+```
+
+## `vtt rm dist/result.json`
+
+remove the generated output so restoration is observable
+
+```
+```
+
+## `vt run --cache test`
+
+unchanged inputs: cache hit restores dist/result.json
+
+```
+$ vitest run ◉ cache hit, replaying
+
+ RUN  v4.1.10 <workspace>
+
+ ✓  chromium  src/greeting.test.js (1 test) <duration>
+JSON report written to <workspace>/dist/result.json
+
+---
+vt run: cache hit.
+```
+
+## `vtt grep-file dist/result.json 'hello browser alpha'`
+
+the automatic output archive restored Vitest's report
+
+```
+dist/result.json: found "hello browser alpha"
+```
+
+## `vtt replace-file-content src/greeting.js 'hello browser alpha' 'hello browser bravo'`
+
+modify a module loaded by the browser
+
+```
+```
+
+## `vt run --cache test`
+
+automatic input changed: cache miss reruns the browser test
+
+```
+$ vitest run ○ cache miss: 'src/greeting.js' modified, executing
+
+ RUN  v4.1.10 <workspace>
+
+ ✓  chromium  src/greeting.test.js (1 test) <duration>
+JSON report written to <workspace>/dist/result.json
+```
+
+## `vtt grep-file dist/result.json 'hello browser bravo'`
+
+the rerun's JSON report contains the modified imported value
+
+```
+dist/result.json: found "hello browser bravo"
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vitest_browser_cache/src/greeting.js
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vitest_browser_cache/src/greeting.js
@@ -1,0 +1,1 @@
+export const greeting = 'hello browser alpha';

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vitest_browser_cache/src/greeting.test.js
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vitest_browser_cache/src/greeting.test.js
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest';
+import { page, server } from 'vitest/browser';
+import { greeting } from './greeting.js';
+
+test(greeting, async () => {
+  document.body.innerHTML = `<h1>${greeting}</h1>`;
+
+  await expect.element(page.getByRole('heading')).toHaveTextContent(greeting);
+  expect(server.browser).toBe('chromium');
+  expect(server.provider).toBe('playwright');
+});

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vitest_browser_cache/vite-task.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vitest_browser_cache/vite-task.json
@@ -1,0 +1,12 @@
+{
+  "tasks": {
+    "test": {
+      "command": "vitest run",
+      "cache": true,
+      "input": [{ "auto": true }],
+      // TODO: Add @voidzero-dev/vite-task-client and have Vitest report this path as ignored.
+      "output": [{ "auto": true }, "!node_modules/.vite/vitest/**"],
+      "untrackedEnv": ["PLAYWRIGHT_HOST_PLATFORM_OVERRIDE"]
+    }
+  }
+}

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vitest_browser_cache/vitest.config.js
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vitest_browser_cache/vitest.config.js
@@ -1,0 +1,20 @@
+import { playwright } from '@vitest/browser-playwright';
+import { defineConfig } from 'vitest/config';
+import { DefaultReporter } from 'vitest/node';
+
+class NoTestSummaryReporter extends DefaultReporter {
+  reportTestSummary() {}
+}
+
+export default defineConfig({
+  test: {
+    reporters: [new NoTestSummaryReporter({ summary: false }), 'json'],
+    outputFile: { json: 'dist/result.json' },
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: playwright(),
+      instances: [{ browser: 'chromium' }],
+    },
+  },
+});

--- a/crates/vite_task_bin/tests/e2e_snapshots/main.rs
+++ b/crates/vite_task_bin/tests/e2e_snapshots/main.rs
@@ -18,9 +18,13 @@ use vite_str::Str;
 use vite_workspace::find_workspace_root;
 
 /// Timeout for each step in e2e tests.
-/// Windows CI needs a longer timeout due to Git Bash startup overhead and slower I/O.
+/// Windows CI and `x86_64` macOS CI need longer for process and browser startup.
 const STEP_TIMEOUT: Duration =
-    if cfg!(windows) { Duration::from_secs(60) } else { Duration::from_secs(20) };
+    if cfg!(any(windows, all(target_os = "macos", target_arch = "x86_64"))) {
+        Duration::from_secs(60)
+    } else {
+        Duration::from_secs(20)
+    };
 
 /// Screen size for the PTY terminal. Large enough to avoid line wrapping.
 const SCREEN_SIZE: ScreenSize = ScreenSize { rows: 500, cols: 500 };
@@ -226,8 +230,8 @@ struct E2e {
     #[serde(default)]
     pub cwd: RelativePathBuf,
     pub steps: Vec<Step>,
-    /// Optional platform filter: "unix", "linux", "linux-gnu", "macos", or
-    /// "windows". If set, test only runs on that platform.
+    /// Optional platform filter: "unix", "linux", "linux-gnu", "non-musl",
+    /// "macos", or "windows". If set, test only runs on that platform.
     #[serde(default)]
     pub platform: Option<Str>,
     /// When true, the generated libtest-mimic trial is marked `#[ignore]`
@@ -444,6 +448,11 @@ fn run_case(
             // by vt100's `Screen::contents()` when the snapshot is rendered,
             // so this does not introduce colour-noise into existing snapshots.
             cmd.env("TERM", "xterm-256color");
+            // The macOS x64 CI shard needs Playwright to select an x64 browser
+            // while running under Rosetta on Apple Silicon.
+            if let Some(value) = env::var_os("PLAYWRIGHT_HOST_PLATFORM_OVERRIDE") {
+                cmd.env("PLAYWRIGHT_HOST_PLATFORM_OVERRIDE", value);
+            }
             // On Windows, ensure common executable extensions are included in PATHEXT for command resolution in subprocesses.
             if cfg!(windows) {
                 cmd.env("PATHEXT", ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC");
@@ -662,6 +671,9 @@ fn main() {
                             // spawned children, which breaks fixtures that
                             // depend on interposer ordering.
                             "linux-gnu" => cfg!(target_os = "linux") && !cfg!(target_env = "musl"),
+                            // Playwright's bundled browser binaries do not
+                            // support musl targets.
+                            "non-musl" => !cfg!(target_env = "musl"),
                             other => panic!("Unknown platform '{}' in test '{}'", other, e2e.name),
                         };
                         if !should_run {

--- a/crates/vite_task_bin/tests/e2e_snapshots/redact.rs
+++ b/crates/vite_task_bin/tests/e2e_snapshots/redact.rs
@@ -45,6 +45,10 @@ pub fn redact_e2e_output(mut output: String, workspace_root: &str) -> String {
         use cow_utils::CowUtils as _;
         workspace_root_stripped.cow_replace('\\', r"\\").into_owned()
     };
+    let workspace_root_forward_slashes = {
+        use cow_utils::CowUtils as _;
+        workspace_root_stripped.cow_replace('\\', "/").into_owned()
+    };
 
     let mut redactions: Vec<(&str, &str)> = vec![
         (workspace_root, "<workspace>"),
@@ -60,6 +64,9 @@ pub fn redact_e2e_output(mut output: String, workspace_root: &str) -> String {
         && workspace_root_stripped_escaped != workspace_root_full_escaped
     {
         redactions.insert(1, (&workspace_root_stripped_escaped, "<workspace>"));
+    }
+    if workspace_root_forward_slashes != workspace_root_stripped {
+        redactions.push((&workspace_root_forward_slashes, "<workspace>"));
     }
 
     redact_string(&mut output, &redactions);

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -3,11 +3,15 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@playwright/browser-chromium": "catalog:",
+    "@vitest/browser-playwright": "catalog:",
     "@voidzero-dev/vite-task-client": "workspace:*",
     "cross-env": "catalog:",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
     "oxlint-tsgolint": "catalog:",
-    "vite": "catalog:"
+    "playwright": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,12 +6,18 @@ settings:
 
 catalogs:
   default:
+    '@playwright/browser-chromium':
+      specifier: 1.52.0
+      version: 1.52.0
     '@tsconfig/strictest':
       specifier: ^2.0.8
       version: 2.0.8
     '@types/node':
       specifier: 25.0.3
       version: 25.0.3
+    '@vitest/browser-playwright':
+      specifier: 4.1.10
+      version: 4.1.10
     cross-env:
       specifier: ^10.1.0
       version: 10.1.0
@@ -30,8 +36,12 @@ catalogs:
     vite-plus:
       specifier: 0.2.4
       version: 0.2.4
+    vitest:
+      specifier: 4.1.10
+      version: 4.1.10
 
 overrides:
+  playwright: 1.52.0
   vite: npm:@voidzero-dev/vite-plus-core@0.2.2
   vite-task-tools>vite: 8.1.3
 
@@ -53,10 +63,16 @@ importers:
         version: '@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3)'
       vite-plus:
         specifier: 'catalog:'
-        version: 0.2.4(@types/node@25.0.3)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(typescript@6.0.3)
+        version: 0.2.4(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(playwright@1.52.0)(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(typescript@6.0.3)
 
   packages/tools:
     dependencies:
+      '@playwright/browser-chromium':
+        specifier: 'catalog:'
+        version: 1.52.0
+      '@vitest/browser-playwright':
+        specifier: 'catalog:'
+        version: 4.1.10(playwright@1.52.0)(vite@8.1.3(@types/node@25.0.3))(vitest@4.1.10)
       '@voidzero-dev/vite-task-client':
         specifier: workspace:*
         version: link:../vite-task-client
@@ -65,16 +81,22 @@ importers:
         version: 10.1.0
       oxfmt:
         specifier: 'catalog:'
-        version: 0.57.0(vite-plus@0.2.4(@types/node@25.0.3)(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.3)))
+        version: 0.57.0(vite-plus@0.2.4(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.3)))
       oxlint:
         specifier: 'catalog:'
-        version: 1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@25.0.3)(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.3)))
+        version: 1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.3)))
       oxlint-tsgolint:
         specifier: 'catalog:'
         version: 0.24.0
+      playwright:
+        specifier: 1.52.0
+        version: 1.52.0
       vite:
         specifier: 8.1.3
         version: 8.1.3(@types/node@25.0.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(vite@8.1.3(@types/node@25.0.3))
 
   packages/vite-task-client: {}
 
@@ -404,6 +426,10 @@ packages:
     resolution: {integrity: sha512-titLmukUt/h8ho7Svlf0xSBjoy2ccZKrXjpXpZCj+v6V4CJccC2KyP45BLSCMx8YIpifMyiDyUptM4+5sruKbQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@playwright/browser-chromium@1.52.0':
+    resolution: {integrity: sha512-n2/e2Q0dFACFg/1JZ0t2IYLorDdno6q1QwKnNbPICHwCkAtW7+fSMqCvJ9FSMWSyPugxZqIFhownSpyATxtiTw==}
+    engines: {node: '>=18'}
+
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
@@ -538,6 +564,12 @@ packages:
 
   '@types/node@25.0.3':
     resolution: {integrity: sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==}
+
+  '@vitest/browser-playwright@4.1.10':
+    resolution: {integrity: sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==}
+    peerDependencies:
+      playwright: 1.52.0
+      vitest: 4.1.10
 
   '@vitest/browser-preview@4.1.10':
     resolution: {integrity: sha512-14MJrL59ZFkqXLjwfSk6RzTDy5Czf9UG4+8q8L6Gxjs2aPjEce/cVNYV14bXAc2BvMjUNu904+ZEZA1Xc1wtvQ==}
@@ -805,6 +837,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -952,6 +989,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.52.0:
+    resolution: {integrity: sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.52.0:
+    resolution: {integrity: sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
@@ -1332,6 +1379,10 @@ snapshots:
 
   '@oxlint/plugins@1.68.0': {}
 
+  '@playwright/browser-chromium@1.52.0':
+    dependencies:
+      playwright-core: 1.52.0
+
   '@polka/url@1.0.0-next.29': {}
 
   '@rolldown/binding-android-arm64@1.1.3':
@@ -1424,24 +1475,51 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(vitest@4.1.10)':
+  '@vitest/browser-playwright@4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(playwright@1.52.0)(vitest@4.1.10)':
     dependencies:
-      '@testing-library/dom': 10.4.1
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(vitest@4.1.10)
-      vitest: 4.1.10(@types/node@25.0.3)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))
+      '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))
+      playwright: 1.52.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(playwright@1.52.0)(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser-playwright@4.1.10(playwright@1.52.0)(vite@8.1.3(@types/node@25.0.3))(vitest@4.1.10)':
+    dependencies:
+      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@25.0.3))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@25.0.3))
+      playwright: 1.52.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(vite@8.1.3(@types/node@25.0.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser-preview@4.1.10(vite@8.1.3(@types/node@25.0.3))(vitest@4.1.10(@types/node@25.0.3)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3)))':
+  '@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(vitest@4.1.10)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@25.0.3))(vitest@4.1.10(@types/node@25.0.3)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3)))
-      vitest: 4.1.10(@types/node@25.0.3)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))
+      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(vitest@4.1.10)
+      vitest: 4.1.10(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(playwright@1.52.0)(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser-preview@4.1.10(vite@8.1.3(@types/node@25.0.3))(vitest@4.1.10)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@25.0.3))(vitest@4.1.10)
+      vitest: 4.1.10(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(vite@8.1.3(@types/node@25.0.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -1458,7 +1536,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@25.0.3)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))
+      vitest: 4.1.10(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(playwright@1.52.0)(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -1466,7 +1544,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(vite@8.1.3(@types/node@25.0.3))(vitest@4.1.10(@types/node@25.0.3)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3)))':
+  '@vitest/browser@4.1.10(vite@8.1.3(@types/node@25.0.3))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
       '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@25.0.3))
@@ -1475,14 +1553,13 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@25.0.3)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))
+      vitest: 4.1.10(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(vite@8.1.3(@types/node@25.0.3))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
-    optional: true
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -1508,7 +1585,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.1.3(@types/node@25.0.3)
-    optional: true
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -1623,6 +1699,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -1691,7 +1770,7 @@ snapshots:
 
   obug@2.1.1: {}
 
-  oxfmt@0.57.0(vite-plus@0.2.4(@types/node@25.0.3)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(typescript@6.0.3)):
+  oxfmt@0.57.0(vite-plus@0.2.4(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(playwright@1.52.0)(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(typescript@6.0.3)):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -1714,9 +1793,9 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.57.0
       '@oxfmt/binding-win32-ia32-msvc': 0.57.0
       '@oxfmt/binding-win32-x64-msvc': 0.57.0
-      vite-plus: 0.2.4(@types/node@25.0.3)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(typescript@6.0.3)
+      vite-plus: 0.2.4(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(playwright@1.52.0)(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(typescript@6.0.3)
 
-  oxfmt@0.57.0(vite-plus@0.2.4(@types/node@25.0.3)(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.3))):
+  oxfmt@0.57.0(vite-plus@0.2.4(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.3))):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -1739,7 +1818,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.57.0
       '@oxfmt/binding-win32-ia32-msvc': 0.57.0
       '@oxfmt/binding-win32-x64-msvc': 0.57.0
-      vite-plus: 0.2.4(@types/node@25.0.3)(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.3))
+      vite-plus: 0.2.4(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.3))
 
   oxlint-tsgolint@0.24.0:
     optionalDependencies:
@@ -1750,7 +1829,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.24.0
       '@oxlint-tsgolint/win32-x64': 0.24.0
 
-  oxlint@1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@25.0.3)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(typescript@6.0.3)):
+  oxlint@1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(playwright@1.52.0)(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(typescript@6.0.3)):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.72.0
       '@oxlint/binding-android-arm64': 1.72.0
@@ -1772,9 +1851,9 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.72.0
       '@oxlint/binding-win32-x64-msvc': 1.72.0
       oxlint-tsgolint: 0.24.0
-      vite-plus: 0.2.4(@types/node@25.0.3)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(typescript@6.0.3)
+      vite-plus: 0.2.4(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(playwright@1.52.0)(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(typescript@6.0.3)
 
-  oxlint@1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@25.0.3)(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.3))):
+  oxlint@1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.3))):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.72.0
       '@oxlint/binding-android-arm64': 1.72.0
@@ -1796,7 +1875,7 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.72.0
       '@oxlint/binding-win32-x64-msvc': 1.72.0
       oxlint-tsgolint: 0.24.0
-      vite-plus: 0.2.4(@types/node@25.0.3)(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.3))
+      vite-plus: 0.2.4(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.3))
 
   path-key@3.1.1: {}
 
@@ -1805,6 +1884,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.52.0: {}
+
+  playwright@1.52.0:
+    dependencies:
+      playwright-core: 1.52.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pngjs@7.0.0: {}
 
@@ -1885,7 +1972,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  vite-plus@0.2.4(@types/node@25.0.3)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(typescript@6.0.3):
+  vite-plus@0.2.4(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(playwright@1.52.0)(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
       '@oxc-project/types': 0.138.0
       '@oxlint/plugins': 1.68.0
@@ -1899,11 +1986,12 @@ snapshots:
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
       '@voidzero-dev/vite-plus-core': 0.2.4(@types/node@25.0.3)(typescript@6.0.3)
-      oxfmt: 0.57.0(vite-plus@0.2.4(@types/node@25.0.3)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(typescript@6.0.3))
-      oxlint: 1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@25.0.3)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(typescript@6.0.3))
+      oxfmt: 0.57.0(vite-plus@0.2.4(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(playwright@1.52.0)(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(typescript@6.0.3))
+      oxlint: 1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(playwright@1.52.0)(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(typescript@6.0.3))
       oxlint-tsgolint: 0.24.0
-      vitest: 4.1.10(@types/node@25.0.3)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))
+      vitest: 4.1.10(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(playwright@1.52.0)(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))
     optionalDependencies:
+      '@vitest/browser-playwright': 4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(playwright@1.52.0)(vitest@4.1.10)
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.4
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.4
       '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.2.4
@@ -1943,12 +2031,12 @@ snapshots:
       - vite
       - yaml
 
-  vite-plus@0.2.4(@types/node@25.0.3)(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.3)):
+  vite-plus@0.2.4(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.3)):
     dependencies:
       '@oxc-project/types': 0.138.0
       '@oxlint/plugins': 1.68.0
-      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@25.0.3))(vitest@4.1.10(@types/node@25.0.3)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3)))
-      '@vitest/browser-preview': 4.1.10(vite@8.1.3(@types/node@25.0.3))(vitest@4.1.10(@types/node@25.0.3)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3)))
+      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@25.0.3))(vitest@4.1.10)
+      '@vitest/browser-preview': 4.1.10(vite@8.1.3(@types/node@25.0.3))(vitest@4.1.10)
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@25.0.3))
       '@vitest/pretty-format': 4.1.10
@@ -1957,11 +2045,12 @@ snapshots:
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
       '@voidzero-dev/vite-plus-core': 0.2.4(@types/node@25.0.3)(typescript@6.0.3)
-      oxfmt: 0.57.0(vite-plus@0.2.4(@types/node@25.0.3)(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.3)))
-      oxlint: 1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@25.0.3)(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.3)))
+      oxfmt: 0.57.0(vite-plus@0.2.4(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.3)))
+      oxlint: 1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(typescript@6.0.3)(vite@8.1.3(@types/node@25.0.3)))
       oxlint-tsgolint: 0.24.0
-      vitest: 4.1.10(@types/node@25.0.3)(@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(vitest@4.1.10))(vite@8.1.3(@types/node@25.0.3))
+      vitest: 4.1.10(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(vite@8.1.3(@types/node@25.0.3))
     optionalDependencies:
+      '@vitest/browser-playwright': 4.1.10(playwright@1.52.0)(vite@8.1.3(@types/node@25.0.3))(vitest@4.1.10)
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.4
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.4
       '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.2.4
@@ -2013,36 +2102,7 @@ snapshots:
       '@types/node': 25.0.3
       fsevents: 2.3.3
 
-  vitest@4.1.10(@types/node@25.0.3)(@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(vitest@4.1.10))(vite@8.1.3(@types/node@25.0.3)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@25.0.3))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.1.3(@types/node@25.0.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 25.0.3
-      '@vitest/browser-preview': 4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(vitest@4.1.10)
-    transitivePeerDependencies:
-      - msw
-    optional: true
-
-  vitest@4.1.10(@types/node@25.0.3)(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3)):
+  vitest@4.1.10(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(playwright@1.52.0)(vitest@4.1.10))(@vitest/browser-preview@4.1.10)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))
@@ -2066,7 +2126,37 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.3
+      '@vitest/browser-playwright': 4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(playwright@1.52.0)(vitest@4.1.10)
       '@vitest/browser-preview': 4.1.10(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.0.3)(typescript@6.0.3))(vitest@4.1.10)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(vite@8.1.3(@types/node@25.0.3)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@25.0.3))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.3(@types/node@25.0.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.0.3
+      '@vitest/browser-playwright': 4.1.10(playwright@1.52.0)(vite@8.1.3(@types/node@25.0.3))(vitest@4.1.10)
+      '@vitest/browser-preview': 4.1.10(vite@8.1.3(@types/node@25.0.3))(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,21 +3,30 @@ packages:
   - packages/tools
   - packages/vite-task-client
 
+allowBuilds:
+  '@playwright/browser-chromium': true
+
 catalog:
   '@tsconfig/strictest': ^2.0.8
   '@types/node': 25.0.3
+  '@playwright/browser-chromium': 1.52.0
+  '@vitest/browser-playwright': 4.1.10
   cross-env: ^10.1.0
   husky: ^9.1.7
   lint-staged: ^17.0.0
   oxfmt: 0.57.0
   oxlint: ^1.55.0
   oxlint-tsgolint: ^0.24.0
+  # Playwright 1.52 pins the browser package to Chromium 136.
+  playwright: 1.52.0
   typescript: ^6.0.3
   vite: npm:@voidzero-dev/vite-plus-core@0.2.2
   vite-plus: 0.2.4
+  vitest: 4.1.10
 
 catalogMode: prefer
 overrides:
+  playwright: 1.52.0
   vite: 'catalog:'
   # The e2e harness symlinks packages/tools' `vite` binary into fixtures to
   # exercise the real vite-task-client integration. The global `vite: catalog:`


### PR DESCRIPTION
## Motivation

Vite Task lacked end-to-end coverage proving that Vitest browser-mode tasks infer source inputs and archive generated reporter outputs correctly. Add Chromium-backed coverage and provision the pinned browser consistently across supported CI platforms.