### PR TITLE
fix: avoid unnecessary napi6 feature activation

### DIFF
--- a/crates/vt_client_napi/Cargo.toml
+++ b/crates/vt_client_napi/Cargo.toml
@@ -12,7 +12,7 @@ test = false
 doctest = false
 
 [dependencies]
-napi = { workspace = true, features = ["napi6", "tracing"] }
+napi = { workspace = true, features = ["tracing"] }
 napi-derive = { workspace = true }
 vt_str = { workspace = true }
 vt_client = { workspace = true }


### PR DESCRIPTION
## Motivation

`vt_client_napi` does not use N-API 6-only APIs. Keeping `napi6` enabled became observable to downstream workspaces after the addon moved from a build dependency to a normal artifact dependency: Cargo now unifies it into their normal N-API feature graph.

In Vite+, that feature unification exposes `ValueType::BigInt` in Rolldown's N-API build and breaks its exhaustive match. Remove the unnecessary feature so downstream consumers keep their intended N-API surface.
