### PR TITLE
chore: group all Vite+ packages on one Renovate policy

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
   "ignorePaths": ["**/fixtures/**"],
   "packageRules": [
     {
-      "description": "Group all Vite+ packages into a single PR; they are published together at the same version. minimumReleaseAge and schedule keep @voidzero-dev/vite-plus-* (the vite catalog alias) on the same policy as vite-plus; the preset's generic npm rule would otherwise hold the alias behind a 3-day age gate and a Monday schedule.",
+      "description": "Group all Vite+ packages into a single PR; they are published together at the same version, and vp pins vitest to the version bundled in vite-plus. minimumReleaseAge and schedule keep @voidzero-dev/vite-plus-* (the vite catalog alias) on the same policy as vite-plus; the preset's generic npm rule would otherwise hold the alias behind a 3-day age gate and a Monday schedule.",
       "groupName": "vite+",
-      "matchPackageNames": ["vite-plus", "@voidzero-dev/vite-plus-*"],
+      "matchPackageNames": ["vite-plus", "@voidzero-dev/vite-plus-*", "vitest"],
       "minimumReleaseAge": "0 days",
       "schedule": ["at any time"]
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>Boshen/renovate"],
-  "ignorePaths": ["**/fixtures/**"]
+  "ignorePaths": ["**/fixtures/**"],
+  "packageRules": [
+    {
+      "description": "Group all Vite+ packages into a single PR; they are published together at the same version. minimumReleaseAge and schedule keep @voidzero-dev/vite-plus-* (the vite catalog alias) on the same policy as vite-plus; the preset's generic npm rule would otherwise hold the alias behind a 3-day age gate and a Monday schedule.",
+      "groupName": "vite+",
+      "matchPackageNames": ["vite-plus", "@voidzero-dev/vite-plus-*"],
+      "minimumReleaseAge": "0 days",
+      "schedule": ["at any time"]
+    }
+  ]
 }


### PR DESCRIPTION
The `vite` catalog entry is an npm alias for `@voidzero-dev/vite-plus-core`, so it misses the preset's vite+ rule (0-day `minimumReleaseAge`, any-time schedule) and falls under the generic npm rule (3-day age, Monday schedule). Renovate then bumps `vite-plus` and leaves the alias behind: main already pairs vite-plus 0.2.4 with core 0.2.2, and #593 would widen that to 0.2.8 vs 0.2.2.

Add a repo rule so `vite-plus`, `@voidzero-dev/vite-plus-*`, and `vitest` share the vite+ group and the same age and schedule. vp pins the vitest override to the version bundled in vite-plus, so a lone vitest bump would desync that pin the same way; vite-task has no vitest today, making the match inert until it does. After merging, a Renovate run should fold the alias bump to 0.2.8 into #593.

Same fix as voidzero-dev/setup-vp#121 and voidzero-dev/setup.viteplus.dev#42, where Renovate folded the alias into the open update PR after the config merged. General write-up in voidzero-dev/vite-plus#2356; the preset-level fix Boshen/renovate#1 is still open, and this rule becomes redundant once it merges.