### PR TITLE
feat(sigsafe): resolve current directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3444,7 +3444,9 @@ dependencies = [
 name = "sigsafe"
 version = "0.0.0"
 dependencies = [
+ "libc",
  "rustix",
+ "syscalls",
 ]
 
 [[package]]

--- a/crates/fspy_preload_unix/src/client/convert.rs
+++ b/crates/fspy_preload_unix/src/client/convert.rs
@@ -9,13 +9,16 @@ use std::{
 use bstr::{BStr, ByteSlice};
 use fspy_shared::ipc::AccessMode;
 use libc::{c_char, c_int};
-use nix::unistd::getcwd;
 use sigsafe::{AsRawFd as _, BorrowedFd, CWD};
 
 #[cfg(target_os = "linux")]
 fn get_fd_path(fd: BorrowedFd<'_>) -> nix::Result<Option<PathBuf>> {
     if fd.as_raw_fd() == CWD.as_raw_fd() {
-        return Ok(Some(getcwd()?));
+        let arena = sigsafe_alloc::arena();
+        let path = sigsafe_alloc::fs::getcwd(&arena)
+            .map_err(|errno| nix::errno::Errno::from_raw(errno.raw_os_error()))?
+            .into_bytes();
+        return Ok(Some(OsStr::from_bytes(&path).into()));
     }
     match nix::fcntl::readlink(
         CString::new(format!("/proc/self/fd/{}", fd.as_raw_fd())).unwrap().as_c_str(),
@@ -29,8 +32,13 @@ fn get_fd_path(fd: BorrowedFd<'_>) -> nix::Result<Option<PathBuf>> {
 #[cfg(target_os = "macos")]
 fn get_fd_path(fd: BorrowedFd<'_>) -> nix::Result<Option<PathBuf>> {
     if fd.as_raw_fd() == CWD.as_raw_fd() {
-        return Ok(Some(getcwd()?));
+        let arena = sigsafe_alloc::arena();
+        let path = sigsafe_alloc::fs::getcwd(&arena)
+            .map_err(|errno| nix::errno::Errno::from_raw(errno.raw_os_error()))?
+            .into_bytes();
+        return Ok(Some(OsStr::from_bytes(&path).into()));
     }
+
     let mut path = std::path::PathBuf::new();
     // SAFETY: this std view has the same descriptor and lifetime as the
     // rustix view accepted by this function.

--- a/crates/sigsafe/Cargo.toml
+++ b/crates/sigsafe/Cargo.toml
@@ -10,6 +10,9 @@ doctest = false
 [target.'cfg(unix)'.dependencies]
 rustix = { workspace = true, features = ["fs"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = { workspace = true }
+
 # On Linux the page size is probed from the kernel directly (see param.rs);
 # rustix's `param` is only needed where sysconf is the platform interface.
 [target.'cfg(all(unix, not(target_os = "linux")))'.dependencies]
@@ -19,6 +22,7 @@ rustix = { workspace = true, features = ["param"] }
 # item to reference; `runtime` is the module that has one.
 [target.'cfg(target_os = "linux")'.dependencies]
 rustix = { workspace = true, features = ["runtime"] }
+syscalls = { workspace = true }
 
 # Cross-validates the page-size probe against rustix's auxv-based answer.
 [target.'cfg(target_os = "linux")'.dev-dependencies]

--- a/crates/sigsafe/README.md
+++ b/crates/sigsafe/README.md
@@ -16,11 +16,11 @@ Most of libc is off limits in those places. `malloc` is the classic trap: a sign
 
 Every function in this crate follows three rules:
 
-1. **Syscalls only.** On Linux, nothing goes through libc — the syscall instructions are emitted directly (rustix's raw backend). On macOS there is no stable syscall interface, so calls go through libSystem's wrappers; for the calls exposed here those are thin stubs with no locks and no state.
+1. **Async-signal-safe operations only.** On Linux, kernel calls use raw syscalls. The compiler may lower ordinary memory operations to POSIX async-signal-safe libc routines such as `strlen`. On macOS there is no stable syscall interface, so calls go through libSystem's wrappers; for the calls exposed here those are thin stubs with no locks and no state.
 2. **No locks, no hidden state.** Nothing a signal or a `fork()` could catch locked or half-written. Where shared state is unavoidable it is a fixed set of atomics, each touched by single complete operations.
 3. **No global allocation.** No function touches a heap behind the caller's back. Code that needs memory gets it from an explicit allocator — [`sigsafe_alloc`](../sigsafe_alloc) provides one built on `mmap`.
 
-## How rule 1 is enforced on Linux
+## How raw syscalls are enforced on Linux
 
 rustix can be built with a libc backend instead of raw syscalls, and anything in the dependency graph — including crates outside this repository — can select it (the `rustix/use-libc` feature, or `RUSTFLAGS=--cfg=rustix_use_libc`). No build script can detect that reliably, so [`lib.rs`](src/lib.rs) checks at compile time instead: it references `rustix::runtime`, a module that exists only in rustix's raw-syscall build. Selecting the libc backend makes this crate fail to compile, rather than silently losing the guarantee.
 
@@ -29,6 +29,7 @@ rustix can be built with a libc backend instead of raw syscalls, and anything in
 Functions whose rustix implementation already meets the rules are re-exposed as-is; being listed in a module here is what marks a call as allowed, and the backend check above is what keeps that true.
 
 - `mm` — anonymous memory mappings: `mmap_anonymous`, `munmap`.
+- `fs` — caller-buffer filesystem operations: `getcwd`.
 - `param` — `page_size`.
 
 Allocation without malloc lives in [`sigsafe_alloc`](../sigsafe_alloc).

--- a/crates/sigsafe/src/c_str.rs
+++ b/crates/sigsafe/src/c_str.rs
@@ -1,4 +1,4 @@
-use core::{ffi::c_char, marker::PhantomData, ptr::NonNull};
+use core::{ffi::c_char, marker::PhantomData, num::NonZeroUsize, ptr::NonNull, slice};
 
 /// Marks a [`CStr`] whose length is not known.
 #[derive(Clone, Copy)]
@@ -6,13 +6,19 @@ pub struct Thin {
     _private: (),
 }
 
+/// Marks a [`CStr`] that retains its length, including the terminating NUL.
+#[derive(Clone, Copy)]
+pub struct Fat {
+    len_with_nul: NonZeroUsize,
+}
+
 /// A borrowed NUL-terminated string.
 ///
-/// [`CStr<'_, Thin>`] stores only the string pointer.
+/// [`CStr<'_, Thin>`] stores only the string pointer, while
+/// [`CStr<'_, Fat>`] also stores the length including the terminating NUL.
 #[derive(Clone, Copy)]
 pub struct CStr<'a, R> {
     ptr: NonNull<c_char>,
-    #[expect(dead_code, reason = "the representation value carries the type state")]
     repr: R,
     lifetime: PhantomData<&'a c_char>,
 }
@@ -23,9 +29,23 @@ impl<R> CStr<'_, R> {
     pub const fn as_ptr(&self) -> *const c_char {
         self.ptr.as_ptr()
     }
+
+    /// Consumes this C string view and returns its representation metadata.
+    #[must_use]
+    pub fn into_repr(self) -> R {
+        self.repr
+    }
 }
 
-impl CStr<'_, Thin> {
+impl Fat {
+    /// Returns the represented length, including the terminating NUL.
+    #[must_use]
+    pub const fn len_with_nul(self) -> usize {
+        self.len_with_nul.get()
+    }
+}
+
+impl<'a> CStr<'a, Thin> {
     /// Creates a thin C string view without finding its length.
     ///
     /// # Safety
@@ -41,20 +61,78 @@ impl CStr<'_, Thin> {
             lifetime: PhantomData,
         }
     }
+
+    /// Counts through the terminating NUL and returns a length-retaining view.
+    #[must_use]
+    pub const fn count(self) -> CStr<'a, Fat> {
+        let mut count = 0;
+        // SAFETY: `CStr<Thin>` points to a NUL-terminated string.
+        while unsafe { self.as_ptr().add(count).read() } != 0 {
+            count += 1;
+        }
+
+        CStr {
+            ptr: self.ptr,
+            repr: Fat {
+                // SAFETY: the count includes at least the terminating NUL.
+                len_with_nul: unsafe { NonZeroUsize::new_unchecked(count + 1) },
+            },
+            lifetime: PhantomData,
+        }
+    }
+}
+
+impl<'a> CStr<'a, Fat> {
+    /// Creates a length-retaining C string from bytes without validation.
+    ///
+    /// # Safety
+    ///
+    /// `bytes` must end with exactly one NUL byte and contain no other NUL
+    /// bytes.
+    #[must_use]
+    pub const unsafe fn from_bytes_with_nul_unchecked(bytes: &'a [u8]) -> Self {
+        Self {
+            // SAFETY: a valid C string is nonempty, so its pointer is non-null.
+            ptr: unsafe { NonNull::new_unchecked(bytes.as_ptr().cast::<c_char>().cast_mut()) },
+            repr: Fat {
+                // SAFETY: a valid C string contains at least its terminating NUL.
+                len_with_nul: unsafe { NonZeroUsize::new_unchecked(bytes.len()) },
+            },
+            lifetime: PhantomData,
+        }
+    }
+
+    /// Returns the string's bytes, including the terminating NUL.
+    #[must_use]
+    pub const fn as_bytes_with_nul(&self) -> &'a [u8] {
+        // SAFETY: this view carries the exact initialized C string length.
+        unsafe { slice::from_raw_parts(self.ptr.as_ptr().cast(), self.len_with_nul()) }
+    }
+
+    /// Returns the number of bytes including the terminating NUL.
+    #[must_use]
+    pub const fn len_with_nul(&self) -> usize {
+        self.repr.len_with_nul()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use core::mem::size_of;
 
-    use super::{CStr, Thin};
+    use super::{CStr, Fat, Thin};
 
     #[test]
-    fn thin_representation_is_one_pointer() {
+    fn representations_retain_the_expected_metadata() {
         // SAFETY: the input contains one trailing NUL.
-        let value = unsafe { CStr::<Thin>::from_ptr(c"abc".as_ptr()) };
+        let fat = unsafe { CStr::<Fat>::from_bytes_with_nul_unchecked(b"abc\0") };
+        // SAFETY: the input contains one trailing NUL.
+        let counted = unsafe { CStr::<Thin>::from_ptr(c"abc".as_ptr()) }.count();
 
         assert_eq!(size_of::<CStr<'_, Thin>>(), size_of::<*const u8>());
-        assert_eq!(value.as_ptr(), c"abc".as_ptr());
+        assert_eq!(size_of::<CStr<'_, Fat>>(), size_of::<(*const u8, usize)>());
+        assert_eq!(fat.len_with_nul(), 4);
+        assert_eq!(fat.as_bytes_with_nul(), b"abc\0");
+        assert_eq!(counted.as_bytes_with_nul(), fat.as_bytes_with_nul());
     }
 }

--- a/crates/sigsafe/src/fs/linux.rs
+++ b/crates/sigsafe/src/fs/linux.rs
@@ -1,0 +1,22 @@
+use core::{mem::MaybeUninit, slice};
+
+use crate::{CStr, Errno, Fat, Result};
+
+// Linux UAPI `PATH_MAX`.
+pub(super) const PATH_MAX: usize = 4096;
+
+pub(super) fn getcwd(buf: &mut [MaybeUninit<u8>]) -> Result<CStr<'_, Fat>> {
+    // rustix exposes only an allocating `getcwd`, so use the raw syscall for
+    // caller-owned storage.
+    // SAFETY: `buf` is writable for exactly `buf.len()` bytes. The syscall
+    // writes no more than that and returns the initialized length including
+    // its terminating NUL.
+    let initialized =
+        unsafe { syscalls::syscall2(syscalls::Sysno::getcwd, buf.as_mut_ptr().addr(), buf.len()) }
+            .map_err(|errno| Errno::from_raw_os_error(errno.into_raw()))?;
+
+    // SAFETY: the syscall initialized this prefix through its terminating NUL.
+    let bytes = unsafe { slice::from_raw_parts(buf.as_ptr().cast(), initialized) };
+    // SAFETY: the syscall returned one NUL-terminated pathname.
+    Ok(unsafe { CStr::from_bytes_with_nul_unchecked(bytes) })
+}

--- a/crates/sigsafe/src/fs/mac.rs
+++ b/crates/sigsafe/src/fs/mac.rs
@@ -1,0 +1,105 @@
+use core::{mem::MaybeUninit, slice};
+
+use rustix::{
+    fd::{AsFd as _, AsRawFd as _, FromRawFd as _, OwnedFd},
+    fs::{Mode, OFlags},
+};
+
+use crate::{BorrowedFd, CStr, CWD, Errno, Fat, Result, Thin};
+
+pub(super) const PATH_MAX: usize = libc::PATH_MAX as usize;
+
+#[expect(clippy::needless_pass_by_value, reason = "CStr is a borrowed value type")]
+fn openat<R>(
+    dirfd: BorrowedFd<'_>,
+    path: CStr<'_, R>,
+    flags: OFlags,
+    mode: Mode,
+) -> Result<OwnedFd> {
+    // SAFETY: `dirfd` remains borrowed, `path` is NUL-terminated for the call,
+    // and variadic arguments use their promoted C types.
+    let fd = unsafe {
+        libc::openat(
+            dirfd.as_raw_fd(),
+            path.as_ptr(),
+            flags.bits().cast_signed(),
+            libc::c_uint::from(mode.bits()),
+        )
+    };
+    if fd == -1 {
+        // SAFETY: libSystem stored this call's error before returning -1.
+        return Err(Errno::from_raw_os_error(unsafe { *libc::__error() }));
+    }
+
+    // SAFETY: ownership of the newly opened descriptor transfers here.
+    Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+}
+
+fn fcntl_getpath<'buf>(
+    fd: BorrowedFd<'_>,
+    buf: &'buf mut [MaybeUninit<u8>; PATH_MAX],
+) -> Result<CStr<'buf, Thin>> {
+    // SAFETY: `fd` remains borrowed and `buf` has the `MAXPATHLEN` storage
+    // required by `F_GETPATH`.
+    let result = unsafe {
+        libc::fcntl(fd.as_raw_fd(), libc::F_GETPATH, buf.as_mut_ptr().cast::<libc::c_char>())
+    };
+    if result == -1 {
+        // SAFETY: libSystem stored this call's error before returning -1.
+        return Err(Errno::from_raw_os_error(unsafe { *libc::__error() }));
+    }
+
+    // SAFETY: `F_GETPATH` wrote a NUL-terminated pathname into `buf`.
+    Ok(unsafe { CStr::from_ptr(buf.as_ptr().cast()) })
+}
+
+pub(super) fn getcwd(buf: &mut [MaybeUninit<u8>]) -> Result<CStr<'_, Fat>> {
+    let (chunks, remainder) = buf.as_chunks_mut::<PATH_MAX>();
+    let Some(full) = chunks.first_mut() else {
+        return getcwd_small(remainder);
+    };
+    getcwd_full(full)
+}
+
+// Keep the `PATH_MAX` scratch storage in a separate stack frame so the
+// large-buffer path does not reserve it. `inline(never)` preserves that
+// conditional stack allocation after optimization.
+#[inline(never)]
+fn getcwd_small(buf: &mut [MaybeUninit<u8>]) -> Result<CStr<'_, Fat>> {
+    let mut scratch = [MaybeUninit::uninit(); PATH_MAX];
+    let initialized = getcwd_full(&mut scratch)?.len_with_nul();
+    let buf = buf.get_mut(..initialized).ok_or(Errno::RANGE)?;
+
+    buf.copy_from_slice(&scratch[..initialized]);
+    // SAFETY: `getcwd_full` initialized this copied C string prefix.
+    let bytes = unsafe { slice::from_raw_parts(buf.as_ptr().cast(), buf.len()) };
+    // SAFETY: upheld by the initialized prefix above.
+    Ok(unsafe { CStr::from_bytes_with_nul_unchecked(bytes) })
+}
+
+/// The allocation-free fast path from Apple's [`getcwd`]: ask an open `.`
+/// descriptor for its path.
+///
+/// libSystem additionally `stat`s that path and compares it against the
+/// descriptor, falling back to walking up through `..` when they disagree —
+/// `F_GETPATH` can name a directory that has since been renamed or removed.
+/// This wrapper deliberately stops short of both. It has no slow path to fall
+/// back to, so the comparison could only turn a slightly stale answer into a
+/// hard error, and its caller records paths that a process accessed rather
+/// than resolving them: a stale name is a cosmetic inaccuracy, an error is a
+/// lost access. Skipping it also keeps this to two syscalls on the most
+/// common resolution there is.
+///
+/// [`getcwd`]: https://github.com/apple-oss-distributions/Libc/blob/Libc-1752.120.2/gen/FreeBSD/getcwd.c#L62-L138
+fn getcwd_full(buf: &mut [MaybeUninit<u8>; PATH_MAX]) -> Result<CStr<'_, Fat>> {
+    // SAFETY: the byte string contains one trailing NUL.
+    let dot_path = unsafe { CStr::<Fat>::from_bytes_with_nul_unchecked(b".\0") };
+    let fd = openat(CWD, dot_path, OFlags::RDONLY | OFlags::CLOEXEC, Mode::empty())?;
+
+    let path = fcntl_getpath(fd.as_fd(), buf)?;
+    drop(fd);
+
+    // `F_GETPATH` returns no length, so count the result before handing it
+    // back with its length retained.
+    Ok(path.count())
+}

--- a/crates/sigsafe/src/fs/mod.rs
+++ b/crates/sigsafe/src/fs/mod.rs
@@ -1,0 +1,38 @@
+//! Filesystem calls with caller-owned storage.
+
+use core::mem::MaybeUninit;
+
+use crate::{CStr, Fat, Result};
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "macos")]
+mod mac;
+
+#[cfg(target_os = "linux")]
+use linux as imp;
+#[cfg(target_os = "macos")]
+use mac as imp;
+
+/// The platform's maximum pathname size, including the terminating NUL.
+pub const PATH_MAX: usize = imp::PATH_MAX;
+
+/// Writes the absolute pathname of the current working directory into `buf`.
+///
+/// The returned C string borrows `buf`, starts at the same address as `buf`,
+/// and includes a terminating NUL. Bytes after that terminator have an
+/// unspecified initialization state.
+///
+/// This function performs one resolution attempt and does not allocate, grow,
+/// or retry. No buffer size guarantees success, including one larger than
+/// [`PATH_MAX`].
+///
+/// # Errors
+///
+/// Returns the error reported while resolving the current working directory.
+pub fn getcwd(buf: &mut [MaybeUninit<u8>]) -> Result<CStr<'_, Fat>> {
+    imp::getcwd(buf)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/sigsafe/src/fs/tests.rs
+++ b/crates/sigsafe/src/fs/tests.rs
@@ -1,0 +1,29 @@
+use core::mem::MaybeUninit;
+use std::os::unix::ffi::OsStrExt as _;
+
+use super::getcwd;
+use crate::Errno;
+
+#[test]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "std::env::current_dir is the reference implementation under test"
+)]
+fn getcwd_returns_current_directory() {
+    let expected = std::env::current_dir().unwrap();
+    let mut buf = vec![MaybeUninit::uninit(); expected.as_os_str().as_bytes().len() + 1];
+    let buf_ptr = buf.as_ptr().cast::<u8>();
+
+    let actual = getcwd(&mut buf).unwrap();
+
+    assert_eq!(actual.as_ptr().cast::<u8>(), buf_ptr);
+    assert_eq!(
+        actual.as_bytes_with_nul()[..actual.len_with_nul() - 1],
+        *expected.as_os_str().as_bytes()
+    );
+}
+
+#[test]
+fn getcwd_rejects_an_empty_buffer() {
+    assert!(matches!(getcwd(&mut []), Err(Errno::RANGE)));
+}

--- a/crates/sigsafe/src/lib.rs
+++ b/crates/sigsafe/src/lib.rs
@@ -6,8 +6,8 @@
 //! async-signal-safe (`open`, `stat`, `execve`, ...), so its code runs in all
 //! of those places, where libc's own machinery — locks, lazy initialization,
 //! malloc — is off limits. Everything this crate exposes follows three rules:
-//! syscalls only (never through libc on Linux), no locks and no hidden state,
-//! and no global allocation. See README.md for the full approach.
+//! kernel calls bypass libc on Linux, operations use no locks or hidden state,
+//! and nothing allocates globally. See README.md for the full approach.
 
 // Compile as an empty crate on non-unix targets: the crate backs the unix
 // preload library.
@@ -15,18 +15,19 @@
 #![cfg_attr(not(test), no_std)]
 
 mod c_str;
+pub mod fs;
 pub mod mm;
 pub mod param;
 
-pub use c_str::{CStr, Thin};
+pub use c_str::{CStr, Fat, Thin};
 pub use rustix::{
     fd::{AsRawFd, BorrowedFd},
     fs::CWD,
-    io::Errno,
+    io::{Errno, Result},
 };
 
 // Compile-time proof that rustix uses its raw-syscall backend (`linux_raw`)
-// on Linux — and with it, that no call in this crate goes through libc there.
+// on Linux — and with it, that rustix calls do not go through libc there.
 // `rustix::runtime` is gated on that backend (`#[cfg(linux_raw)]`), so this
 // reference fails to resolve, failing the whole build, whenever anything
 // selects the libc backend instead: the `rustix/use-libc` feature (which any
@@ -38,7 +39,7 @@ pub use rustix::{
 // The module's contents are not covered by rustix's stability promise, so a
 // rustix upgrade may break this line. If that happens, re-point it at any
 // other `rustix::runtime` item — do not delete it: it is the only enforcement
-// of the no-libc rule above.
+// of the raw-rustix rule above.
 #[cfg(all(target_os = "linux", not(miri)))]
 const _: () = {
     let _ = rustix::runtime::exit_group;

--- a/crates/sigsafe_alloc/Cargo.toml
+++ b/crates/sigsafe_alloc/Cargo.toml
@@ -8,14 +8,9 @@ publish = false
 doctest = false
 
 [target.'cfg(unix)'.dependencies]
-allocator-api2 = { workspace = true }
+allocator-api2 = { workspace = true, features = ["alloc"] }
 bump-scope = { workspace = true }
 sigsafe = { workspace = true }
-
-[target.'cfg(unix)'.dev-dependencies]
-# The `alloc` feature provides `Global`, letting tests run the pool against
-# the host allocator (and thus under Miri).
-allocator-api2 = { workspace = true, features = ["alloc"] }
 
 [lints]
 workspace = true

--- a/crates/sigsafe_alloc/src/c_string.rs
+++ b/crates/sigsafe_alloc/src/c_string.rs
@@ -1,0 +1,80 @@
+use core::{mem::MaybeUninit, ptr, slice};
+
+use allocator_api2::{alloc::Allocator, boxed::Box, vec::Vec};
+use sigsafe::{CStr, Fat};
+
+/// An allocator-backed owned C string.
+pub struct CString<R, A: Allocator> {
+    bytes: Box<[MaybeUninit<u8>], A>,
+    repr: R,
+}
+
+impl<A: Allocator> CString<Fat, A> {
+    /// Converts a byte vector to a C string without checking its contents.
+    ///
+    /// # Safety
+    ///
+    /// `bytes` must end with exactly one NUL byte and contain no other NUL
+    /// bytes.
+    #[must_use]
+    pub unsafe fn from_vec_with_nul_unchecked(bytes: Vec<u8, A>) -> Self {
+        // SAFETY: upheld by the caller.
+        let repr = unsafe { CStr::<Fat>::from_bytes_with_nul_unchecked(&bytes) }.into_repr();
+        let (bytes, _len, capacity, allocator) = bytes.into_raw_parts_with_alloc();
+        let bytes = ptr::slice_from_raw_parts_mut(bytes.cast::<MaybeUninit<u8>>(), capacity);
+
+        Self {
+            // SAFETY: this uses the vector's original pointer, capacity, and
+            // allocator. Its initialized prefix is described by `repr`; any
+            // spare capacity is valid as `MaybeUninit<u8>`.
+            bytes: unsafe { Box::from_raw_in(bytes, allocator) },
+            repr,
+        }
+    }
+
+    /// Extracts a borrowed C string view containing the entire string.
+    #[must_use]
+    pub fn as_c_str(&self) -> CStr<'_, Fat> {
+        // SAFETY: the initialized prefix described by `repr` is a C string.
+        unsafe { CStr::from_bytes_with_nul_unchecked(self.as_bytes_with_nul()) }
+    }
+
+    /// Returns the contents of this C string without the terminating NUL.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        let bytes = self.as_bytes_with_nul();
+        bytes.split_at(bytes.len() - 1).0
+    }
+
+    /// Returns the contents of this C string, including the terminating NUL.
+    #[must_use]
+    pub fn as_bytes_with_nul(&self) -> &[u8] {
+        // SAFETY: `repr` describes the initialized C string prefix.
+        unsafe { slice::from_raw_parts(self.bytes.as_ptr().cast(), self.repr.len_with_nul()) }
+    }
+
+    /// Consumes this C string and returns its bytes without the terminating NUL.
+    #[must_use = "`self` will be dropped if the result is not used"]
+    pub fn into_bytes(self) -> Vec<u8, A> {
+        let len = self.repr.len_with_nul() - 1;
+        self.into_vec(len)
+    }
+
+    /// Consumes this C string and returns its bytes, including the terminating
+    /// NUL.
+    #[must_use = "`self` will be dropped if the result is not used"]
+    pub fn into_bytes_with_nul(self) -> Vec<u8, A> {
+        let len = self.repr.len_with_nul();
+        self.into_vec(len)
+    }
+
+    fn into_vec(self, len: usize) -> Vec<u8, A> {
+        let Self { bytes, .. } = self;
+        let capacity = bytes.len();
+        let (bytes, allocator) = Box::into_raw_with_allocator(bytes);
+
+        // SAFETY: the box was allocated for `capacity` bytes with `allocator`.
+        // The first `len` bytes are initialized.
+        unsafe { Vec::from_raw_parts_in(bytes.cast::<u8>(), len, capacity, allocator) }
+    }
+}

--- a/crates/sigsafe_alloc/src/fs.rs
+++ b/crates/sigsafe_alloc/src/fs.rs
@@ -1,0 +1,48 @@
+//! Allocating filesystem wrappers.
+
+use allocator_api2::{alloc::Allocator, vec::Vec};
+use sigsafe::{Errno, Fat, Result};
+
+use crate::CString;
+
+/// Returns the absolute pathname of the current working directory, allocated
+/// with `allocator`.
+///
+/// # Errors
+///
+/// Returns [`Errno::NOMEM`] if storage cannot be allocated, or the error from
+/// [`sigsafe::fs::getcwd`].
+pub fn getcwd<A: Allocator>(allocator: A) -> Result<CString<Fat, A>> {
+    let mut bytes = Vec::new_in(allocator);
+    bytes.try_reserve_exact(sigsafe::fs::PATH_MAX).map_err(|_| Errno::NOMEM)?;
+    let initialized =
+        sigsafe::fs::getcwd(&mut bytes.spare_capacity_mut()[..sigsafe::fs::PATH_MAX])?
+            .len_with_nul();
+
+    // SAFETY: `getcwd` initialized this prefix.
+    unsafe { bytes.set_len(initialized) };
+
+    // SAFETY: `getcwd` returned one C string including its terminating NUL.
+    Ok(unsafe { CString::from_vec_with_nul_unchecked(bytes) })
+}
+
+#[cfg(test)]
+mod tests {
+    use allocator_api2::alloc::Global;
+
+    #[test]
+    fn getcwd_allocates_a_c_string() {
+        let path = super::getcwd(Global).unwrap();
+        let mut buffer = [core::mem::MaybeUninit::uninit(); sigsafe::fs::PATH_MAX];
+        let expected = sigsafe::fs::getcwd(&mut buffer).unwrap();
+        let expected = expected.as_bytes_with_nul();
+
+        assert_eq!(path.as_c_str().as_bytes_with_nul(), expected);
+        assert_eq!(path.as_bytes(), &expected[..expected.len() - 1]);
+        assert_eq!(path.as_bytes_with_nul(), expected);
+        assert_eq!(path.into_bytes().as_slice(), &expected[..expected.len() - 1]);
+
+        let path = super::getcwd(Global).unwrap();
+        assert_eq!(path.into_bytes_with_nul().as_slice(), expected);
+    }
+}

--- a/crates/sigsafe_alloc/src/lib.rs
+++ b/crates/sigsafe_alloc/src/lib.rs
@@ -14,6 +14,8 @@
 #![cfg(unix)]
 #![cfg_attr(not(test), no_std)]
 
+mod c_string;
+pub mod fs;
 mod mmap;
 mod pool;
 
@@ -23,6 +25,7 @@ use bump_scope::{
     alloc::compat::AllocatorApi2V02Compat,
     settings::{BumpAllocatorSettings, BumpSettings},
 };
+pub use c_string::CString;
 use mmap::MmapAllocator;
 use pool::ChunkPool;
 


### PR DESCRIPTION
## Motivation

Preload path resolution still obtains the current directory through `nix`, which may allocate through libc in interception contexts. Add caller-buffer `sigsafe::fs::getcwd` and its explicit-allocator adapter, then immediately use it inside the existing `to_absolute_path` callback contract.

The macOS `openat` and `fcntl_getpath` wrappers remain private because they are implementation details of the allocation-free libSystem fast path in this slice.

That fast path stops short of libSystem's verification step. libSystem `stat`s the path `F_GETPATH` returned and compares it against the descriptor, falling back to walking up through `..` when they disagree. This wrapper has no slow path to fall back to, so the comparison could only turn a slightly stale answer into a hard error — and its caller records paths a process accessed rather than resolving them, where a stale name is a cosmetic inaccuracy but an error is a lost access. Skipping it also keeps the most common resolution to two syscalls.