### PR TITLE
feat(sigsafe): resolve macOS descriptor paths

### DIFF
--- a/crates/fspy_preload_unix/src/client/convert.rs
+++ b/crates/fspy_preload_unix/src/client/convert.rs
@@ -1,10 +1,6 @@
 use std::ffi::CStr;
-#[cfg(target_os = "macos")]
-use std::{ffi::OsStr, os::unix::ffi::OsStrExt as _, path::PathBuf};
 
-#[cfg(target_os = "linux")]
-use allocator_api2::alloc::Allocator;
-use allocator_api2::vec::Vec;
+use allocator_api2::{alloc::Allocator, vec::Vec};
 use bstr::{BStr, ByteSlice};
 use fspy_shared::ipc::AccessMode;
 use libc::{c_char, c_int};
@@ -50,23 +46,22 @@ fn proc_fd_path<'buf>(
 }
 
 #[cfg(target_os = "macos")]
-fn get_fd_path(fd: BorrowedFd<'_>) -> nix::Result<Option<PathBuf>> {
+fn get_fd_path<A: Allocator>(allocator: A, fd: BorrowedFd<'_>) -> nix::Result<Option<Vec<u8, A>>> {
     if fd.as_raw_fd() == CWD.as_raw_fd() {
-        let arena = sigsafe_alloc::arena();
-        let path = sigsafe_alloc::fs::getcwd(&arena)
+        let path = sigsafe_alloc::fs::getcwd(allocator)
             .map_err(|errno| nix::errno::Errno::from_raw(errno.raw_os_error()))?
             .into_bytes();
-        return Ok(Some(OsStr::from_bytes(&path).into()));
+        return Ok(Some(path));
     }
 
-    let mut path = std::path::PathBuf::new();
-    // SAFETY: this std view has the same descriptor and lifetime as the
-    // rustix view accepted by this function.
-    let fd = unsafe { std::os::fd::BorrowedFd::borrow_raw(fd.as_raw_fd()) };
-    match nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_GETPATH(&mut path)) {
-        Ok(_) => Ok(Some(path)),
-        Err(nix::Error::EBADF | nix::Error::ENOENT) => Ok(None), // invalid fd or no such file (Most likely a stdio fd)
-        Err(e) => Err(e),
+    match sigsafe_alloc::fs::fcntl_getpath(allocator, fd) {
+        Ok(path) => {
+            // `F_GETPATH` does not return a length. Count at this caller before
+            // converting its allocation into the returned path.
+            Ok(Some(path.count().into_bytes()))
+        }
+        Err(sigsafe::Errno::BADF | sigsafe::Errno::NOENT) => Ok(None),
+        Err(errno) => Err(nix::errno::Errno::from_raw(errno.raw_os_error())),
     }
 }
 
@@ -82,18 +77,9 @@ impl ToAbsolutePath for BorrowedFd<'_> {
         self,
         f: F,
     ) -> nix::Result<R> {
-        #[cfg(target_os = "linux")]
-        {
-            let arena = sigsafe_alloc::arena();
-            let path = get_fd_path(&arena, self)?;
-            f(path.as_ref().map(|path| path.as_slice().as_bstr()))
-        }
-
-        #[cfg(target_os = "macos")]
-        {
-            let path = get_fd_path(self)?;
-            f(path.as_ref().map(|path| path.as_os_str().as_bytes().as_bstr()))
-        }
+        let arena = sigsafe_alloc::arena();
+        let path = get_fd_path(&arena, self)?;
+        f(path.as_ref().map(|path| path.as_slice().as_bstr()))
     }
 }
 

--- a/crates/sigsafe/README.md
+++ b/crates/sigsafe/README.md
@@ -29,7 +29,7 @@ rustix can be built with a libc backend instead of raw syscalls, and anything in
 Functions whose rustix implementation already meets the rules are re-exposed as-is; being listed in a module here is what marks a call as allowed, and the backend check above is what keeps that true.
 
 - `mm` — anonymous memory mappings: `mmap_anonymous`, `munmap`.
-- `fs` — caller-buffer filesystem operations: `getcwd`.
+- `fs` — caller-buffer filesystem operations: `getcwd`, plus macOS `fcntl_getpath`.
 - `param` — `page_size`.
 
 Allocation without malloc lives in [`sigsafe_alloc`](../sigsafe_alloc).

--- a/crates/sigsafe/src/fs/mac.rs
+++ b/crates/sigsafe/src/fs/mac.rs
@@ -35,7 +35,20 @@ fn openat<R>(
     Ok(unsafe { OwnedFd::from_raw_fd(fd) })
 }
 
-fn fcntl_getpath<'buf>(
+/// Gets the path associated with `fd`.
+///
+/// `F_GETPATH` writes a NUL-terminated path into its `MAXPATHLEN` buffer but
+/// does not report the length, so this function returns [`CStr<Thin>`] without
+/// scanning for the terminator. The returned C string borrows `buf` and starts
+/// at the same address as `buf`.
+///
+/// This function performs one `fcntl` call and does not retry. `F_GETPATH`
+/// accepts no buffer length and always uses its fixed `MAXPATHLEN` storage.
+///
+/// # Errors
+///
+/// Returns the error reported by `fcntl`.
+pub fn fcntl_getpath<'buf>(
     fd: BorrowedFd<'_>,
     buf: &'buf mut [MaybeUninit<u8>; PATH_MAX],
 ) -> Result<CStr<'buf, Thin>> {

--- a/crates/sigsafe/src/fs/mod.rs
+++ b/crates/sigsafe/src/fs/mod.rs
@@ -15,6 +15,8 @@ use linux as imp;
 pub use linux::readlinkat;
 #[cfg(target_os = "macos")]
 use mac as imp;
+#[cfg(target_os = "macos")]
+pub use mac::fcntl_getpath;
 
 /// The platform's maximum pathname size, including the terminating NUL.
 pub const PATH_MAX: usize = imp::PATH_MAX;

--- a/crates/sigsafe/src/fs/tests.rs
+++ b/crates/sigsafe/src/fs/tests.rs
@@ -28,6 +28,25 @@ fn getcwd_rejects_an_empty_buffer() {
     assert!(matches!(getcwd(&mut []), Err(Errno::RANGE)));
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn fcntl_getpath_returns_descriptor_path() {
+    use rustix::{
+        fd::AsFd as _,
+        fs::{Mode, OFlags, open},
+    };
+
+    let root = open(c"/", OFlags::RDONLY, Mode::empty()).unwrap();
+    let mut buf = [MaybeUninit::uninit(); super::PATH_MAX];
+    let buf_ptr = buf.as_ptr().cast::<u8>();
+
+    let path = super::fcntl_getpath(root.as_fd(), &mut buf).unwrap();
+
+    assert_eq!(path.as_ptr().cast::<u8>(), buf_ptr);
+    let path = path.count();
+    assert_eq!(path.as_bytes_with_nul(), b"/\0");
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn readlinkat_returns_the_initialized_target() {

--- a/crates/sigsafe_alloc/src/c_string.rs
+++ b/crates/sigsafe_alloc/src/c_string.rs
@@ -1,7 +1,7 @@
 use core::{mem::MaybeUninit, ptr, slice};
 
 use allocator_api2::{alloc::Allocator, boxed::Box, vec::Vec};
-use sigsafe::{CStr, Fat};
+use sigsafe::{CStr, Fat, Thin};
 
 /// An allocator-backed owned C string.
 pub struct CString<R, A: Allocator> {
@@ -31,7 +31,41 @@ impl<A: Allocator> CString<Fat, A> {
             repr,
         }
     }
+}
 
+impl<A: Allocator> CString<Thin, A> {
+    /// Converts boxed storage to a thin C string without checking its
+    /// contents.
+    ///
+    /// # Safety
+    ///
+    /// `bytes` must begin with a valid NUL-terminated C string. Bytes after
+    /// that string may be uninitialized.
+    #[must_use]
+    pub unsafe fn from_boxed_with_nul_unchecked(bytes: Box<[MaybeUninit<u8>], A>) -> Self {
+        // SAFETY: upheld by the caller. Creating a thin view does not scan the
+        // allocation or retain the string length.
+        let repr = unsafe { CStr::<Thin>::from_ptr(bytes.as_ptr().cast()) }.into_repr();
+        Self { bytes, repr }
+    }
+
+    /// Returns a thin borrowed view of this C string.
+    #[must_use]
+    pub fn as_c_str(&self) -> CStr<'_, Thin> {
+        // SAFETY: upheld by the constructor; `self` owns the storage.
+        unsafe { CStr::from_ptr(self.bytes.as_ptr().cast()) }
+    }
+
+    /// Counts through the terminating NUL and returns a length-retaining C
+    /// string using the same allocation.
+    #[must_use]
+    pub fn count(self) -> CString<Fat, A> {
+        let repr = self.as_c_str().count().into_repr();
+        CString { bytes: self.bytes, repr }
+    }
+}
+
+impl<A: Allocator> CString<Fat, A> {
     /// Extracts a borrowed C string view containing the entire string.
     #[must_use]
     pub fn as_c_str(&self) -> CStr<'_, Fat> {

--- a/crates/sigsafe_alloc/src/fs.rs
+++ b/crates/sigsafe_alloc/src/fs.rs
@@ -1,8 +1,12 @@
 //! Allocating filesystem wrappers.
 
+#[cfg(target_os = "macos")]
+use allocator_api2::boxed::Box;
 use allocator_api2::{alloc::Allocator, vec::Vec};
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use sigsafe::Thin;
 #[cfg(target_os = "linux")]
-use sigsafe::{BorrowedFd, CStr, Thin};
+use sigsafe::{BorrowedFd, CStr};
 use sigsafe::{Errno, Fat, Result};
 
 use crate::CString;
@@ -63,6 +67,39 @@ pub fn readlinkat<A: Allocator>(
     }
 }
 
+/// Returns the path associated with `fd`, allocated with `allocator`.
+///
+/// The returned C string remains thin because `F_GETPATH` reports no length.
+///
+/// # Errors
+///
+/// Returns [`Errno::NOMEM`] if storage cannot be allocated, or the error from
+/// [`sigsafe::fs::fcntl_getpath`].
+#[cfg(target_os = "macos")]
+pub fn fcntl_getpath<A: Allocator>(
+    allocator: A,
+    fd: sigsafe::BorrowedFd<'_>,
+) -> Result<CString<Thin, A>> {
+    let mut bytes = path_buffer(allocator)?;
+    sigsafe::fs::fcntl_getpath(fd, &mut bytes)?;
+
+    // SAFETY: `fcntl_getpath` initialized a NUL-terminated string at the start
+    // of `bytes`.
+    Ok(unsafe { CString::from_boxed_with_nul_unchecked(Box::slice(bytes)) })
+}
+
+#[cfg(target_os = "macos")]
+fn path_buffer<A: Allocator>(
+    allocator: A,
+) -> Result<Box<[core::mem::MaybeUninit<u8>; sigsafe::fs::PATH_MAX], A>> {
+    let bytes =
+        Box::<[core::mem::MaybeUninit<u8>; sigsafe::fs::PATH_MAX], A>::try_new_uninit_in(allocator)
+            .map_err(|_| Errno::NOMEM)?;
+
+    // SAFETY: an array of `MaybeUninit<u8>` requires no initialization.
+    Ok(unsafe { bytes.assume_init() })
+}
+
 #[cfg(test)]
 mod tests {
     use allocator_api2::alloc::Global;
@@ -81,6 +118,19 @@ mod tests {
 
         let path = super::getcwd(Global).unwrap();
         assert_eq!(path.into_bytes_with_nul().as_slice(), expected);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn fcntl_getpath_allocates_a_thin_c_string() {
+        use std::{fs::File, os::fd::AsRawFd as _};
+
+        let root = File::open("/").unwrap();
+        // SAFETY: `root` remains open for the call.
+        let root = unsafe { sigsafe::BorrowedFd::borrow_raw(root.as_raw_fd()) };
+        let path = super::fcntl_getpath(Global, root).unwrap();
+
+        assert_eq!(path.as_c_str().count().as_bytes_with_nul(), b"/\0");
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Motivation

macOS descriptor path resolution still uses `nix::fcntl` and `PathBuf`. Expose the already-used `F_GETPATH` primitive, add its explicit-allocator adapter, and immediately consume it from preload.

`F_GETPATH` returns no length, so the wrapper returns `CString<Thin>` without scanning. Preload explicitly counts it before converting the same allocation into path bytes.