### PR TITLE
perf: optimize release build dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,31 +209,13 @@ strip = "symbols" # set to `false` for debug information
 debug = false # set to `true` for debug information
 panic = "abort" # Let it crash and force ourselves to write safe Rust.
 
-# Cargo compiles artifact dependencies declared under `[build-dependencies]`
-# with the build-override profile — opt-level 0, no codegen-units setting —
-# even in release builds, and even with `target = "target"`. Their output
-# still lands under `target/<triple>/release/`, so the missing optimization
-# is easy to miss. (Artifact deps under `[dependencies]`/`[dev-dependencies]`
-# get the normal profile and need nothing here.) See
+# Cargo normally compiles build scripts, proc macros, artifact dependencies,
+# and their dependencies with opt-level 0 and 256 codegen units, even in
+# release builds. Artifact dependencies are runtime code, so optimize the
+# entire build graph instead of maintaining a list of individual artifacts.
+# Profile overrides do not inherit `strip`, so restate it here. See
 # https://github.com/rust-lang/cargo/issues/16719.
-#
-# These are the workspace's build-dependency artifacts: the preload libraries
-# are injected into every traced process and run inside every intercepted
-# libc call, and the napi library backs the Node.js client.
-#
-# `strip` must be restated: a package override resets an inherited `strip`
-# to "debuginfo" when the field is omitted (Cargo quirk in profile merging).
-[profile.release.package.fspy_preload_unix]
-opt-level = 3
-codegen-units = 1
-strip = "symbols"
-
-[profile.release.package.fspy_preload_windows]
-opt-level = 3
-codegen-units = 1
-strip = "symbols"
-
-[profile.release.package.vt_client_napi]
+[profile.release.build-override]
 opt-level = 3
 codegen-units = 1
 strip = "symbols"


### PR DESCRIPTION
## Motivation

Cargo compiles build dependencies at optimization level 0 by default. That includes artifact dependencies containing runtime code, so the workspace currently maintains a package override for every shipped artifact and can silently miss newly extracted runtime crates.

Apply the optimized release settings to the complete build-dependency graph instead. This removes the individual preload and N-API overrides, keeps artifact symbols stripped, and automatically covers future artifact dependencies and their runtime dependencies.