### PR TITLE
refactor(fspy-shm): generate Unix names through sigsafe

### DIFF
--- a/crates/fspy_shm/Cargo.toml
+++ b/crates/fspy_shm/Cargo.toml
@@ -7,14 +7,12 @@ license.workspace = true
 publish = false
 rust-version.workspace = true
 
-[dependencies]
-uuid = { workspace = true, features = ["v4"] }
-
 [target.'cfg(unix)'.dependencies]
 sigsafe = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 memmap2 = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = [
@@ -27,6 +25,7 @@ windows-sys = { workspace = true, features = [
 [dev-dependencies]
 ctor = { workspace = true }
 subprocess_test = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 
 [lints]
 workspace = true

--- a/crates/fspy_shm/src/unix.rs
+++ b/crates/fspy_shm/src/unix.rs
@@ -4,7 +4,7 @@
 use std::{
     env::temp_dir,
     ffi::OsStr,
-    fs, io,
+    io,
     num::NonZeroUsize,
     os::unix::ffi::OsStrExt as _,
     path::PathBuf,
@@ -126,13 +126,20 @@ fn open_file(
     flags: sigsafe::fs::OFlags,
     mode: sigsafe::fs::Mode,
 ) -> Result<sigsafe::OwnedFd> {
+    let mut path = [0_u8; sigsafe::fs::PATH_MAX];
+    let path = copy_path(id, &mut path)?;
+    sigsafe::fs::openat(sigsafe::CWD, path, flags, mode)
+}
+
+fn copy_path<'buf>(
+    id: &OsStr,
+    buf: &'buf mut [u8; sigsafe::fs::PATH_MAX],
+) -> Result<sigsafe::CStr<'buf, sigsafe::Fat>> {
     let id = id.as_bytes();
     let len_with_nul = id.len().checked_add(1).ok_or(sigsafe::Errno::NAMETOOLONG)?;
-    let mut path = [0_u8; sigsafe::fs::PATH_MAX];
-    let path = path.get_mut(..len_with_nul).ok_or(sigsafe::Errno::NAMETOOLONG)?;
+    let path = buf.get_mut(..len_with_nul).ok_or(sigsafe::Errno::NAMETOOLONG)?;
     path[..id.len()].copy_from_slice(id);
-    let path = sigsafe::CStr::from_bytes_with_nul(path).map_err(|_| sigsafe::Errno::INVAL)?;
-    sigsafe::fs::openat(sigsafe::CWD, path, flags, mode)
+    sigsafe::CStr::from_bytes_with_nul(path).map_err(|_| sigsafe::Errno::INVAL)
 }
 
 fn errno_to_io(errno: sigsafe::Errno) -> io::Error {
@@ -141,7 +148,11 @@ fn errno_to_io(errno: sigsafe::Errno) -> io::Error {
 
 impl Drop for ShmKeeper {
     fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
+        let mut path = [0_u8; sigsafe::fs::PATH_MAX];
+        let Ok(path) = copy_path(self.path.as_os_str(), &mut path) else {
+            return;
+        };
+        let _ = sigsafe::fs::unlinkat(sigsafe::CWD, path, sigsafe::fs::AtFlags::empty());
     }
 }
 

--- a/crates/fspy_shm/src/unix.rs
+++ b/crates/fspy_shm/src/unix.rs
@@ -9,11 +9,14 @@ use std::{
     os::unix::ffi::OsStrExt as _,
     path::PathBuf,
     ptr::{self, NonNull},
+    str,
 };
 
-use uuid::Uuid;
-
 use crate::BACKING_PREFIX;
+
+const RANDOM_BYTES: usize = 16;
+const RANDOM_HEX_BYTES: usize = RANDOM_BYTES * 2;
+const HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
 
 /// Error returned by shared-memory operations on Unix.
 pub type Error = sigsafe::Error;
@@ -76,8 +79,9 @@ pub fn create(size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
     // `temp_dir` reflects `TMPDIR` verbatim, which may be relative. The
     // identifier travels to processes with other working directories, so
     // resolve it against the creator's current directory first.
-    let path = std::path::absolute(temp_dir())?
-        .join(format!("{BACKING_PREFIX}{}.shm", Uuid::new_v4().simple()));
+    let random = random_hex()?;
+    let random = str::from_utf8(&random).map_err(|_| io::ErrorKind::InvalidData)?;
+    let path = std::path::absolute(temp_dir())?.join(format!("{BACKING_PREFIX}{random}.shm"));
 
     let file = open_file(
         path.as_os_str(),
@@ -144,6 +148,18 @@ fn copy_path<'buf>(
 
 fn errno_to_io(errno: sigsafe::Errno) -> io::Error {
     io::Error::from_raw_os_error(errno.raw_os_error())
+}
+
+fn random_hex() -> io::Result<[u8; RANDOM_HEX_BYTES]> {
+    let mut random = [0; RANDOM_BYTES];
+    sigsafe::random::fill(&mut random).map_err(errno_to_io)?;
+
+    let mut hex = [0; RANDOM_HEX_BYTES];
+    for (byte, digits) in random.into_iter().zip(hex.as_chunks_mut::<2>().0) {
+        digits[0] = HEX_DIGITS[usize::from(byte >> 4)];
+        digits[1] = HEX_DIGITS[usize::from(byte & 0x0f)];
+    }
+    Ok(hex)
 }
 
 impl Drop for ShmKeeper {

--- a/crates/sigsafe/src/fs/mod.rs
+++ b/crates/sigsafe/src/fs/mod.rs
@@ -1,8 +1,8 @@
 //! Filesystem calls with caller-owned storage.
 
-use core::mem::MaybeUninit;
+use core::{ffi::CStr as CoreCStr, mem::MaybeUninit};
 
-pub use rustix::fs::{Mode, OFlags, Stat, fstat, ftruncate};
+pub use rustix::fs::{AtFlags, Mode, OFlags, Stat, fstat, ftruncate};
 
 use crate::{BorrowedFd, CStr, Fat, OwnedFd, Result};
 
@@ -35,6 +35,17 @@ pub fn openat<R>(
     mode: Mode,
 ) -> Result<OwnedFd> {
     imp::openat(dirfd, path, flags, mode)
+}
+
+/// Removes `path` relative to `dirfd`.
+///
+/// # Errors
+///
+/// Returns the error reported by `unlinkat`.
+pub fn unlinkat(dirfd: BorrowedFd<'_>, path: CStr<'_, Fat>, flags: AtFlags) -> Result<()> {
+    // SAFETY: `path` already guarantees exactly one trailing NUL.
+    let path = unsafe { CoreCStr::from_bytes_with_nul_unchecked(path.as_bytes_with_nul()) };
+    rustix::fs::unlinkat(dirfd, path, flags)
 }
 
 /// Writes the absolute pathname of the current working directory into `buf`.

--- a/crates/sigsafe/src/lib.rs
+++ b/crates/sigsafe/src/lib.rs
@@ -20,6 +20,7 @@ pub mod env;
 pub mod fs;
 pub mod mm;
 pub mod param;
+pub mod random;
 
 pub use c_str::{Bytes, CStr, Fat, Thin};
 pub use rustix::{

--- a/crates/sigsafe/src/random.rs
+++ b/crates/sigsafe/src/random.rs
@@ -1,0 +1,71 @@
+//! Kernel-backed random bytes with no allocation or hidden initialization.
+
+use crate::Result;
+
+/// Fills `bytes` with random data supplied by the kernel.
+///
+/// Linux uses the `getrandom` syscall directly. macOS uses libSystem's
+/// `getentropy` system-call wrapper in chunks within its 256-byte limit.
+///
+/// # Errors
+///
+/// Returns the error reported by the platform random-data call.
+pub fn fill(bytes: &mut [u8]) -> Result<()> {
+    imp::fill(bytes)
+}
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use crate::{Errno, Result};
+
+    pub(super) fn fill(mut bytes: &mut [u8]) -> Result<()> {
+        while !bytes.is_empty() {
+            // SAFETY: `bytes` is writable for its complete length and the
+            // kernel initializes only the count it returns.
+            let initialized = unsafe {
+                syscalls::syscall3(
+                    syscalls::Sysno::getrandom,
+                    bytes.as_mut_ptr().addr(),
+                    bytes.len(),
+                    0,
+                )
+            }
+            .map_err(|errno| Errno::from_raw_os_error(errno.into_raw()))?;
+            if initialized == 0 {
+                return Err(Errno::IO);
+            }
+            let (_, remaining) = bytes.split_at_mut_checked(initialized).ok_or(Errno::IO)?;
+            bytes = remaining;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use crate::{Errno, Result};
+
+    pub(super) fn fill(bytes: &mut [u8]) -> Result<()> {
+        for chunk in bytes.chunks_mut(256) {
+            // SAFETY: `chunk` is writable for the supplied length, which is
+            // within getentropy's 256-byte limit.
+            let result = unsafe { libc::getentropy(chunk.as_mut_ptr().cast(), chunk.len()) };
+            if result == -1 {
+                // SAFETY: libSystem stored this call's error before returning.
+                return Err(Errno::from_raw_os_error(unsafe { *libc::__error() }));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fills_empty_and_nonempty_buffers() {
+        fill(&mut []).unwrap();
+        fill(&mut [0; 32]).unwrap();
+    }
+}


### PR DESCRIPTION
## Motivation

UUID generation brings heap- and runtime-dependent machinery into Unix backing-file creation. Kernel-backed sigsafe randomness provides the same collision resistance with fixed-size buffers and is immediately used to generate the shared-memory filename.