### PR TITLE
perf: optimize artifact dependencies, and fail the build when a consumer does not

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "artifact_profile"
+version = "0.0.0"
+
+[[package]]
 name = "assert2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,6 +1296,7 @@ name = "fspy_preload_unix"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "artifact_profile",
  "bstr",
  "ctor",
  "fspy_shared",
@@ -1305,6 +1310,7 @@ dependencies = [
 name = "fspy_preload_windows"
 version = "0.1.0"
 dependencies = [
+ "artifact_profile",
  "constcat",
  "fspy_detours_sys",
  "fspy_shared",
@@ -4243,6 +4249,7 @@ dependencies = [
 name = "vt_client_napi"
 version = "0.1.0"
 dependencies = [
+ "artifact_profile",
  "napi",
  "napi-build",
  "napi-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ multiple_crate_versions = "allow"
 future_not_send = "allow"
 
 [workspace.dependencies]
+artifact_profile = { path = "crates/artifact_profile" }
 anstream = "1.0.0"
 anyhow = "1.0.103"
 assert2 = "0.4.0"
@@ -201,3 +202,32 @@ codegen-units = 1
 strip = "symbols" # set to `false` for debug information
 debug = false # set to `true` for debug information
 panic = "abort" # Let it crash and force ourselves to write safe Rust.
+
+# Cargo compiles artifact dependencies declared under `[build-dependencies]`
+# with the build-override profile — opt-level 0, no codegen-units setting —
+# even in release builds, and even with `target = "target"`. Their output
+# still lands under `target/<triple>/release/`, so the missing optimization
+# is easy to miss. (Artifact deps under `[dependencies]`/`[dev-dependencies]`
+# get the normal profile and need nothing here.) See
+# https://github.com/rust-lang/cargo/issues/16719.
+#
+# These are the workspace's build-dependency artifacts: the preload libraries
+# are injected into every traced process and run inside every intercepted
+# libc call, and the napi library backs the Node.js client.
+#
+# `strip` must be restated: a package override resets an inherited `strip`
+# to "debuginfo" when the field is omitted (Cargo quirk in profile merging).
+[profile.release.package.fspy_preload_unix]
+opt-level = 3
+codegen-units = 1
+strip = "symbols"
+
+[profile.release.package.fspy_preload_windows]
+opt-level = 3
+codegen-units = 1
+strip = "symbols"
+
+[profile.release.package.vt_client_napi]
+opt-level = 3
+codegen-units = 1
+strip = "symbols"

--- a/crates/artifact_profile/Cargo.toml
+++ b/crates/artifact_profile/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "artifact_profile"
+version = "0.0.0"
+edition = "2024"
+license.workspace = true
+publish = false
+
+[lib]
+test = false
+doctest = false
+
+[lints]
+workspace = true

--- a/crates/artifact_profile/src/lib.rs
+++ b/crates/artifact_profile/src/lib.rs
@@ -1,0 +1,63 @@
+//! Build-script guard for crates that are consumed as artifact dependencies.
+//!
+//! This is the producer side of the artifact contract, and it has to live
+//! here rather than in `materialized_artifact_build`: that crate runs from the
+//! *consuming* crate's build script, which only ever sees its own profile.
+//! A consumer's build script reports `OPT_LEVEL=3` while the artifact it just
+//! embedded was built at 0, and the artifact's path records nothing about how
+//! it was compiled. Only the artifact crate's own build script can tell.
+
+use std::env;
+
+/// Fails the build when the calling crate is compiled without optimizations
+/// in a release build.
+///
+/// Cargo compiles artifact dependencies declared under `[build-dependencies]`
+/// with the build-override profile — opt-level 0 — even in release builds, and
+/// it only reads profiles from the root manifest of the workspace being built.
+/// A workspace that depends on this repo therefore has to opt in explicitly,
+/// and nothing tells it otherwise: the output still lands under
+/// `target/<triple>/release/`, and the only symptom is a slower binary. See
+/// <https://github.com/rust-lang/cargo/issues/16719>.
+///
+/// Call this from the artifact crate's own build script, where `OPT_LEVEL`
+/// reports that crate's own profile rather than its parent's.
+///
+/// Only the optimization level is checked. Cargo passes `OPT_LEVEL`, `DEBUG`
+/// and `PROFILE` to build scripts but not `codegen-units` or `strip`, so the
+/// rest of the recommended profile block cannot be verified here — which is
+/// why the failure prints the whole block rather than just the one setting.
+/// `strip` in particular must be restated by anyone adding an override at all:
+/// a package override that omits it silently resets an inherited
+/// `strip = "symbols"` to `"debuginfo"`.
+///
+/// # Panics
+///
+/// Panics — failing the build — when `PROFILE` is `release` and `OPT_LEVEL` is
+/// `0`.
+pub fn require_optimized_in_release() {
+    // `PROFILE` is `release` for release-like profiles and `debug` otherwise,
+    // so debug builds — where opt-level 0 is correct — never trip this.
+    if env::var("PROFILE").as_deref() != Ok("release")
+        || env::var("OPT_LEVEL").as_deref() != Ok("0")
+    {
+        return;
+    }
+    let package = env::var("CARGO_PKG_NAME").unwrap_or_else(|_| "this crate".into());
+    panic!(
+        "\n\n\
+         `{package}` was built without optimizations in a release build.\n\n\
+         It is an artifact dependency, which Cargo compiles with the\n\
+         build-override profile (opt-level 0) even in release builds. Profiles\n\
+         only take effect from the root manifest of the workspace being built,\n\
+         so add this to the root Cargo.toml of *your* workspace:\n\n    \
+         [profile.release.package.{package}]\n    \
+         opt-level = 3\n    \
+         codegen-units = 1\n    \
+         strip = \"symbols\"\n\n\
+         Keep all three: an override that omits `strip` resets it to\n\
+         \"debuginfo\", and `codegen-units` is dropped by the build-override\n\
+         profile. Without this block the crate ships unoptimized and nothing\n\
+         else reports it.\n"
+    );
+}

--- a/crates/fspy_preload_unix/Cargo.toml
+++ b/crates/fspy_preload_unix/Cargo.toml
@@ -17,5 +17,8 @@ fspy_shared_unix = { workspace = true }
 libc = { workspace = true }
 nix = { workspace = true, features = ["signal", "fs", "socket", "mman", "time"] }
 
+[build-dependencies]
+artifact_profile = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/fspy_preload_unix/build.rs
+++ b/crates/fspy_preload_unix/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    // This library is injected into every traced process and runs inside every
+    // intercepted libc call, so an unoptimized build is a silent, large
+    // regression for whoever consumes it.
+    artifact_profile::require_optimized_in_release();
+}

--- a/crates/fspy_preload_windows/Cargo.toml
+++ b/crates/fspy_preload_windows/Cargo.toml
@@ -29,5 +29,8 @@ winsafe = { workspace = true }
 [target.'cfg(target_os = "windows")'.dev-dependencies]
 tempfile = { workspace = true }
 
+[build-dependencies]
+artifact_profile = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/fspy_preload_windows/build.rs
+++ b/crates/fspy_preload_windows/build.rs
@@ -1,4 +1,7 @@
 fn main() {
+    // Injected into every traced process; see the unix preload's build.rs.
+    artifact_profile::require_optimized_in_release();
+
     if std::env::var_os("CARGO_CFG_TARGET_OS").unwrap() == "windows" {
         println!("cargo:rustc-cdylib-link-arg=/EXPORT:DetourFinishHelperProcess,@1,NONAME");
     }

--- a/crates/vt_client_napi/Cargo.toml
+++ b/crates/vt_client_napi/Cargo.toml
@@ -18,6 +18,7 @@ vt_str = { workspace = true }
 vt_client = { workspace = true }
 
 [build-dependencies]
+artifact_profile = { workspace = true }
 napi-build = { workspace = true }
 
 [lints]

--- a/crates/vt_client_napi/build.rs
+++ b/crates/vt_client_napi/build.rs
@@ -8,6 +8,9 @@ extern crate napi_build;
 use std::{env, fs, path::PathBuf};
 
 fn main() {
+    // Shipped inside the built product; see `artifact_profile`.
+    artifact_profile::require_optimized_in_release();
+
     napi_build::setup();
 
     // Keep this crate's napi-derive type-defs out of any consumer's generated


### PR DESCRIPTION
## Motivation

Cargo compiles artifact dependencies declared under `[build-dependencies]` with the build-override profile — opt-level 0 — even in release builds. It is the `[build-dependencies]` placement, not the `artifact = ...` key, that triggers this (artifact deps under `[dependencies]` get the normal profile). The output still lands under `target/<triple>/release/`, so nothing reports the omission. See [rust-lang/cargo#16719](https://github.com/rust-lang/cargo/issues/16719); the per-package override used here is what maintainers recommend ([rust-lang/cargo#11680](https://github.com/rust-lang/cargo/issues/11680)).

Three workspace artifacts are build-dependencies and have been shipping unoptimized: the two preload libraries — injected into every traced process, running inside every intercepted libc call — and `vt_client_napi`.

## What this does

**Sets the profile.** A `[profile.release.package.<name>]` block per artifact, with `opt-level = 3`, `codegen-units = 1` (the host profile drops the workspace setting), and `strip = "symbols"` (a package override otherwise resets an inherited `strip` to `"debuginfo"`, which would leave the preload `.so` — embedded into the `fspy` binary — larger than intended).

**Then checks that it worked.** Profiles only take effect from the root manifest of the workspace being built, so these entries do not reach workspaces that consume these crates. vite-plus builds the preload at opt-level 0 today and would keep doing so after this merges, silently. Rather than rely on every consumer knowing, each artifact crate now inspects its own `OPT_LEVEL` in its build script and fails a release build that is unoptimized:

```
`fspy_preload_unix` was built without optimizations in a release build.

It is an artifact dependency, which Cargo compiles with the
build-override profile (opt-level 0) even in release builds. Profiles
only take effect from the root manifest of the workspace being built,
so add this to the root Cargo.toml of *your* workspace:

    [profile.release.package.fspy_preload_unix]
    opt-level = 3
    codegen-units = 1
    strip = "symbols"

Keep all three: an override that omits `strip` resets it to
"debuginfo", and `codegen-units` is dropped by the build-override
profile. Without this block the crate ships unoptimized and nothing
else reports it.
```

Debug builds are unaffected, since opt-level 0 is correct there.

Only the optimization level is checked: Cargo passes `OPT_LEVEL`, `DEBUG` and `PROFILE` to build scripts, but not `codegen-units` or `strip`, so those cannot be verified — which is why the message prints the whole block rather than the one setting it can see. The check lives in each artifact crate rather than in `materialized_artifact_build` because that crate runs from the *consuming* build script, which reports its own `OPT_LEVEL` (3) while the artifact it just embedded was built at 0.

**This is a breaking change for downstream workspaces.** vite-plus will fail to build until it adds the three blocks to its root `Cargo.toml` — it already uses that pattern for `vite_trampoline` and `vite_installer`. That failure is the point: the alternative is shipping a preload that costs ~25% on every intercepted call, with no signal at all.

## Measurements

x86_64 Linux, benchmark launcher built with vs. without the profile change, batch median per 8 tracked opens:

```
access             -24.8%
access-relative    -19.1%
```

Raising the *dependency subtree's* pre-LTO opt-level on top of this measured within noise — fat LTO re-optimizes the merged module at the cdylib's opt-level — so this keeps the smaller, cdylib-only override set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)