### PR TITLE
feat(sigsafe): resolve Linux descriptor paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,7 @@ dependencies = [
  "ctor",
  "fspy_shared",
  "fspy_shared_unix",
+ "itoa",
  "libc",
  "nix 0.31.2",
  "sigsafe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ futures = "0.3.31"
 futures-util = "0.3.31"
 globset = "0.4.18"
 getrandom = "0.4.2"
+itoa = "1.0.17"
 jsonc-parser = { version = "0.32.0", features = ["serde"] }
 libc = "0.2.185"
 libtest-mimic = "0.8.2"

--- a/crates/fspy_preload_unix/Cargo.toml
+++ b/crates/fspy_preload_unix/Cargo.toml
@@ -20,6 +20,9 @@ nix = { workspace = true, features = ["signal", "fs", "socket", "mman", "time"] 
 sigsafe = { workspace = true }
 sigsafe_alloc = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+itoa = { workspace = true }
+
 [build-dependencies]
 artifact_profile = { workspace = true }
 

--- a/crates/fspy_preload_unix/src/client/convert.rs
+++ b/crates/fspy_preload_unix/src/client/convert.rs
@@ -1,32 +1,52 @@
-#[cfg(target_os = "linux")]
-use std::ffi::CString;
-use std::{
-    ffi::{CStr, OsStr},
-    os::unix::ffi::OsStrExt as _,
-    path::PathBuf,
-};
+use std::ffi::CStr;
+#[cfg(target_os = "macos")]
+use std::{ffi::OsStr, os::unix::ffi::OsStrExt as _, path::PathBuf};
 
+#[cfg(target_os = "linux")]
+use allocator_api2::alloc::Allocator;
+use allocator_api2::vec::Vec;
 use bstr::{BStr, ByteSlice};
 use fspy_shared::ipc::AccessMode;
 use libc::{c_char, c_int};
 use sigsafe::{AsRawFd as _, BorrowedFd, CWD};
 
 #[cfg(target_os = "linux")]
-fn get_fd_path(fd: BorrowedFd<'_>) -> nix::Result<Option<PathBuf>> {
+fn get_fd_path<A: Allocator>(allocator: A, fd: BorrowedFd<'_>) -> nix::Result<Option<Vec<u8, A>>> {
     if fd.as_raw_fd() == CWD.as_raw_fd() {
-        let arena = sigsafe_alloc::arena();
-        let path = sigsafe_alloc::fs::getcwd(&arena)
+        let path = sigsafe_alloc::fs::getcwd(allocator)
             .map_err(|errno| nix::errno::Errno::from_raw(errno.raw_os_error()))?
             .into_bytes();
-        return Ok(Some(OsStr::from_bytes(&path).into()));
+        return Ok(Some(path));
     }
-    match nix::fcntl::readlink(
-        CString::new(format!("/proc/self/fd/{}", fd.as_raw_fd())).unwrap().as_c_str(),
-    ) {
-        Ok(path) => Ok(Some(path.into())),
-        Err(nix::Error::EBADF | nix::Error::ENOENT) => Ok(None), // invalid fd or no such file (Most likely a stdio fd)
-        Err(e) => Err(e),
+    let mut path = [0; PROC_FD_PATH_CAPACITY];
+    let path = proc_fd_path(fd, &mut path);
+    match sigsafe_alloc::fs::readlinkat(allocator, CWD, path) {
+        Ok(path) => Ok(Some(path)),
+        Err(sigsafe::Errno::BADF | sigsafe::Errno::NOENT) => Ok(None),
+        Err(errno) => Err(nix::errno::Errno::from_raw(errno.raw_os_error())),
     }
+}
+
+#[cfg(target_os = "linux")]
+const PROC_FD_PATH_CAPACITY: usize = b"/proc/self/fd/".len() + 11 + 1;
+
+#[cfg(target_os = "linux")]
+fn proc_fd_path<'buf>(
+    fd: BorrowedFd<'_>,
+    buf: &'buf mut [u8; PROC_FD_PATH_CAPACITY],
+) -> sigsafe::CStr<'buf, sigsafe::Thin> {
+    const PREFIX: &[u8] = b"/proc/self/fd/";
+
+    let mut formatted = itoa::Buffer::new();
+    let fd = formatted.format(fd.as_raw_fd()).as_bytes();
+
+    buf[..PREFIX.len()].copy_from_slice(PREFIX);
+    let end = PREFIX.len() + fd.len();
+    buf[PREFIX.len()..end].copy_from_slice(fd);
+    buf[end] = 0;
+
+    // SAFETY: the initialized prefix ends in NUL and lives as long as `buf`.
+    unsafe { sigsafe::CStr::from_ptr(buf.as_ptr().cast()) }
 }
 
 #[cfg(target_os = "macos")]
@@ -62,8 +82,18 @@ impl ToAbsolutePath for BorrowedFd<'_> {
         self,
         f: F,
     ) -> nix::Result<R> {
-        let path = get_fd_path(self)?;
-        f(path.as_ref().map(|path| path.as_os_str().as_bytes().as_bstr()))
+        #[cfg(target_os = "linux")]
+        {
+            let arena = sigsafe_alloc::arena();
+            let path = get_fd_path(&arena, self)?;
+            f(path.as_ref().map(|path| path.as_slice().as_bstr()))
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            let path = get_fd_path(self)?;
+            f(path.as_ref().map(|path| path.as_os_str().as_bytes().as_bstr()))
+        }
     }
 }
 
@@ -93,13 +123,27 @@ impl ToAbsolutePath for PathAt<'_, '_> {
         if pathname.first().copied() == Some(b'/') {
             f(pathname.into())
         } else {
-            let Some(mut abs_path) = get_fd_path(self.0)? else {
-                return f(None);
-            };
-            if !pathname.is_empty() {
-                abs_path.push(OsStr::from_bytes(pathname));
-            }
-            f(Some(abs_path.as_os_str().as_bytes().as_bstr()))
+            self.0.to_absolute_path(|base| {
+                let Some(base) = base else {
+                    return f(None);
+                };
+                if pathname.is_empty() {
+                    return f(Some(base));
+                }
+
+                let arena = sigsafe_alloc::arena();
+                let needs_separator = !base.ends_with(b"/");
+                let mut abs_path = Vec::with_capacity_in(
+                    base.len() + usize::from(needs_separator) + pathname.len(),
+                    &arena,
+                );
+                abs_path.extend_from_slice(base);
+                if needs_separator {
+                    abs_path.push(b'/');
+                }
+                abs_path.extend_from_slice(pathname);
+                f(Some(abs_path.as_slice().as_bstr()))
+            })
         }
     }
 }

--- a/crates/sigsafe/src/fs/linux.rs
+++ b/crates/sigsafe/src/fs/linux.rs
@@ -1,9 +1,43 @@
 use core::{mem::MaybeUninit, slice};
 
-use crate::{CStr, Errno, Fat, Result};
+use crate::{AsRawFd as _, BorrowedFd, CStr, Errno, Fat, Result, Thin};
 
 // Linux UAPI `PATH_MAX`.
 pub(super) const PATH_MAX: usize = 4096;
+
+/// Reads the target of `path` relative to `dirfd` into `buf`.
+///
+/// The returned bytes borrow the initialized prefix of `buf`. As with the
+/// underlying syscall, they do not include a terminating NUL, and a result
+/// that fills `buf` may have been truncated.
+///
+/// This function performs one syscall and does not retry a full buffer.
+///
+/// # Errors
+///
+/// Returns the error reported by `readlinkat`.
+pub fn readlinkat<'buf>(
+    dirfd: BorrowedFd<'_>,
+    path: CStr<'_, Thin>,
+    buf: &'buf mut [MaybeUninit<u8>],
+) -> Result<&'buf [u8]> {
+    // SAFETY: `dirfd` remains borrowed, `path` is NUL-terminated, and `buf`
+    // is writable for `buf.len()` bytes. `readlinkat` returns the initialized
+    // byte count.
+    let initialized = unsafe {
+        syscalls::syscall4(
+            syscalls::Sysno::readlinkat,
+            (dirfd.as_raw_fd() as isize).cast_unsigned(),
+            path.as_ptr().addr(),
+            buf.as_mut_ptr().addr(),
+            buf.len(),
+        )
+    }
+    .map_err(|errno| Errno::from_raw_os_error(errno.into_raw()))?;
+
+    // SAFETY: the syscall initialized exactly this prefix.
+    Ok(unsafe { slice::from_raw_parts(buf.as_ptr().cast(), initialized) })
+}
 
 pub(super) fn getcwd(buf: &mut [MaybeUninit<u8>]) -> Result<CStr<'_, Fat>> {
     // rustix exposes only an allocating `getcwd`, so use the raw syscall for

--- a/crates/sigsafe/src/fs/mod.rs
+++ b/crates/sigsafe/src/fs/mod.rs
@@ -11,6 +11,8 @@ mod mac;
 
 #[cfg(target_os = "linux")]
 use linux as imp;
+#[cfg(target_os = "linux")]
+pub use linux::readlinkat;
 #[cfg(target_os = "macos")]
 use mac as imp;
 

--- a/crates/sigsafe/src/fs/tests.rs
+++ b/crates/sigsafe/src/fs/tests.rs
@@ -27,3 +27,15 @@ fn getcwd_returns_current_directory() {
 fn getcwd_rejects_an_empty_buffer() {
     assert!(matches!(getcwd(&mut []), Err(Errno::RANGE)));
 }
+
+#[cfg(target_os = "linux")]
+#[test]
+fn readlinkat_returns_the_initialized_target() {
+    let mut buf = [MaybeUninit::uninit(); super::PATH_MAX];
+    // SAFETY: the literal is NUL-terminated and lives for the call.
+    let path = unsafe { crate::CStr::<crate::Thin>::from_ptr(c"/proc/self/exe".as_ptr()) };
+
+    let target = super::readlinkat(crate::CWD, path, &mut buf).unwrap();
+
+    assert_eq!(target, std::fs::read_link("/proc/self/exe").unwrap().as_os_str().as_bytes());
+}

--- a/crates/sigsafe_alloc/src/fs.rs
+++ b/crates/sigsafe_alloc/src/fs.rs
@@ -1,6 +1,8 @@
 //! Allocating filesystem wrappers.
 
 use allocator_api2::{alloc::Allocator, vec::Vec};
+#[cfg(target_os = "linux")]
+use sigsafe::{BorrowedFd, CStr, Thin};
 use sigsafe::{Errno, Fat, Result};
 
 use crate::CString;
@@ -26,6 +28,41 @@ pub fn getcwd<A: Allocator>(allocator: A) -> Result<CString<Fat, A>> {
     Ok(unsafe { CString::from_vec_with_nul_unchecked(bytes) })
 }
 
+/// Returns the target of `path` relative to `dirfd`, allocated with
+/// `allocator`.
+///
+/// The buffer grows and retries when `readlinkat` fills it, because the
+/// underlying operation does not otherwise distinguish an exact fit from a
+/// truncated result.
+///
+/// # Errors
+///
+/// Returns [`Errno::NOMEM`] if storage cannot be allocated, or the error from
+/// [`sigsafe::fs::readlinkat`].
+#[cfg(target_os = "linux")]
+pub fn readlinkat<A: Allocator>(
+    allocator: A,
+    dirfd: BorrowedFd<'_>,
+    path: CStr<'_, Thin>,
+) -> Result<Vec<u8, A>> {
+    let mut bytes = Vec::new_in(allocator);
+    bytes.try_reserve_exact(sigsafe::fs::PATH_MAX).map_err(|_| Errno::NOMEM)?;
+
+    loop {
+        let capacity = bytes.capacity();
+        let initialized = sigsafe::fs::readlinkat(dirfd, path, bytes.spare_capacity_mut())?.len();
+        if initialized < capacity {
+            // SAFETY: `readlinkat` initialized this prefix.
+            unsafe { bytes.set_len(initialized) };
+            return Ok(bytes);
+        }
+
+        // The length remains zero, so reserve the desired total capacity.
+        let next_capacity = capacity.checked_mul(2).ok_or(Errno::NOMEM)?;
+        bytes.try_reserve_exact(next_capacity).map_err(|_| Errno::NOMEM)?;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use allocator_api2::alloc::Global;
@@ -44,5 +81,18 @@ mod tests {
 
         let path = super::getcwd(Global).unwrap();
         assert_eq!(path.into_bytes_with_nul().as_slice(), expected);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn readlinkat_allocates_the_complete_target() {
+        // SAFETY: the literal is NUL-terminated and lives for the call.
+        let path = unsafe { sigsafe::CStr::<sigsafe::Thin>::from_ptr(c"/proc/self/exe".as_ptr()) };
+        let target = super::readlinkat(Global, sigsafe::CWD, path).unwrap();
+
+        assert_eq!(
+            target.as_slice(),
+            std::fs::read_link("/proc/self/exe").unwrap().as_os_str().as_encoded_bytes()
+        );
     }
 }


### PR DESCRIPTION
## Motivation

Linux descriptor path resolution still uses `nix::readlink` and heap-backed formatting. Add a raw caller-buffer `readlinkat` wrapper and allocator adapter, then immediately replace that path with stack formatting and arena storage.

The low-level wrapper preserves readlink truncation semantics; the allocating adapter retries only when the buffer is filled.