### PR TITLE
docs: use gh stack for pull request stacks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ just lint-windows  # Cross-clippy for Windows (requires cargo-xwin)
 just doc           # Documentation generation
 ```
 
-If `gt` (Graphite CLI) is available in PATH, use it instead of `gh` to create pull requests.
+Use `gh stack` to create pull request stacks.
 
 PR titles must use [Conventional Commits](https://www.conventionalcommits.org) format: `type(scope): summary` (scope is optional), e.g. `feat(cache): add LRU eviction`, `fix: handle symlink loops`, `test(e2e): add ctrl-c propagation test`.
 


### PR DESCRIPTION
## Motivation

The contributor guidance recommends Graphite’s `gt` command when available, but the project now standardizes on GitHub CLI’s native stacked pull request workflow. Update the instruction so contributors use `gh stack` to create pull request stacks.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>