### PR TITLE
feat: mark task-spawned processes with VP_RUN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- **Added** Tasks now run with `VP_RUN=1` set, so tools can tell they are running under `vp run` instead of being invoked directly ([#570](https://github.com/voidzero-dev/vite-task/pull/570)).
 - **Fixed** The task cache now supports much larger automatically tracked input sets without hitting wincode's default 4 MiB sequence preallocation limit ([#554](https://github.com/voidzero-dev/vite-task/pull/554)).
 - **Fixed** npm workspace patterns beginning with `./` now discover matching packages correctly ([vite-plus#2201](https://github.com/voidzero-dev/vite-plus/issues/2201), [#547](https://github.com/voidzero-dev/vite-task/pull/547)).
 - **Fixed** Failures while forwarding output from a started task process no longer incorrectly say the process failed to spawn ([#506](https://github.com/voidzero-dev/vite-task/issues/506)).

--- a/crates/vite_task/src/lib.rs
+++ b/crates/vite_task/src/lib.rs
@@ -17,4 +17,4 @@ pub use vite_task_graph::{
 };
 /// Re-exports useful for `CommandHandler` implementations.
 pub use vite_task_plan::get_path_env;
-pub use vite_task_plan::{plan_request, plan_request::ScriptCommand};
+pub use vite_task_plan::{MARKER_ENV_NAME, plan_request, plan_request::ScriptCommand};

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vp_run_env/package.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vp_run_env/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "vp-run-env",
+  "private": true
+}

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vp_run_env/snapshots.toml
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vp_run_env/snapshots.toml
@@ -1,0 +1,29 @@
+[[e2e]]
+name = "vp_run_env_marks_every_spawned_task"
+comment = """
+Every process a task spawns gets `VP_RUN=1`, so a tool can tell it was started by `vp run` instead of being typed directly.
+
+The parent shell sets `VP_RUN=0` in both steps to show the marker is forced rather than inherited. The cached task also restricts passthrough to `env: ["NODE_ENV"]`, which filters the parent's value out entirely; the marker is set after that filtering, so it survives either way.
+"""
+steps = [
+  { argv = [
+    "vt",
+    "run",
+    "print-marker-cached",
+  ], envs = [
+    [
+      "VP_RUN",
+      "0",
+    ],
+  ], comment = "cached task: env passthrough cannot drop the marker" },
+  { argv = [
+    "vt",
+    "run",
+    "print-marker-uncached",
+  ], envs = [
+    [
+      "VP_RUN",
+      "0",
+    ],
+  ], comment = "uncached task: the parent environment flows through, but the marker still wins" },
+]

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vp_run_env/snapshots/vp_run_env_marks_every_spawned_task.md
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vp_run_env/snapshots/vp_run_env_marks_every_spawned_task.md
@@ -1,0 +1,23 @@
+# vp_run_env_marks_every_spawned_task
+
+Every process a task spawns gets `VP_RUN=1`, so a tool can tell it was started by `vp run` instead of being typed directly.
+
+The parent shell sets `VP_RUN=0` in both steps to show the marker is forced rather than inherited. The cached task also restricts passthrough to `env: ["NODE_ENV"]`, which filters the parent's value out entirely; the marker is set after that filtering, so it survives either way.
+
+## `VP_RUN=0 vt run print-marker-cached`
+
+cached task: env passthrough cannot drop the marker
+
+```
+$ vtt print-env VP_RUN
+1
+```
+
+## `VP_RUN=0 vt run print-marker-uncached`
+
+uncached task: the parent environment flows through, but the marker still wins
+
+```
+$ vtt print-env VP_RUN ⊘ cache disabled
+1
+```

--- a/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vp_run_env/vite-task.json
+++ b/crates/vite_task_bin/tests/e2e_snapshots/fixtures/vp_run_env/vite-task.json
@@ -1,0 +1,15 @@
+{
+  "tasks": {
+    "print-marker-cached": {
+      "command": "vtt print-env VP_RUN",
+      "cache": true,
+      "env": ["NODE_ENV"],
+      "input": ["package.json"],
+      "output": []
+    },
+    "print-marker-uncached": {
+      "command": "vtt print-env VP_RUN",
+      "cache": false
+    }
+  }
+}

--- a/crates/vite_task_plan/src/envs.rs
+++ b/crates/vite_task_plan/src/envs.rs
@@ -11,6 +11,12 @@ use wincode::{SchemaRead, SchemaWrite};
 const SHA256_DIGEST_LEN: usize = 32;
 const SHA256_PREFIX: &str = "sha256:";
 
+/// Name of the environment variable set to `1` in every process a task spawns.
+///
+/// Lets a tool tell that it is running as part of a task rather than having
+/// been invoked directly.
+pub const MARKER_ENV_NAME: &str = "VP_RUN";
+
 /// SHA-256 digest of a fingerprinted environment variable value.
 #[derive(SchemaWrite, SchemaRead, PartialEq, Eq, Clone, Copy)]
 pub struct EnvValueHash([u8; SHA256_DIGEST_LEN]);

--- a/crates/vite_task_plan/src/lib.rs
+++ b/crates/vite_task_plan/src/lib.rs
@@ -12,6 +12,7 @@ mod ps1_shim;
 use std::{collections::BTreeMap, ffi::OsStr, fmt::Debug, sync::Arc};
 
 use context::PlanContext;
+pub use envs::MARKER_ENV_NAME;
 pub use error::Error;
 pub use execution_graph::{DEFAULT_CONCURRENCY_LIMIT, ExecutionGraph};
 pub use in_process::InProcessExecution;

--- a/crates/vite_task_plan/src/plan.rs
+++ b/crates/vite_task_plan/src/plan.rs
@@ -31,7 +31,7 @@ use crate::{
     ExecutionItem, ExecutionItemDisplay, ExecutionItemKind, LeafExecutionKind, PlanContext,
     SpawnCommand, SpawnExecution, TaskExecution,
     cache_metadata::{CacheMetadata, ExecutionCacheKey, ProgramFingerprint, SpawnFingerprint},
-    envs::{EnvFingerprints, EnvValueHash},
+    envs::{EnvFingerprints, EnvValueHash, MARKER_ENV_NAME},
     error::{CdCommandError, Error, PathFingerprintError, PathFingerprintErrorKind, PathType},
     execution_graph::{ExecutionGraph, ExecutionNodeIndex, InnerExecutionGraph},
     in_process::InProcessExecution,
@@ -679,6 +679,13 @@ fn plan_spawn_execution(
             });
         }
     }
+
+    // Mark the child as task-spawned. Set after `EnvFingerprints::resolve` has
+    // filtered `spawn_envs`, so a task's `env`/`untrackedEnv` patterns cannot
+    // drop it, and always to `1`, so a stale value in the parent environment
+    // cannot make a task look like it was invoked directly. A prefix
+    // assignment (`VP_RUN=… command`) still wins: those are applied below.
+    spawn_envs.insert(OsStr::new(MARKER_ENV_NAME).into(), OsStr::new("1").into());
 
     // Add prefix envs to spawn envs.
     spawn_envs.extend(prefix_envs.iter().map(|(name, value)| {

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/additional_env/snapshots/query_tool_synthetic_task_in_user_task.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/additional_env/snapshots/query_tool_synthetic_task_in_user_task.jsonc
@@ -76,7 +76,8 @@
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
                       "PATH": "<workspace>/node_modules/.bin:<tools>",
-                      "TEST_VAR": "hello_world"
+                      "TEST_VAR": "hello_world",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_does_not_override_per_task_cache_false.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_does_not_override_per_task_cache_false.jsonc
@@ -35,7 +35,8 @@
                     ],
                     "spawn_envs": {
                       "NO_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_enables_script_caching.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_enables_script_caching.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_enables_task_caching_even_when_cache_tasks_is_false.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_enables_task_caching_even_when_cache_tasks_is_false.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_on_task_with_per_task_cache_true_enables_caching.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___cache_on_task_with_per_task_cache_true_enables_caching.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___no_cache_disables_task_caching.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___no_cache_disables_task_caching.jsonc
@@ -35,7 +35,8 @@
                     ],
                     "spawn_envs": {
                       "NO_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___no_cache_overrides_per_task_cache_true.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query___no_cache_overrides_per_task_cache_true.jsonc
@@ -35,7 +35,8 @@
                     ],
                     "spawn_envs": {
                       "NO_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query_baseline___tasks_not_cached_when_cache_tasks_is_false.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_cli_override/snapshots/query_baseline___tasks_not_cached_when_cache_tasks_is_false.jsonc
@@ -35,7 +35,8 @@
                     ],
                     "spawn_envs": {
                       "NO_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_echo_and_lint_with_extra_args.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_echo_and_lint_with_extra_args.jsonc
@@ -102,7 +102,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_lint_and_echo_with_extra_args.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_lint_and_echo_with_extra_args.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_normal_task_with_extra_args.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_normal_task_with_extra_args.jsonc
@@ -75,7 +75,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_synthetic_task_in_user_task.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_synthetic_task_in_user_task.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_synthetic_task_in_user_task_with_cwd.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_synthetic_task_in_user_task_with_cwd.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_synthetic_task_with_extra_args_in_user_task.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_keys/snapshots/query_synthetic_task_with_extra_args_in_user_task.jsonc
@@ -77,7 +77,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_default/snapshots/query_script_not_cached_by_default.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_default/snapshots/query_script_not_cached_by_default.jsonc
@@ -35,7 +35,8 @@
                     ],
                     "spawn_envs": {
                       "NO_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_task_override/snapshots/query_another_task_cached_by_default.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_task_override/snapshots/query_another_task_cached_by_default.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_task_override/snapshots/query_script_not_cached_by_default.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_task_override/snapshots/query_script_not_cached_by_default.jsonc
@@ -35,7 +35,8 @@
                     ],
                     "spawn_envs": {
                       "NO_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_task_override/snapshots/query_task_cached_by_default.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_scripts_task_override/snapshots/query_task_cached_by_default.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_subcommand/snapshots/query_cache_clean_in_script.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_subcommand/snapshots/query_cache_clean_in_script.jsonc
@@ -35,7 +35,8 @@
                     ],
                     "spawn_envs": {
                       "NO_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_tasks_disabled/snapshots/query_per_task_cache_true_still_disabled_by_cache_tasks_false.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_tasks_disabled/snapshots/query_per_task_cache_true_still_disabled_by_cache_tasks_false.jsonc
@@ -35,7 +35,8 @@
                     ],
                     "spawn_envs": {
                       "NO_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_tasks_disabled/snapshots/query_script_not_cached.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_tasks_disabled/snapshots/query_script_not_cached.jsonc
@@ -35,7 +35,8 @@
                     ],
                     "spawn_envs": {
                       "NO_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_tasks_disabled/snapshots/query_task_not_cached_when_cache_tasks_is_false.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_tasks_disabled/snapshots/query_task_not_cached_when_cache_tasks_is_false.jsonc
@@ -35,7 +35,8 @@
                     ],
                     "spawn_envs": {
                       "NO_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_true_no_force_enable/snapshots/query_script_cached_when_global_cache_true.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_true_no_force_enable/snapshots/query_script_cached_when_global_cache_true.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_true_no_force_enable/snapshots/query_task_cached_when_global_cache_true.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_true_no_force_enable/snapshots/query_task_cached_when_global_cache_true.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_true_no_force_enable/snapshots/query_task_with_cache_false_not_cached_despite_global_cache_true.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cache_true_no_force_enable/snapshots/query_task_with_cache_false_not_cached_despite_global_cache_true.jsonc
@@ -35,7 +35,8 @@
                     ],
                     "spawn_envs": {
                       "NO_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cd_in_scripts/snapshots/query_cd_before_vt_lint_should_put_synthetic_task_under_cwd.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cd_in_scripts/snapshots/query_cd_before_vt_lint_should_put_synthetic_task_under_cwd.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/src"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/cd_in_scripts/snapshots/query_cd_before_vt_run_should_not_affect_expanded_task_cwd.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/cd_in_scripts/snapshots/query_cd_before_vt_run_should_not_affect_expanded_task_cwd.jsonc
@@ -98,7 +98,8 @@
                                   ],
                                   "spawn_envs": {
                                     "FORCE_COLOR": "1",
-                                    "PATH": "<workspace>/node_modules/.bin:<tools>"
+                                    "PATH": "<workspace>/node_modules/.bin:<tools>",
+                                    "VP_RUN": "1"
                                   },
                                   "cwd": "<workspace>/"
                                 }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/extra_args_not_forwarded_to_depends_on/snapshots/query_extra_args_only_reach_requested_task.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/extra_args_not_forwarded_to_depends_on/snapshots/query_extra_args_only_reach_requested_task.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }
@@ -161,7 +162,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_nested___cache_enables_inner_task_caching.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_nested___cache_enables_inner_task_caching.jsonc
@@ -98,7 +98,8 @@
                                   ],
                                   "spawn_envs": {
                                     "FORCE_COLOR": "1",
-                                    "PATH": "<workspace>/node_modules/.bin:<tools>"
+                                    "PATH": "<workspace>/node_modules/.bin:<tools>",
+                                    "VP_RUN": "1"
                                   },
                                   "cwd": "<workspace>/"
                                 }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_nested___no_cache_disables_inner_task_caching.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_nested___no_cache_disables_inner_task_caching.jsonc
@@ -60,7 +60,8 @@
                                   ],
                                   "spawn_envs": {
                                     "NO_COLOR": "1",
-                                    "PATH": "<workspace>/node_modules/.bin:<tools>"
+                                    "PATH": "<workspace>/node_modules/.bin:<tools>",
+                                    "VP_RUN": "1"
                                   },
                                   "cwd": "<workspace>/"
                                 }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_nested_run_without_flags_inherits_parent_cache.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_nested_run_without_flags_inherits_parent_cache.jsonc
@@ -60,7 +60,8 @@
                                   ],
                                   "spawn_envs": {
                                     "NO_COLOR": "1",
-                                    "PATH": "<workspace>/node_modules/.bin:<tools>"
+                                    "PATH": "<workspace>/node_modules/.bin:<tools>",
+                                    "VP_RUN": "1"
                                   },
                                   "cwd": "<workspace>/"
                                 }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_outer___cache_propagates_to_nested_run_without_flags.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_outer___cache_propagates_to_nested_run_without_flags.jsonc
@@ -98,7 +98,8 @@
                                   ],
                                   "spawn_envs": {
                                     "FORCE_COLOR": "1",
-                                    "PATH": "<workspace>/node_modules/.bin:<tools>"
+                                    "PATH": "<workspace>/node_modules/.bin:<tools>",
+                                    "VP_RUN": "1"
                                   },
                                   "cwd": "<workspace>/"
                                 }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_outer___no_cache_does_not_propagate_into_nested___cache.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_outer___no_cache_does_not_propagate_into_nested___cache.jsonc
@@ -98,7 +98,8 @@
                                   ],
                                   "spawn_envs": {
                                     "FORCE_COLOR": "1",
-                                    "PATH": "<workspace>/node_modules/.bin:<tools>"
+                                    "PATH": "<workspace>/node_modules/.bin:<tools>",
+                                    "VP_RUN": "1"
                                   },
                                   "cwd": "<workspace>/"
                                 }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_outer___no_cache_propagates_to_nested_run_without_flags.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/nested_cache_override/snapshots/query_outer___no_cache_propagates_to_nested_run_without_flags.jsonc
@@ -60,7 +60,8 @@
                                   ],
                                   "spawn_envs": {
                                     "NO_COLOR": "1",
-                                    "PATH": "<workspace>/node_modules/.bin:<tools>"
+                                    "PATH": "<workspace>/node_modules/.bin:<tools>",
+                                    "VP_RUN": "1"
                                   },
                                   "cwd": "<workspace>/"
                                 }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/shell_fallback/snapshots/query_shell_fallback_for_pipe_command.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/shell_fallback/snapshots/query_shell_fallback_for_pipe_command.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_parent_cache_false_does_not_affect_expanded_query_tasks.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_parent_cache_false_does_not_affect_expanded_query_tasks.jsonc
@@ -98,7 +98,8 @@
                                   ],
                                   "spawn_envs": {
                                     "FORCE_COLOR": "1",
-                                    "PATH": "<workspace>/node_modules/.bin:<tools>"
+                                    "PATH": "<workspace>/node_modules/.bin:<tools>",
+                                    "VP_RUN": "1"
                                   },
                                   "cwd": "<workspace>/"
                                 }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_script_cache_false_does_not_affect_expanded_synthetic_cache.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_script_cache_false_does_not_affect_expanded_synthetic_cache.jsonc
@@ -98,7 +98,8 @@
                                   ],
                                   "spawn_envs": {
                                     "FORCE_COLOR": "1",
-                                    "PATH": "<workspace>/node_modules/.bin:<tools>"
+                                    "PATH": "<workspace>/node_modules/.bin:<tools>",
+                                    "VP_RUN": "1"
                                   },
                                   "cwd": "<workspace>/"
                                 }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_script_without_cache_scripts_defaults_to_no_cache.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_script_without_cache_scripts_defaults_to_no_cache.jsonc
@@ -35,7 +35,8 @@
                     ],
                     "spawn_envs": {
                       "NO_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_task_untrackedEnv_inherited_by_synthetic.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_task_untrackedEnv_inherited_by_synthetic.jsonc
@@ -74,7 +74,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_task_with_cache_false_disables_synthetic_cache.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_task_with_cache_false_disables_synthetic_cache.jsonc
@@ -35,7 +35,8 @@
                     ],
                     "spawn_envs": {
                       "NO_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_task_with_cache_true_enables_synthetic_cache.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_cache_disabled/snapshots/query_task_with_cache_true_enables_synthetic_cache.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_in_subpackage/snapshots/query_synthetic_in_subpackage.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/synthetic_in_subpackage/snapshots/query_synthetic_in_subpackage.jsonc
@@ -98,7 +98,8 @@
                                   ],
                                   "spawn_envs": {
                                     "FORCE_COLOR": "1",
-                                    "PATH": "<workspace>/packages/a/node_modules/.bin:<workspace>/node_modules/.bin:<tools>"
+                                    "PATH": "<workspace>/packages/a/node_modules/.bin:<workspace>/node_modules/.bin:<tools>",
+                                    "VP_RUN": "1"
                                   },
                                   "cwd": "<workspace>/packages/a"
                                 }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_array_cd.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_array_cd.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }
@@ -141,7 +142,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/snapshots"
                   }
@@ -209,7 +211,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/snapshots"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_array_shorthand.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_array_shorthand.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }
@@ -141,7 +142,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }
@@ -209,7 +211,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_array_unbalanced_quotes.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_array_unbalanced_quotes.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }
@@ -141,7 +142,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_array_with_and.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_array_with_and.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }
@@ -141,7 +142,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }
@@ -209,7 +211,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_nested_vt_array.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_nested_vt_array.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }
@@ -166,7 +167,8 @@
                                   ],
                                   "spawn_envs": {
                                     "FORCE_COLOR": "1",
-                                    "PATH": "<workspace>/node_modules/.bin:<tools>"
+                                    "PATH": "<workspace>/node_modules/.bin:<tools>",
+                                    "VP_RUN": "1"
                                   },
                                   "cwd": "<workspace>/"
                                 }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_object_array_depends_on.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_object_array_depends_on.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }
@@ -141,7 +142,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }
@@ -209,7 +211,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }
@@ -298,7 +301,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_string_shorthand.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/task_command_shorthands/snapshots/query_string_shorthand.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/windows_cmd_shim_rewrite/snapshots/query_dev_filter_from_root.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/windows_cmd_shim_rewrite/snapshots/query_dev_filter_from_root.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/packages/foo/node_modules/.bin:<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/packages/foo/node_modules/.bin:<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/packages/foo"
                   }

--- a/crates/vite_task_plan/tests/plan_snapshots/fixtures/windows_cmd_shim_rewrite/snapshots/query_dev_in_subpackage.jsonc
+++ b/crates/vite_task_plan/tests/plan_snapshots/fixtures/windows_cmd_shim_rewrite/snapshots/query_dev_in_subpackage.jsonc
@@ -73,7 +73,8 @@
                     ],
                     "spawn_envs": {
                       "FORCE_COLOR": "1",
-                      "PATH": "<workspace>/packages/foo/node_modules/.bin:<workspace>/node_modules/.bin:<tools>"
+                      "PATH": "<workspace>/packages/foo/node_modules/.bin:<workspace>/node_modules/.bin:<tools>",
+                      "VP_RUN": "1"
                     },
                     "cwd": "<workspace>/packages/foo"
                   }


### PR DESCRIPTION
## Motivation

A tool started from a task cannot tell whether it was launched by `vp run` or
typed directly. Vite+ needs that distinction: its built-in commands point at
`vpr <name>` when a same-named script exists, which is misleading when that
very script is what spawned them.

Every spawned task now carries `VP_RUN=1`. It is set after `env`/`untrackedEnv`
filtering so a task's passthrough config cannot drop it, and it is forced
rather than inherited so a stale parent value cannot make a task look like a
direct invocation. A prefix assignment on the command still wins. The name is
exported as `MARKER_ENV_NAME` so consumers do not hardcode it.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>