### PR TITLE
refactor(fspy): retain C string lengths in path resolution

### DIFF
--- a/crates/fspy_preload_unix/src/client/convert.rs
+++ b/crates/fspy_preload_unix/src/client/convert.rs
@@ -103,11 +103,10 @@ impl ToAbsolutePath for PathAt<'_, '_> {
         self,
         f: F,
     ) -> nix::Result<R> {
-        // SAFETY: self.1 is a valid NUL-terminated string.
-        let pathname = unsafe { CStr::from_ptr(self.1.as_ptr()) }.to_bytes().as_bstr();
+        let pathname = self.1.count().as_bytes().as_bstr();
 
-        if pathname.first().copied() == Some(b'/') {
-            f(pathname.into())
+        if pathname.starts_with(b"/") {
+            f(Some(pathname))
         } else {
             self.0.to_absolute_path(|base| {
                 let Some(base) = base else {

--- a/crates/sigsafe/src/c_str.rs
+++ b/crates/sigsafe/src/c_str.rs
@@ -102,6 +102,13 @@ impl<'a> CStr<'a, Fat> {
         }
     }
 
+    /// Returns the string's bytes without the terminating NUL.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &'a [u8] {
+        let bytes = self.as_bytes_with_nul();
+        bytes.split_at(bytes.len() - 1).0
+    }
+
     /// Returns the string's bytes, including the terminating NUL.
     #[must_use]
     pub const fn as_bytes_with_nul(&self) -> &'a [u8] {
@@ -132,6 +139,7 @@ mod tests {
         assert_eq!(size_of::<CStr<'_, Thin>>(), size_of::<*const u8>());
         assert_eq!(size_of::<CStr<'_, Fat>>(), size_of::<(*const u8, usize)>());
         assert_eq!(fat.len_with_nul(), 4);
+        assert_eq!(fat.as_bytes(), b"abc");
         assert_eq!(fat.as_bytes_with_nul(), b"abc\0");
         assert_eq!(counted.as_bytes_with_nul(), fat.as_bytes_with_nul());
     }


### PR DESCRIPTION
## Motivation

Path resolution currently converts `sigsafe::CStr<Thin>` back into `core::ffi::CStr`, so its terminator scan produces only a temporary slice. Count into `sigsafe::CStr<Fat>`, expose its bytes without the terminator, and use that retained length while resolving paths.

This keeps the callback and allocation behavior unchanged so the following PR can review the output-ownership change independently.