### PR TITLE
refactor(fspy): return resolved paths without callbacks

### DIFF
--- a/crates/fspy_preload_unix/src/client/convert.rs
+++ b/crates/fspy_preload_unix/src/client/convert.rs
@@ -1,7 +1,7 @@
 use std::ffi::CStr;
 
 use allocator_api2::{alloc::Allocator, vec::Vec};
-use bstr::{BStr, ByteSlice};
+use bstr::ByteSlice;
 use fspy_shared::ipc::AccessMode;
 use libc::{c_char, c_int};
 use sigsafe::{AsRawFd as _, BorrowedFd, CWD};
@@ -24,7 +24,8 @@ fn get_fd_path<A: Allocator>(allocator: A, fd: BorrowedFd<'_>) -> nix::Result<Op
 }
 
 #[cfg(target_os = "linux")]
-const PROC_FD_PATH_CAPACITY: usize = b"/proc/self/fd/".len() + 11 + 1;
+const PROC_FD_PATH_CAPACITY: usize =
+    b"/proc/self/fd/".len() + <c_int as itoa::Integer>::MAX_STR_LEN + 1;
 
 #[cfg(target_os = "linux")]
 fn proc_fd_path<'buf>(
@@ -66,20 +67,38 @@ fn get_fd_path<A: Allocator>(allocator: A, fd: BorrowedFd<'_>) -> nix::Result<Op
 }
 
 pub trait ToAbsolutePath {
-    fn to_absolute_path<R, F: FnOnce(Option<&BStr>) -> nix::Result<R>>(
+    /// Resolves this argument to an absolute path allocated in `allocator`,
+    /// or borrowed from the argument itself when it is already absolute.
+    ///
+    /// The result is a C string so that callers forwarding it to an exec —
+    /// which needs a terminator — cannot be handed unterminated bytes;
+    /// [`as_bytes`] gives the path without the NUL.
+    ///
+    /// [`as_bytes`]: sigsafe::CStr::as_bytes
+    fn to_absolute_path<'a, A: Allocator>(
         self,
-        f: F,
-    ) -> nix::Result<R>;
+        allocator: &'a A,
+    ) -> nix::Result<Option<sigsafe::CStr<'a, sigsafe::Fat>>>
+    where
+        Self: 'a;
 }
 
 impl ToAbsolutePath for BorrowedFd<'_> {
-    fn to_absolute_path<R, F: FnOnce(Option<&BStr>) -> nix::Result<R>>(
+    fn to_absolute_path<'a, A: Allocator>(
         self,
-        f: F,
-    ) -> nix::Result<R> {
-        let arena = sigsafe_alloc::arena();
-        let path = get_fd_path(&arena, self)?;
-        f(path.as_ref().map(|path| path.as_slice().as_bstr()))
+        allocator: &'a A,
+    ) -> nix::Result<Option<sigsafe::CStr<'a, sigsafe::Fat>>>
+    where
+        Self: 'a,
+    {
+        let Some(mut path) = get_fd_path(allocator, self)? else {
+            return Ok(None);
+        };
+        path.push(0);
+        // SAFETY: a resolved descriptor path carries no interior NUL, and
+        // exactly one was appended above. The storage stays in `allocator`
+        // until it is dropped, which for a per-call arena ends the call.
+        Ok(Some(unsafe { sigsafe::CStr::from_bytes_with_nul_unchecked(path.leak()) }))
     }
 }
 
@@ -99,46 +118,48 @@ impl PathAt<'_, '_> {
 }
 
 impl ToAbsolutePath for PathAt<'_, '_> {
-    fn to_absolute_path<R, F: FnOnce(Option<&BStr>) -> nix::Result<R>>(
+    fn to_absolute_path<'a, A: Allocator>(
         self,
-        f: F,
-    ) -> nix::Result<R> {
-        let pathname = self.1.count().as_bytes().as_bstr();
+        allocator: &'a A,
+    ) -> nix::Result<Option<sigsafe::CStr<'a, sigsafe::Fat>>>
+    where
+        Self: 'a,
+    {
+        let counted = self.1.count();
+        let pathname = counted.as_bytes();
 
         if pathname.starts_with(b"/") {
-            f(Some(pathname))
+            // Already absolute, and already NUL-terminated by the caller.
+            Ok(Some(counted))
         } else {
-            self.0.to_absolute_path(|base| {
-                let Some(base) = base else {
-                    return f(None);
-                };
-                if pathname.is_empty() {
-                    return f(Some(base));
+            let Some(mut base) = get_fd_path(allocator, self.0)? else {
+                return Ok(None);
+            };
+            if !pathname.is_empty() {
+                if !base.ends_with(b"/") {
+                    base.push(b'/');
                 }
-
-                let arena = sigsafe_alloc::arena();
-                let needs_separator = !base.ends_with(b"/");
-                let mut abs_path = Vec::with_capacity_in(
-                    base.len() + usize::from(needs_separator) + pathname.len(),
-                    &arena,
-                );
-                abs_path.extend_from_slice(base);
-                if needs_separator {
-                    abs_path.push(b'/');
-                }
-                abs_path.extend_from_slice(pathname);
-                f(Some(abs_path.as_slice().as_bstr()))
-            })
+                base.extend_from_slice(pathname);
+            }
+            base.push(0);
+            // SAFETY: neither the directory nor the pathname carries an
+            // interior NUL — both come from C strings or the kernel — and
+            // exactly one was appended above. The storage stays in
+            // `allocator` until it is dropped.
+            Ok(Some(unsafe { sigsafe::CStr::from_bytes_with_nul_unchecked(base.leak()) }))
         }
     }
 }
 
 impl ToAbsolutePath for sigsafe::CStr<'_, sigsafe::Thin> {
-    fn to_absolute_path<R, F: FnOnce(Option<&BStr>) -> nix::Result<R>>(
+    fn to_absolute_path<'a, A: Allocator>(
         self,
-        f: F,
-    ) -> nix::Result<R> {
-        PathAt(CWD, self).to_absolute_path(f)
+        allocator: &'a A,
+    ) -> nix::Result<Option<sigsafe::CStr<'a, sigsafe::Fat>>>
+    where
+        Self: 'a,
+    {
+        PathAt(CWD, self).to_absolute_path(allocator)
     }
 }
 

--- a/crates/fspy_preload_unix/src/client/mod.rs
+++ b/crates/fspy_preload_unix/src/client/mod.rs
@@ -109,14 +109,11 @@ impl Client {
     ) -> anyhow::Result<()> {
         // SAFETY: mode contains a valid pointer (if ModeStr) or a plain value, as provided by the caller
         let mode = unsafe { mode.to_access_mode() };
-        let () = path.to_absolute_path(|abs_path| {
-            let Some(abs_path) = abs_path else {
-                return Ok(Ok(()));
-            };
-            Ok(self.send(mode, Path::new(OsStr::from_bytes(abs_path))))
-        })??;
-
-        Ok(())
+        let arena = sigsafe_alloc::arena();
+        let Some(abs_path) = path.to_absolute_path(&arena)? else {
+            return Ok(());
+        };
+        self.send(mode, Path::new(OsStr::from_bytes(abs_path.as_bytes())))
     }
 }
 

--- a/crates/fspy_preload_unix/src/interceptions/spawn/exec/mod.rs
+++ b/crates/fspy_preload_unix/src/interceptions/spawn/exec/mod.rs
@@ -1,8 +1,5 @@
 mod with_argv;
 
-#[cfg(target_os = "linux")]
-use std::ffi::CString;
-
 use fspy_shared_unix::exec::ExecResolveConfig;
 use libc::{c_char, c_int};
 use with_argv::with_argv;
@@ -195,26 +192,30 @@ mod linux_only {
             reason = "suppresses unused warning on *::original"
         )]
         let _unused = execveat::original;
-        // SAFETY: dirfd and pathname come from the interposed execveat call.
+        let arena = sigsafe_alloc::arena();
+
+        // SAFETY: dirfd and pathname are valid arguments from the interposed execveat call.
         let path = unsafe { PathAt::borrow_raw(dirfd, pathname) };
-        let abs_path_result = path.to_absolute_path(|path| {
-            let Some(path) = path else {
-                return Ok(None);
-            };
-            Ok(Some(CString::new(&**path).unwrap()))
-        });
-        let abs_path = match abs_path_result {
+        let abs_path = match path.to_absolute_path(&arena) {
             Ok(None) => {
                 // SAFETY: forwarding the original arguments to the real execveat syscall
                 return unsafe { execveat::original()(dirfd, pathname, argv, envp, flags) };
             }
-            Ok(Some(path)) => path.as_ptr(),
+            Ok(Some(path)) => path,
             Err(errno) => {
                 errno.set();
                 return -1;
             }
         };
-        handle_exec(ExecResolveConfig::search_path_disabled(), abs_path, argv.cast(), envp.cast())
+
+        // `abs_path` is a C string, so the exec receives a terminated
+        // pointer by construction rather than by convention.
+        handle_exec(
+            ExecResolveConfig::search_path_disabled(),
+            abs_path.as_ptr(),
+            argv.cast(),
+            envp.cast(),
+        )
     }
 
     intercept!(fexecve(64): unsafe extern "C" fn(


### PR DESCRIPTION
## Motivation

`to_absolute_path` still exposes each resolved path through a callback even though every intercepted call can provide a signal-safe arena. Accept that allocator directly and return the resolved path instead.

The return type is `sigsafe::CStr<Fat>` rather than a plain `BStr`, because `execveat` forwards the result to a real exec, which needs a terminator. Carrying that in the type means an implementation cannot hand the exec unterminated bytes; callers wanting the path without the NUL use `as_bytes`.

Descriptor resolution continues to produce a vector, so relative pathnames and the trailing NUL are appended to that same storage before it is left in the arena. Already-absolute inputs return their original C string with no allocation at all. `execveat` resolves once and makes one `handle_exec` call.