### PR TITLE
feat(sigsafe): resolve Linux descriptor paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,6 +1313,7 @@ dependencies = [
  "fspy_shared_unix",
  "libc",
  "nix 0.31.2",
+ "sigsafe",
  "sigsafe_alloc",
  "wincode",
 ]

--- a/crates/fspy_preload_unix/Cargo.toml
+++ b/crates/fspy_preload_unix/Cargo.toml
@@ -17,6 +17,7 @@ fspy_shared = { workspace = true }
 fspy_shared_unix = { workspace = true }
 libc = { workspace = true }
 nix = { workspace = true, features = ["signal", "fs", "socket", "mman", "time"] }
+sigsafe = { workspace = true }
 sigsafe_alloc = { workspace = true }
 
 [build-dependencies]

--- a/crates/fspy_preload_unix/src/client/convert.rs
+++ b/crates/fspy_preload_unix/src/client/convert.rs
@@ -1,10 +1,6 @@
-#[cfg(target_os = "linux")]
-use std::ffi::CString;
-use std::{
-    ffi::{CStr, OsStr},
-    os::{fd::RawFd, unix::ffi::OsStrExt as _},
-    path::PathBuf,
-};
+#[cfg(target_os = "macos")]
+use std::os::unix::ffi::OsStrExt as _;
+use std::{ffi::CStr, os::fd::RawFd};
 
 use allocator_api2::{alloc::Allocator, vec::Vec};
 use bstr::{BStr, ByteSlice};
@@ -12,16 +8,53 @@ use fspy_shared::ipc::AccessMode;
 use libc::{c_char, c_int};
 
 #[cfg(target_os = "linux")]
-fn get_fd_path(fd: RawFd) -> nix::Result<Option<PathBuf>> {
-    match nix::fcntl::readlink(CString::new(format!("/proc/self/fd/{fd}")).unwrap().as_c_str()) {
-        Ok(path) => Ok(Some(path.into())),
-        Err(nix::Error::EBADF | nix::Error::ENOENT) => Ok(None), // invalid fd or no such file (Most likely a stdio fd)
-        Err(e) => Err(e),
+fn get_fd_path<A: Allocator>(fd: RawFd, allocator: A) -> nix::Result<Option<Vec<u8, A>>> {
+    let mut path = [0; PROC_FD_PATH_CAPACITY];
+    let path = proc_fd_path(fd, &mut path);
+    match sigsafe_alloc::fs::readlink(allocator, path) {
+        Ok(path) => Ok(Some(path)),
+        Err(sigsafe::Errno::BADF | sigsafe::Errno::NOENT) => Ok(None),
+        Err(errno) => Err(nix::errno::Errno::from_raw(errno.raw_os_error())),
     }
 }
 
+#[cfg(target_os = "linux")]
+const PROC_FD_PATH_CAPACITY: usize = b"/proc/self/fd/".len() + 11 + 1;
+
+#[cfg(target_os = "linux")]
+fn proc_fd_path(
+    fd: RawFd,
+    buf: &mut [u8; PROC_FD_PATH_CAPACITY],
+) -> sigsafe::CStr<'_, sigsafe::Thin> {
+    const PREFIX: &[u8] = b"/proc/self/fd/";
+
+    let mut digits = [0; 11];
+    let mut start = digits.len();
+    let mut value = fd.unsigned_abs();
+    loop {
+        start -= 1;
+        digits[start] = b'0' + (value % 10) as u8;
+        value /= 10;
+        if value == 0 {
+            break;
+        }
+    }
+    if fd.is_negative() {
+        start -= 1;
+        digits[start] = b'-';
+    }
+
+    buf[..PREFIX.len()].copy_from_slice(PREFIX);
+    let end = PREFIX.len() + digits.len() - start;
+    buf[PREFIX.len()..end].copy_from_slice(&digits[start..]);
+    buf[end] = 0;
+
+    // SAFETY: the initialized prefix ends in NUL and lives as long as `buf`.
+    unsafe { sigsafe::CStr::from_ptr(buf.as_ptr().cast()) }
+}
+
 #[cfg(target_os = "macos")]
-fn get_fd_path(fd: RawFd) -> nix::Result<Option<PathBuf>> {
+fn get_fd_path(fd: RawFd) -> nix::Result<Option<std::path::PathBuf>> {
     let mut path = std::path::PathBuf::new();
     match nix::fcntl::fcntl(
         // SAFETY: fd is a valid file descriptor provided by the caller, and the borrow does not outlive this function call
@@ -59,8 +92,18 @@ impl ToAbsolutePath for Fd {
             return f(Some(path.as_slice().as_bstr()));
         }
 
-        let path = get_fd_path(self.0)?;
-        f(path.as_ref().map(|path| path.as_os_str().as_bytes().as_bstr()))
+        #[cfg(target_os = "linux")]
+        {
+            let arena = sigsafe_alloc::arena();
+            let path = get_fd_path(self.0, &arena)?;
+            f(path.as_ref().map(|path| path.as_slice().as_bstr()))
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            let path = get_fd_path(self.0)?;
+            f(path.as_ref().map(|path| path.as_os_str().as_bytes().as_bstr()))
+        }
     }
 }
 
@@ -76,24 +119,31 @@ impl ToAbsolutePath for PathAt {
 
         if pathname.first().copied() == Some(b'/') {
             f(pathname.into())
-        } else if self.0 == libc::AT_FDCWD {
-            let arena = sigsafe_alloc::arena();
-            let mut abs_path = getcwd(&arena)?;
-            if !pathname.is_empty() {
-                if !abs_path.ends_with(b"/") {
-                    abs_path.push(b'/');
-                }
-                abs_path.extend_from_slice(pathname);
-            }
-            f(Some(abs_path.as_slice().as_bstr()))
         } else {
-            let Some(mut abs_path) = get_fd_path(self.0)? else {
-                return f(None);
-            };
-            if !pathname.is_empty() {
-                abs_path.push(OsStr::from_bytes(pathname));
+            // SAFETY: delegates the same caller-provided descriptor to Fd.
+            unsafe {
+                Fd(self.0).to_absolute_path(|base| {
+                    let Some(base) = base else {
+                        return f(None);
+                    };
+                    if pathname.is_empty() {
+                        return f(Some(base));
+                    }
+
+                    let arena = sigsafe_alloc::arena();
+                    let needs_separator = !base.ends_with(b"/");
+                    let mut abs_path = Vec::with_capacity_in(
+                        base.len() + usize::from(needs_separator) + pathname.len(),
+                        &arena,
+                    );
+                    abs_path.extend_from_slice(base);
+                    if needs_separator {
+                        abs_path.push(b'/');
+                    }
+                    abs_path.extend_from_slice(pathname);
+                    f(Some(abs_path.as_slice().as_bstr()))
+                })
             }
-            f(Some(abs_path.as_os_str().as_bytes().as_bstr()))
         }
     }
 }

--- a/crates/sigsafe/src/fs/linux.rs
+++ b/crates/sigsafe/src/fs/linux.rs
@@ -1,9 +1,40 @@
 use core::{mem::MaybeUninit, slice};
 
-use crate::{CStr, Errno, Fat, Result};
+use crate::{CStr, Errno, Fat, Result, Thin};
 
 // Linux UAPI `PATH_MAX`.
 pub(super) const PATH_MAX: usize = 4096;
+const AT_FDCWD: usize = (-100_isize).cast_unsigned();
+
+/// Reads the target of `path` into `buf`.
+///
+/// The returned bytes borrow the initialized prefix of `buf`. As with the
+/// underlying syscall, they do not include a terminating NUL, and a result
+/// that fills `buf` may have been truncated.
+///
+/// # Errors
+///
+/// Returns the error reported by `readlinkat`.
+pub fn readlink<'buf>(
+    path: CStr<'_, Thin>,
+    buf: &'buf mut [MaybeUninit<u8>],
+) -> Result<&'buf [u8]> {
+    // SAFETY: `path` is NUL-terminated and `buf` is writable for `buf.len()`
+    // bytes. `readlinkat` returns the initialized byte count.
+    let initialized = unsafe {
+        syscalls::syscall4(
+            syscalls::Sysno::readlinkat,
+            AT_FDCWD,
+            path.as_ptr().addr(),
+            buf.as_mut_ptr().addr(),
+            buf.len(),
+        )
+    }
+    .map_err(|errno| Errno::from_raw_os_error(errno.into_raw()))?;
+
+    // SAFETY: the syscall initialized exactly this prefix.
+    Ok(unsafe { slice::from_raw_parts(buf.as_ptr().cast(), initialized) })
+}
 
 pub(super) fn getcwd(buf: &mut [MaybeUninit<u8>]) -> Result<CStr<'_, Fat>> {
     // rustix exposes only an allocating `getcwd`, so use the raw syscall for

--- a/crates/sigsafe/src/fs/mod.rs
+++ b/crates/sigsafe/src/fs/mod.rs
@@ -11,6 +11,8 @@ mod mac;
 
 #[cfg(target_os = "linux")]
 use linux as imp;
+#[cfg(target_os = "linux")]
+pub use linux::readlink;
 #[cfg(target_os = "macos")]
 use mac as imp;
 

--- a/crates/sigsafe/src/fs/tests.rs
+++ b/crates/sigsafe/src/fs/tests.rs
@@ -25,3 +25,15 @@ fn getcwd_returns_current_directory() {
 fn getcwd_rejects_an_empty_buffer() {
     assert!(matches!(getcwd(&mut []), Err(Errno::RANGE)));
 }
+
+#[cfg(target_os = "linux")]
+#[test]
+fn readlink_returns_the_initialized_target() {
+    let mut buf = [MaybeUninit::uninit(); super::PATH_MAX];
+    // SAFETY: the literal is NUL-terminated and lives for the call.
+    let path = unsafe { crate::CStr::<crate::Thin>::from_ptr(c"/proc/self/exe".as_ptr()) };
+
+    let target = super::readlink(path, &mut buf).unwrap();
+
+    assert_eq!(target, std::fs::read_link("/proc/self/exe").unwrap().as_os_str().as_bytes());
+}

--- a/crates/sigsafe_alloc/src/fs.rs
+++ b/crates/sigsafe_alloc/src/fs.rs
@@ -1,6 +1,10 @@
 //! Allocating filesystem wrappers.
 
+#[cfg(target_os = "linux")]
+use allocator_api2::vec::Vec;
 use allocator_api2::{alloc::Allocator, boxed::Box};
+#[cfg(target_os = "linux")]
+use sigsafe::{CStr, Thin};
 use sigsafe::{Errno, Fat, Result};
 
 use crate::CString;
@@ -18,6 +22,39 @@ pub fn getcwd<A: Allocator>(allocator: A) -> Result<CString<Fat, A>> {
 
     // SAFETY: `getcwd` initialized the C string described by `repr`.
     Ok(unsafe { CString::from_buffer_unchecked(bytes, repr) })
+}
+
+/// Returns the target of `path`, allocated with `allocator`.
+///
+/// The buffer grows and retries when `readlinkat` fills it, because the
+/// underlying operation does not otherwise distinguish an exact fit from a
+/// truncated result.
+///
+/// # Errors
+///
+/// Returns [`Errno::NOMEM`] if storage cannot be allocated, or the error from
+/// [`sigsafe::fs::readlink`].
+#[cfg(target_os = "linux")]
+pub fn readlink<A: Allocator>(allocator: A, path: CStr<'_, Thin>) -> Result<Vec<u8, A>> {
+    let mut bytes = Vec::new_in(allocator);
+    bytes.try_reserve_exact(sigsafe::fs::PATH_MAX).map_err(|_| Errno::NOMEM)?;
+
+    loop {
+        let capacity = bytes.capacity();
+        let initialized = sigsafe::fs::readlink(path, bytes.spare_capacity_mut())?.len();
+        if initialized < capacity {
+            // SAFETY: `readlink` initialized this prefix.
+            unsafe { bytes.set_len(initialized) };
+            return Ok(bytes);
+        }
+
+        // A full buffer may be truncated. It is entirely initialized, so use
+        // it as the current length while requesting twice the storage.
+        // SAFETY: `readlink` returned `capacity`, initializing every byte.
+        unsafe { bytes.set_len(capacity) };
+        bytes.try_reserve_exact(capacity).map_err(|_| Errno::NOMEM)?;
+        bytes.clear();
+    }
 }
 
 fn path_buffer<A: Allocator>(
@@ -42,5 +79,18 @@ mod tests {
         let expected = sigsafe::fs::getcwd(&mut buffer).unwrap();
 
         assert_eq!(path.as_slice(), &expected.as_bytes_with_nul()[..expected.len_with_nul() - 1]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn readlink_allocates_the_complete_target() {
+        // SAFETY: the literal is NUL-terminated and lives for the call.
+        let path = unsafe { sigsafe::CStr::<sigsafe::Thin>::from_ptr(c"/proc/self/exe".as_ptr()) };
+        let target = super::readlink(Global, path).unwrap();
+
+        assert_eq!(
+            target.as_slice(),
+            std::fs::read_link("/proc/self/exe").unwrap().as_os_str().as_encoded_bytes()
+        );
     }
 }


### PR DESCRIPTION
## Motivation

Linux descriptor path resolution still uses `nix::readlink` and heap-backed formatting. Add a raw caller-buffer `readlinkat` wrapper and allocator adapter, then immediately replace that path with stack formatting and arena storage.

The low-level wrapper preserves readlink truncation semantics; the allocating adapter retries only when the buffer is filled.