### PR TITLE
feat(sigsafe): resolve macOS descriptor paths

### DIFF
--- a/crates/fspy_preload_unix/src/client/convert.rs
+++ b/crates/fspy_preload_unix/src/client/convert.rs
@@ -1,5 +1,3 @@
-#[cfg(target_os = "macos")]
-use std::os::unix::ffi::OsStrExt as _;
 use std::{ffi::CStr, os::fd::RawFd};
 
 use allocator_api2::{alloc::Allocator, vec::Vec};
@@ -54,16 +52,17 @@ fn proc_fd_path(
 }
 
 #[cfg(target_os = "macos")]
-fn get_fd_path(fd: RawFd) -> nix::Result<Option<std::path::PathBuf>> {
-    let mut path = std::path::PathBuf::new();
-    match nix::fcntl::fcntl(
-        // SAFETY: fd is a valid file descriptor provided by the caller, and the borrow does not outlive this function call
-        unsafe { std::os::fd::BorrowedFd::borrow_raw(fd) },
-        nix::fcntl::FcntlArg::F_GETPATH(&mut path),
-    ) {
-        Ok(_) => Ok(Some(path)),
-        Err(nix::Error::EBADF | nix::Error::ENOENT) => Ok(None), // invalid fd or no such file (Most likely a stdio fd)
-        Err(e) => Err(e),
+fn get_fd_path<A: Allocator>(fd: RawFd, allocator: A) -> nix::Result<Option<Vec<u8, A>>> {
+    // SAFETY: the descriptor remains borrowed for this call.
+    let fd = unsafe { sigsafe::BorrowedFd::borrow_raw(fd) };
+    match sigsafe_alloc::fs::fcntl_getpath(allocator, fd) {
+        Ok(path) => {
+            // `F_GETPATH` does not return a length. Count at this caller before
+            // converting its allocation into the returned path.
+            Ok(Some(path.count().into_bytes()))
+        }
+        Err(sigsafe::Errno::BADF | sigsafe::Errno::NOENT) => Ok(None),
+        Err(errno) => Err(nix::errno::Errno::from_raw(errno.raw_os_error())),
     }
 }
 
@@ -101,8 +100,9 @@ impl ToAbsolutePath for Fd {
 
         #[cfg(target_os = "macos")]
         {
-            let path = get_fd_path(self.0)?;
-            f(path.as_ref().map(|path| path.as_os_str().as_bytes().as_bstr()))
+            let arena = sigsafe_alloc::arena();
+            let path = get_fd_path(self.0, &arena)?;
+            f(path.as_ref().map(|path| path.as_slice().as_bstr()))
         }
     }
 }

--- a/crates/sigsafe/README.md
+++ b/crates/sigsafe/README.md
@@ -29,7 +29,7 @@ rustix can be built with a libc backend instead of raw syscalls, and anything in
 Functions whose rustix implementation already meets the rules are re-exposed as-is; being listed in a module here is what marks a call as allowed, and the backend check above is what keeps that true.
 
 - `mm` — anonymous memory mappings: `mmap_anonymous`, `munmap`.
-- `fs` — caller-buffer filesystem operations: `getcwd`.
+- `fs` — caller-buffer filesystem operations: `getcwd`, plus macOS `fcntl_getpath`.
 - `param` — `page_size`.
 
 Allocation without malloc lives in [`sigsafe_alloc`](../sigsafe_alloc).

--- a/crates/sigsafe/src/fs/mac.rs
+++ b/crates/sigsafe/src/fs/mac.rs
@@ -1,11 +1,11 @@
 use core::{mem::MaybeUninit, slice};
 
 use rustix::{
-    fd::{AsFd as _, AsRawFd as _, BorrowedFd, FromRawFd as _, OwnedFd},
+    fd::{AsFd as _, AsRawFd as _, FromRawFd as _, OwnedFd},
     fs::{Mode, OFlags, fstat, stat},
 };
 
-use crate::{CStr, Errno, Fat, Result, Thin};
+use crate::{BorrowedFd, CStr, Errno, Fat, Result, Thin};
 
 pub(super) const PATH_MAX: usize = libc::PATH_MAX as usize;
 
@@ -25,7 +25,16 @@ fn open<R>(path: CStr<'_, R>, flags: OFlags, mode: Mode) -> Result<OwnedFd> {
     Ok(unsafe { OwnedFd::from_raw_fd(fd) })
 }
 
-fn fcntl_getpath<'buf>(
+/// Gets the path associated with `fd`.
+///
+/// `F_GETPATH` writes a NUL-terminated path into its `MAXPATHLEN` buffer but
+/// does not report the length, so this function returns [`CStr<Thin>`] without
+/// scanning for the terminator.
+///
+/// # Errors
+///
+/// Returns the error reported by `fcntl`.
+pub fn fcntl_getpath<'buf>(
     fd: BorrowedFd<'_>,
     buf: &'buf mut [MaybeUninit<u8>; PATH_MAX],
 ) -> Result<CStr<'buf, Thin>> {

--- a/crates/sigsafe/src/fs/mod.rs
+++ b/crates/sigsafe/src/fs/mod.rs
@@ -15,6 +15,8 @@ use linux as imp;
 pub use linux::readlink;
 #[cfg(target_os = "macos")]
 use mac as imp;
+#[cfg(target_os = "macos")]
+pub use mac::fcntl_getpath;
 
 /// The platform's maximum pathname size, including the terminating NUL.
 pub const PATH_MAX: usize = imp::PATH_MAX;

--- a/crates/sigsafe/src/fs/tests.rs
+++ b/crates/sigsafe/src/fs/tests.rs
@@ -26,6 +26,22 @@ fn getcwd_rejects_an_empty_buffer() {
     assert!(matches!(getcwd(&mut []), Err(Errno::RANGE)));
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn fcntl_getpath_returns_descriptor_path() {
+    use rustix::{
+        fd::AsFd as _,
+        fs::{Mode, OFlags, open},
+    };
+
+    let root = open(c"/", OFlags::RDONLY, Mode::empty()).unwrap();
+    let mut buf = [MaybeUninit::uninit(); super::PATH_MAX];
+
+    let path = super::fcntl_getpath(root.as_fd(), &mut buf).unwrap().count();
+
+    assert_eq!(path.as_bytes_with_nul(), b"/\0");
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn readlink_returns_the_initialized_target() {

--- a/crates/sigsafe/src/lib.rs
+++ b/crates/sigsafe/src/lib.rs
@@ -20,7 +20,10 @@ pub mod mm;
 pub mod param;
 
 pub use c_str::{CStr, Fat, Thin};
-pub use rustix::io::{Errno, Result};
+pub use rustix::{
+    fd::BorrowedFd,
+    io::{Errno, Result},
+};
 
 // Compile-time proof that rustix uses its raw-syscall backend (`linux_raw`)
 // on Linux — and with it, that no call in this crate goes through libc there.

--- a/crates/sigsafe_alloc/src/c_string.rs
+++ b/crates/sigsafe_alloc/src/c_string.rs
@@ -1,7 +1,7 @@
 use core::mem::MaybeUninit;
 
 use allocator_api2::{alloc::Allocator, boxed::Box, vec::Vec};
-use sigsafe::Fat;
+use sigsafe::{CStr, Fat, Thin};
 
 /// An allocator-backed owned C string.
 pub struct CString<R, A: Allocator> {
@@ -24,6 +24,23 @@ impl<R, A: Allocator> CString<R, A> {
         // SAFETY: the array and slice have the same element layout and length.
         let bytes = unsafe { Box::from_raw_in(bytes, allocator) };
         Self { bytes, repr }
+    }
+}
+
+impl<A: Allocator> CString<Thin, A> {
+    /// Returns a thin borrowed view of this C string.
+    #[must_use]
+    pub fn as_c_str(&self) -> CStr<'_, Thin> {
+        // SAFETY: upheld by the constructor; `self` owns the storage.
+        unsafe { CStr::from_ptr(self.bytes.as_ptr().cast()) }
+    }
+
+    /// Counts through the terminating NUL and returns a length-retaining C
+    /// string using the same allocation.
+    #[must_use]
+    pub fn count(self) -> CString<Fat, A> {
+        let repr = self.as_c_str().count().into_repr();
+        CString { bytes: self.bytes, repr }
     }
 }
 

--- a/crates/sigsafe_alloc/src/fs.rs
+++ b/crates/sigsafe_alloc/src/fs.rs
@@ -4,7 +4,9 @@
 use allocator_api2::vec::Vec;
 use allocator_api2::{alloc::Allocator, boxed::Box};
 #[cfg(target_os = "linux")]
-use sigsafe::{CStr, Thin};
+use sigsafe::CStr;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use sigsafe::Thin;
 use sigsafe::{Errno, Fat, Result};
 
 use crate::CString;
@@ -57,6 +59,26 @@ pub fn readlink<A: Allocator>(allocator: A, path: CStr<'_, Thin>) -> Result<Vec<
     }
 }
 
+/// Returns the path associated with `fd`, allocated with `allocator`.
+///
+/// The returned C string remains thin because `F_GETPATH` reports no length.
+///
+/// # Errors
+///
+/// Returns [`Errno::NOMEM`] if storage cannot be allocated, or the error from
+/// [`sigsafe::fs::fcntl_getpath`].
+#[cfg(target_os = "macos")]
+pub fn fcntl_getpath<A: Allocator>(
+    allocator: A,
+    fd: sigsafe::BorrowedFd<'_>,
+) -> Result<CString<Thin, A>> {
+    let mut bytes = path_buffer(allocator)?;
+    let repr = sigsafe::fs::fcntl_getpath(fd, &mut bytes)?.into_repr();
+
+    // SAFETY: `fcntl_getpath` initialized the C string described by `repr`.
+    Ok(unsafe { CString::from_buffer_unchecked(bytes, repr) })
+}
+
 fn path_buffer<A: Allocator>(
     allocator: A,
 ) -> Result<Box<[core::mem::MaybeUninit<u8>; sigsafe::fs::PATH_MAX], A>> {
@@ -79,6 +101,19 @@ mod tests {
         let expected = sigsafe::fs::getcwd(&mut buffer).unwrap();
 
         assert_eq!(path.as_slice(), &expected.as_bytes_with_nul()[..expected.len_with_nul() - 1]);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn fcntl_getpath_allocates_a_thin_c_string() {
+        use std::{fs::File, os::fd::AsRawFd as _};
+
+        let root = File::open("/").unwrap();
+        // SAFETY: `root` remains open for the call.
+        let root = unsafe { sigsafe::BorrowedFd::borrow_raw(root.as_raw_fd()) };
+        let path = super::fcntl_getpath(Global, root).unwrap();
+
+        assert_eq!(path.as_c_str().count().as_bytes_with_nul(), b"/\0");
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Motivation

macOS descriptor path resolution still uses `nix::fcntl` and `PathBuf`. Expose the already-used `F_GETPATH` primitive, add its explicit-allocator adapter, and immediately consume it from preload.

`F_GETPATH` returns no length, so the wrapper returns `CString<Thin>` without scanning. Preload explicitly counts it before converting the same allocation into the returned path.