### PR TITLE
refactor(fspy-shm): store Unix paths inline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,6 +1417,7 @@ version = "0.0.0"
 dependencies = [
  "ctor",
  "memmap2",
+ "sigsafe",
  "subprocess_test",
  "uuid",
  "windows-sys 0.61.2",

--- a/crates/fspy_shared/src/ipc/channel/mod.rs
+++ b/crates/fspy_shared/src/ipc/channel/mod.rs
@@ -28,8 +28,8 @@ pub fn channel(capacity: usize) -> io::Result<(ChannelConf, Receiver)> {
     let lock_file_path = temp_dir.join(format!("fspy_ipc_{id}.lock"));
     let shm_path = temp_dir.join(format!("fspy_ipc_{id}.shm"));
 
-    let (keeper, handle) = fspy_shm::create(shm_path.as_os_str(), capacity)?;
-    let mapping = handle.map()?;
+    let (keeper, handle) = shm_result(fspy_shm::create(shm_path.as_os_str(), capacity))?;
+    let mapping = shm_result(handle.map())?;
 
     let conf = ChannelConf {
         lock_file_path: lock_file_path.as_os_str().into(),
@@ -52,13 +52,24 @@ impl ChannelConf {
         let lock_file = File::open(self.lock_file_path.to_cow_os_str())?;
         lock_file.try_lock_shared()?;
 
-        let mapping = fspy_shm::open(&self.shm_path.to_cow_os_str())?.map()?;
+        let handle = shm_result(fspy_shm::open(&self.shm_path.to_cow_os_str()))?;
+        let mapping = shm_result(handle.map())?;
         // SAFETY: `mapping` is a freshly mapped shared memory region with valid
         // pointer and size. Exclusive write access is ensured by the shared
         // file lock held by this sender.
         let writer = unsafe { ShmWriter::new(mapping) };
         Ok(Sender { writer, lock_file, lock_file_path: self.lock_file_path.clone() })
     }
+}
+
+#[cfg(unix)]
+fn shm_result<T>(result: fspy_shm::Result<T>) -> io::Result<T> {
+    result.map_err(|error| io::Error::from_raw_os_error(error.raw_os_error()))
+}
+
+#[cfg(windows)]
+const fn shm_result<T>(result: fspy_shm::Result<T>) -> io::Result<T> {
+    result
 }
 
 pub struct Sender {

--- a/crates/fspy_shared/src/ipc/channel/mod.rs
+++ b/crates/fspy_shared/src/ipc/channel/mod.rs
@@ -17,21 +17,23 @@ use super::NativeStr;
 #[derive(SchemaWrite, SchemaRead, Clone, Debug)]
 pub struct ChannelConf {
     lock_file_path: Box<NativeStr>,
-    shm_id: Box<NativeStr>,
+    shm_path: Box<NativeStr>,
 }
 
 /// Creates a mpsc IPC channel with one receiver and a `ChannelConf` that can be passed around processes and used to create multiple senders
 #[expect(clippy::missing_errors_doc, reason = "non-vt crate: cannot use vt_str/vt_path types")]
 pub fn channel(capacity: usize) -> io::Result<(ChannelConf, Receiver)> {
-    // Initialize the lock file with a unique name.
-    let lock_file_path = temp_dir().join(format!("fspy_ipc_{}.lock", Uuid::new_v4()));
+    let id = Uuid::new_v4();
+    let temp_dir = std::path::absolute(temp_dir())?;
+    let lock_file_path = temp_dir.join(format!("fspy_ipc_{id}.lock"));
+    let shm_path = temp_dir.join(format!("fspy_ipc_{id}.shm"));
 
-    let (keeper, handle) = fspy_shm::create(capacity)?;
+    let (keeper, handle) = fspy_shm::create(shm_path.as_os_str(), capacity)?;
     let mapping = handle.map()?;
 
     let conf = ChannelConf {
         lock_file_path: lock_file_path.as_os_str().into(),
-        shm_id: keeper.id().into(),
+        shm_path: shm_path.as_os_str().into(),
     };
 
     let receiver = Receiver::new(lock_file_path, keeper, mapping)?;
@@ -50,7 +52,7 @@ impl ChannelConf {
         let lock_file = File::open(self.lock_file_path.to_cow_os_str())?;
         lock_file.try_lock_shared()?;
 
-        let mapping = fspy_shm::open(&self.shm_id.to_cow_os_str())?.map()?;
+        let mapping = fspy_shm::open(&self.shm_path.to_cow_os_str())?.map()?;
         // SAFETY: `mapping` is a freshly mapped shared memory region with valid
         // pointer and size. Exclusive write access is ensured by the shared
         // file lock held by this sender.

--- a/crates/fspy_shared/src/ipc/channel/shm_io.rs
+++ b/crates/fspy_shared/src/ipc/channel/shm_io.rs
@@ -672,8 +672,11 @@ mod tests {
 
         const SHM_SIZE: usize = 1024 * 1024;
 
-        let (keeper, handle) = fspy_shm::create(SHM_SIZE).unwrap();
-        let shm_name = keeper.id().to_str().expect("test temp dir is UTF-8").to_owned();
+        let shm_path = std::path::absolute(std::env::temp_dir())
+            .unwrap()
+            .join(format!("fspy_ipc_test_{}.shm", uuid::Uuid::new_v4()));
+        let (_keeper, handle) = fspy_shm::create(shm_path.as_os_str(), SHM_SIZE).unwrap();
+        let shm_name = shm_path.to_str().expect("test temp dir is UTF-8").to_owned();
         // Map before the children run. Windows keeps views coherent while they
         // exist at the same time; a view created after every writer exited can
         // observe the file before the writers' dirty pages reach it.

--- a/crates/fspy_shm/Cargo.toml
+++ b/crates/fspy_shm/Cargo.toml
@@ -7,11 +7,11 @@ license.workspace = true
 publish = false
 rust-version.workspace = true
 
-[dependencies]
-memmap2 = { workspace = true }
-
 [target.'cfg(unix)'.dependencies]
 sigsafe = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+memmap2 = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = [

--- a/crates/fspy_shm/Cargo.toml
+++ b/crates/fspy_shm/Cargo.toml
@@ -10,6 +10,9 @@ rust-version.workspace = true
 [dependencies]
 memmap2 = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+sigsafe = { workspace = true }
+
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = [
   "Win32_Foundation",

--- a/crates/fspy_shm/Cargo.toml
+++ b/crates/fspy_shm/Cargo.toml
@@ -9,7 +9,6 @@ rust-version.workspace = true
 
 [dependencies]
 memmap2 = { workspace = true }
-uuid = { workspace = true, features = ["v4"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = [
@@ -22,6 +21,7 @@ windows-sys = { workspace = true, features = [
 [dev-dependencies]
 ctor = { workspace = true }
 subprocess_test = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 
 [lints]
 workspace = true

--- a/crates/fspy_shm/README.md
+++ b/crates/fspy_shm/README.md
@@ -27,7 +27,7 @@ One implementation serves every platform: a sparse file at the full path supplie
 
 Only written pages ever occupy memory or disk. The multi-gigabyte capacity fspy asks for therefore costs about as much as the data a run actually records.
 
-Unix creates, sizes, opens, maps, and unlinks through `sigsafe`; on Linux, its raw-syscall backend works before libc initialization. Windows maps through `memmap2`. The remaining platform-specific parts are short passages:
+Unix creates, sizes, opens, maps, and unlinks through `sigsafe`; on Linux, its raw-syscall backend works before libc initialization. Unix path storage is fixed-capacity and inline, so these operations do not allocate. Windows maps through `memmap2`. The remaining platform-specific parts are short passages:
 
 | Concern           | Unix                                     | Windows                                                                     |
 | ----------------- | ---------------------------------------- | --------------------------------------------------------------------------- |

--- a/crates/fspy_shm/README.md
+++ b/crates/fspy_shm/README.md
@@ -1,8 +1,8 @@
 # `fspy_shm`
 
-`fspy_shm` is the private shared-memory layer used by fspy IPC channels. It gives the channel one API for creating a mapping, passing its identifier to another process, and opening additional views of the same bytes.
+`fspy_shm` is the private shared-memory layer used by fspy IPC channels. It gives the channel one API for creating a mapping at a caller-chosen path and opening additional views of the same bytes.
 
-`fspy_shm` exposes only the operations used by fspy. Treat an identifier as an opaque `OsStr`; do not depend on how it is built.
+`fspy_shm` exposes only the operations used by fspy. The caller owns the full absolute path and passes it to both `create` and `open`.
 
 ## API
 
@@ -10,21 +10,20 @@ The public API is defined in [`src/lib.rs`](src/lib.rs).
 
 | API                   | Contract                                                                                |
 | --------------------- | --------------------------------------------------------------------------------------- |
-| `create(size)`        | Creates a zero-initialized backing file and returns its `ShmKeeper` and an `ShmHandle`. |
-| `open(id)`            | Opens an `ShmHandle` on the shared memory identified by `id`.                           |
-| `ShmKeeper::id()`     | Returns the identifier another process passes to `open`.                                |
+| `create(path, size)`  | Creates a zero-initialized backing file and returns its `ShmKeeper` and an `ShmHandle`. |
+| `open(path)`          | Opens an `ShmHandle` on the shared memory at the same path.                             |
 | `ShmHandle::map()`    | Maps the shared bytes. Callable more than once.                                         |
 | `Mapping::len()`      | Returns the mapped size.                                                                |
 | `Mapping::as_ptr()`   | Returns a mutable raw pointer to the first byte.                                        |
 | `Mapping::as_slice()` | Returns the bytes as a shared slice. The caller must prevent mutation for its lifetime. |
 
-`ShmKeeper` is the name: while it lives, `open` succeeds, and dropping it removes the backing file. `ShmHandle` is the opened file: `create` returns one so the creator never looks its own file up by name, and `open` returns one to everybody else. `Mapping` is the bytes: it keeps them alive until dropped and can do nothing else. None of the three synchronizes memory access. The fspy channel adds that on top with atomic frame headers and a lock file: senders hold a shared file lock while writing, and the receiver takes the exclusive lock before reading, which waits for existing senders and rejects new ones.
+`ShmKeeper` owns the name's lifetime: while it lives, `open` succeeds, and dropping it removes the backing file. `ShmHandle` is the opened file: `create` returns one so the creator never looks its own file up by name, and `open` returns one to everybody else. `Mapping` is the bytes: it keeps them alive until dropped and can do nothing else. None of the three synchronizes memory access. The fspy channel adds that on top with atomic frame headers and a lock file: senders hold a shared file lock while writing, and the receiver takes the exclusive lock before reading, which waits for existing senders and rejects new ones.
 
 Every byte in a mapping returned by `create` is initially zero. `open` exposes the mapping's current contents and does not reinitialize them.
 
 ## Implementation
 
-One implementation serves every platform: a sparse file named `vite-task-fspy-<uuid>.shm` directly in the system temporary directory. The identifier is the file's absolute path, so another process opens the mapping by opening that path. There is no broker, no global object name, and no asynchronous runtime. The files sit in the temporary directory itself rather than a shared subdirectory: a subdirectory would belong to whichever user created it first and block everyone else, while uniquely named `0o600` files in a sticky-bit directory work for all users.
+One implementation serves every platform: a sparse file at the full path supplied by the caller. The fspy channel chooses a unique name directly in the system temporary directory and passes that path to every process. There is no broker, no global object name, and no asynchronous runtime. On Unix, files sit in the temporary directory itself rather than a shared subdirectory: a subdirectory would belong to whichever user created it first and block everyone else, while uniquely named `0o600` files in a sticky-bit directory work for all users.
 
 Only written pages ever occupy memory or disk. The multi-gigabyte capacity fspy asks for therefore costs about as much as the data a run actually records.
 
@@ -61,12 +60,12 @@ Earlier revisions rejected temporary files because dirty pages can reach disk. O
 
 ## Lifetime semantics
 
-`create` returns the only keeper. `open` returns `ShmHandle`s.
+`create(path, size)` returns the only keeper. `open(path)` returns `ShmHandle`s.
 
-- While the keeper is alive, a process that knows the identifier can open the shared memory.
+- While the keeper is alive, a process that knows the path can open the shared memory.
 - Dropping the keeper removes the backing file's name, so later opens fail. This is cleanup, not a stop signal: processes that already opened the shared memory keep reading and writing. The fspy channel stops writers with the close gate it stores in the shared bytes.
-- An `ShmHandle` and its `Mapping`s stay usable after the keeper is gone. They keep the bytes alive and cannot extend the identifier's validity.
+- An `ShmHandle` and its `Mapping`s stay usable after the keeper is gone. They keep the bytes alive and cannot extend the path's validity.
 
 The channel guards the same window from its own side: [`ChannelConf::sender`](../fspy_shared/src/ipc/channel/mod.rs) opens and locks the receiver's exact lock-file path before it calls `fspy_shm::open`, and the receiver removes that path before dropping the keeper, so a sender that starts later fails before opening shared memory.
 
-If the keeper's process is killed, its `Drop` never runs and the file stays behind: on Unix for the system's temporary-file reaper, on Windows until a cleanup tool runs. The file costs about as much disk as the run wrote into it.
+If the keeper's process is killed, its `Drop` never runs and the file stays behind. The fspy channel places it in the system temporary directory, where Unix temporary-file reapers or Windows cleanup tools can remove it. The file costs about as much disk as the run wrote into it.

--- a/crates/fspy_shm/README.md
+++ b/crates/fspy_shm/README.md
@@ -27,14 +27,14 @@ One implementation serves every platform: a sparse file at the full path supplie
 
 Only written pages ever occupy memory or disk. The multi-gigabyte capacity fspy asks for therefore costs about as much as the data a run actually records.
 
-Mapping goes through `memmap2` on every platform. The remaining platform-specific parts are three short passages:
+Unix opens and maps through `sigsafe`; on Linux, its raw-syscall backend works before libc initialization. Windows maps through `memmap2`. The remaining platform-specific parts are short passages:
 
 | Concern           | Unix                                     | Windows                                                                     |
 | ----------------- | ---------------------------------------- | --------------------------------------------------------------------------- |
 | Same-user access  | `mode(0o600)` on the backing file        | the per-user `%TEMP%` ACL                                                   |
 | Sparseness        | file holes, produced by setting a length | `FSCTL_SET_SPARSE` before setting a length, or NTFS allocates every cluster |
 | Keeper cleanup    | unlink the path                          | unlink the path; see the fallback below                                     |
-| Descriptor safety | `O_CLOEXEC`, the Rust standard default   | non-inheritable handles, the Rust standard default                          |
+| Descriptor safety | raw `openat` with `O_CLOEXEC`            | non-inheritable handles, the Rust standard default                          |
 
 `FILE_ATTRIBUTE_TEMPORARY` asks Windows to keep the data in memory when it can. Creation fails on a volume without sparse-file support.
 

--- a/crates/fspy_shm/README.md
+++ b/crates/fspy_shm/README.md
@@ -27,7 +27,7 @@ One implementation serves every platform: a sparse file at the full path supplie
 
 Only written pages ever occupy memory or disk. The multi-gigabyte capacity fspy asks for therefore costs about as much as the data a run actually records.
 
-Unix opens and maps through `sigsafe`; on Linux, its raw-syscall backend works before libc initialization. Windows maps through `memmap2`. The remaining platform-specific parts are short passages:
+Unix creates, sizes, opens, maps, and unlinks through `sigsafe`; on Linux, its raw-syscall backend works before libc initialization. Windows maps through `memmap2`. The remaining platform-specific parts are short passages:
 
 | Concern           | Unix                                     | Windows                                                                     |
 | ----------------- | ---------------------------------------- | --------------------------------------------------------------------------- |
@@ -38,7 +38,7 @@ Unix opens and maps through `sigsafe`; on Linux, its raw-syscall backend works b
 
 `FILE_ATTRIBUTE_TEMPORARY` asks Windows to keep the data in memory when it can. Creation fails on a volume without sparse-file support.
 
-The keeper removes the name with `remove_file` on every platform. Modern Windows deletes with POSIX semantics: the name goes away at once, while [existing handles keep working](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_file_disposition_information_ex) and [mapped views keep the data alive](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-createfilemappingw) until the last one goes away. The first page also reserves the right to fail the delete while a mapped view exists, and Windows versions without POSIX delete do fail it. The keeper then falls back to reopening the file with `FILE_FLAG_DELETE_ON_CLOSE` and closing it, which deletes the file once every handle to it is closed.
+The Unix keeper removes the name through `sigsafe`. The Windows keeper first uses `remove_file`. Modern Windows deletes with POSIX semantics: the name goes away at once, while [existing handles keep working](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_file_disposition_information_ex) and [mapped views keep the data alive](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-createfilemappingw) until the last one goes away. The first page also reserves the right to fail the delete while a mapped view exists, and Windows versions without POSIX delete do fail it. The keeper then falls back to reopening the file with `FILE_FLAG_DELETE_ON_CLOSE` and closing it, which deletes the file once every handle to it is closed.
 
 ## Options considered
 

--- a/crates/fspy_shm/src/lib.rs
+++ b/crates/fspy_shm/src/lib.rs
@@ -11,13 +11,6 @@ use unix as platform;
 #[cfg(windows)]
 use windows as platform;
 
-/// Prefix of backing file names inside the system temporary directory.
-///
-/// The files sit directly in the temporary directory. A shared subdirectory
-/// would belong to whichever user created it first and block everyone else;
-/// uniquely named `0o600` files in the sticky-bit temp directory avoid that.
-const BACKING_PREFIX: &str = "vite-task-fspy-";
-
 #[cfg(test)]
 mod tests {
     #[cfg(windows)]
@@ -34,18 +27,36 @@ mod tests {
     use subprocess_test::command_for_fn;
     use uuid::Uuid;
 
-    use super::{BACKING_PREFIX, Mapping, create, open};
+    use super::{Mapping, ShmHandle, ShmKeeper, create as create_at, open};
 
+    const TEST_BACKING_PREFIX: &str = "vite-task-fspy-test-";
     // Page-aligned on all supported targets.
     const SIZE: usize = 64 * 1024;
     // Use one byte more than 64 KiB to test multiple pages and a partial last page.
     const ZERO_INITIALIZED_SIZE: usize = SIZE + 1;
 
     #[test]
+    fn create_rejects_relative_path() {
+        assert!(create_at(OsStr::new("relative.shm"), SIZE).is_err());
+    }
+
+    #[test]
+    fn open_rejects_relative_path() {
+        let path = OsString::from(format!("{TEST_BACKING_PREFIX}relative-{}.shm", Uuid::new_v4()));
+        let file = fs::OpenOptions::new().write(true).create_new(true).open(&path).unwrap();
+        file.set_len(u64::try_from(SIZE).unwrap()).unwrap();
+        drop(file);
+
+        let accepted = open(&path).is_ok();
+        fs::remove_file(&path).unwrap();
+        assert!(!accepted);
+    }
+
+    #[test]
     fn new_mapping_is_zero_initialized_in_all_views() {
-        let (keeper, handle) = create(ZERO_INITIALIZED_SIZE).unwrap();
+        let (id, _keeper, handle) = create(ZERO_INITIALIZED_SIZE);
         let first = handle.map().unwrap();
-        let second = open(keeper.id()).unwrap().map().unwrap();
+        let second = open(&id).unwrap().map().unwrap();
 
         assert_zero_initialized(&first);
         assert_zero_initialized(&second);
@@ -53,12 +64,12 @@ mod tests {
 
     #[test]
     fn mappings_of_one_keeper_are_shared() {
-        let (keeper, handle) = create(SIZE).unwrap();
+        let (id, _keeper, handle) = create(SIZE);
         let first = handle.map().unwrap();
         assert_eq!(first.len(), SIZE);
         assert_eq!(first.as_ptr() as usize % align_of::<usize>(), 0);
 
-        let second = open(keeper.id()).unwrap().map().unwrap();
+        let second = open(&id).unwrap().map().unwrap();
         assert_eq!(second.len(), SIZE);
 
         write_byte(&first, 0, 17);
@@ -69,7 +80,7 @@ mod tests {
 
     #[test]
     fn one_handle_maps_repeatedly() {
-        let (_keeper, handle) = create(SIZE).unwrap();
+        let (_id, _keeper, handle) = create(SIZE);
         let first = handle.map().unwrap();
         let second = handle.map().unwrap();
 
@@ -79,11 +90,11 @@ mod tests {
 
     #[test]
     fn mapping_is_visible_across_processes() {
-        let (keeper, handle) = create(SIZE).unwrap();
+        let (id, _keeper, handle) = create(SIZE);
         let mapping = handle.map().unwrap();
         write_byte(&mapping, 0, 17);
 
-        let id = keeper.id().to_str().expect("test temp dir is UTF-8").to_owned();
+        let id = id.to_str().expect("test temp dir is UTF-8").to_owned();
         let command = command_for_fn!(id, |id: String| {
             let opened = open(OsStr::new(&id)).unwrap().map().unwrap();
             assert_eq!(read_byte(&opened, 0), 17);
@@ -95,21 +106,21 @@ mod tests {
 
     #[test]
     fn subprocess_open_ignores_changed_temp_and_working_directory() {
-        let (keeper, handle) = create(SIZE).unwrap();
+        let (id, _keeper, handle) = create(SIZE);
         let mapping = handle.map().unwrap();
         let changed_cwd =
-            temp_dir().join(format!("{BACKING_PREFIX}changed-cwd-{}", Uuid::new_v4()));
+            temp_dir().join(format!("{TEST_BACKING_PREFIX}changed-cwd-{}", Uuid::new_v4()));
         fs::create_dir(&changed_cwd).unwrap();
         write_byte(&mapping, 0, 17);
 
-        let id = keeper.id().to_str().expect("test temp dir is UTF-8").to_owned();
+        let id = id.to_str().expect("test temp dir is UTF-8").to_owned();
         let mut command = command_for_fn!(id, |id: String| {
             let opened = open(OsStr::new(&id)).unwrap().map().unwrap();
             assert_eq!(read_byte(&opened, 0), 17);
             write_byte(&opened, SIZE - 1, 29);
         });
         command.cwd = changed_cwd.clone();
-        // The identifier is an absolute path, so a relative temporary directory
+        // The shared-memory path is absolute, so a relative temporary directory
         // in the child must make no difference on any platform.
         for name in ["TMPDIR", "TMP", "TEMP"] {
             command.envs.insert(OsString::from(name), OsString::from("changed-relative-tmp"));
@@ -123,8 +134,7 @@ mod tests {
 
     #[test]
     fn keeper_drop_prevents_new_opens() {
-        let (keeper, handle) = create(SIZE).unwrap();
-        let id = keeper.id().to_owned();
+        let (id, keeper, handle) = create(SIZE);
         drop(handle);
         drop(keeper);
 
@@ -133,8 +143,7 @@ mod tests {
 
     #[test]
     fn opened_mapping_survives_keeper_drop() {
-        let (keeper, handle) = create(SIZE).unwrap();
-        let id = keeper.id().to_owned();
+        let (id, keeper, handle) = create(SIZE);
         let opened = open(&id).unwrap().map().unwrap();
         write_byte(&opened, 0, 17);
         drop(handle);
@@ -150,8 +159,7 @@ mod tests {
     /// bytes alive across the keeper's removal of the name.
     #[test]
     fn keeper_drop_removes_backing_file_and_preserves_existing_mappings() {
-        let (keeper, handle) = create(SIZE).unwrap();
-        let id = keeper.id().to_owned();
+        let (id, keeper, handle) = create(SIZE);
         let path = Path::new(&id).to_owned();
         let opened = open(&id).unwrap().map().unwrap();
         drop(handle);
@@ -169,8 +177,7 @@ mod tests {
     /// still open, and that handle keeps mapping the same bytes afterwards.
     #[test]
     fn keeper_drop_with_open_handle_removes_name_and_handle_still_maps() {
-        let (keeper, handle) = create(SIZE).unwrap();
-        let id = keeper.id().to_owned();
+        let (id, keeper, handle) = create(SIZE);
         let before = handle.map().unwrap();
         write_byte(&before, 0, 17);
 
@@ -192,16 +199,16 @@ mod tests {
         #[cfg(windows)]
         const MAX_ENDPOINT_ALLOCATION: u64 = 16 * 1024 * 1024;
 
-        let (keeper, handle) = create(PRODUCTION_SIZE).unwrap();
+        let (id, _keeper, handle) = create(PRODUCTION_SIZE);
         #[cfg(windows)]
         {
-            let (logical_size, initial_allocation) = backing_file_sizes(keeper.id());
+            let (logical_size, initial_allocation) = backing_file_sizes(&id);
             assert_eq!(logical_size, PRODUCTION_SIZE as u64);
             assert!(initial_allocation < MAX_ENDPOINT_ALLOCATION);
         }
 
         let first = handle.map().unwrap();
-        let opened = open(keeper.id()).unwrap().map().unwrap();
+        let opened = open(&id).unwrap().map().unwrap();
         write_byte(&first, 0, 17);
         write_byte(&first, PRODUCTION_SIZE - 1, 29);
         assert_eq!(read_byte(&opened, 0), 17);
@@ -210,7 +217,7 @@ mod tests {
         // Touching both endpoints must not have allocated the range between them.
         #[cfg(windows)]
         {
-            let (logical_size, endpoint_allocation) = backing_file_sizes(keeper.id());
+            let (logical_size, endpoint_allocation) = backing_file_sizes(&id);
             assert_eq!(logical_size, PRODUCTION_SIZE as u64);
             assert!(endpoint_allocation < MAX_ENDPOINT_ALLOCATION);
         }
@@ -220,6 +227,15 @@ mod tests {
     fn backing_file_sizes(id: &OsStr) -> (u64, u64) {
         let file = File::open(id).unwrap();
         super::windows::file_sizes(&file).unwrap()
+    }
+
+    fn create(size: usize) -> (OsString, ShmKeeper, ShmHandle) {
+        let path = std::path::absolute(temp_dir())
+            .unwrap()
+            .join(format!("{TEST_BACKING_PREFIX}{}.shm", Uuid::new_v4().simple()));
+        let id = path.into_os_string();
+        let (keeper, handle) = create_at(&id, size).unwrap();
+        (id, keeper, handle)
     }
 
     fn read_byte(mapping: &Mapping, index: usize) -> u8 {

--- a/crates/fspy_shm/src/lib.rs
+++ b/crates/fspy_shm/src/lib.rs
@@ -5,7 +5,7 @@ mod unix;
 #[cfg(windows)]
 mod windows;
 
-pub use platform::{Mapping, ShmHandle, ShmKeeper, create, open};
+pub use platform::{Error, Mapping, Result, ShmHandle, ShmKeeper, create, open};
 #[cfg(unix)]
 use unix as platform;
 #[cfg(windows)]

--- a/crates/fspy_shm/src/unix.rs
+++ b/crates/fspy_shm/src/unix.rs
@@ -2,12 +2,16 @@
 
 use std::{
     ffi::OsStr,
-    io,
     num::NonZeroUsize,
     os::unix::ffi::OsStrExt as _,
     path::PathBuf,
     ptr::{self, NonNull},
 };
+
+/// Error returned by shared-memory operations on Unix.
+pub type Error = sigsafe::Error;
+/// Result returned by shared-memory operations on Unix.
+pub type Result<T> = sigsafe::Result<T>;
 
 /// Keeps the shared memory's backing-file name alive and removes it on drop.
 ///
@@ -36,12 +40,8 @@ pub struct Mapping {
     len: NonZeroUsize,
 }
 
-fn ensure_absolute(path: &OsStr) -> io::Result<()> {
-    if path.as_bytes().starts_with(b"/") {
-        Ok(())
-    } else {
-        Err(io::Error::new(io::ErrorKind::InvalidInput, "shared-memory path must be absolute"))
-    }
+fn ensure_absolute(path: &OsStr) -> Result<()> {
+    if path.as_bytes().starts_with(b"/") { Ok(()) } else { Err(sigsafe::Errno::INVAL) }
 }
 
 // SAFETY: a mapping owns no thread-affine state; access synchronization is
@@ -63,13 +63,9 @@ unsafe impl Sync for Mapping {}
 ///
 /// Returns an error if `path` is not absolute or the shared memory cannot be
 /// created or sized.
-pub fn create(path: &OsStr, size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
-    let size = NonZeroUsize::new(size).ok_or_else(|| {
-        io::Error::new(io::ErrorKind::InvalidInput, "shared-memory size must be nonzero")
-    })?;
-    let size_u64 = u64::try_from(size.get()).map_err(|_| {
-        io::Error::new(io::ErrorKind::InvalidInput, "shared-memory size exceeds u64")
-    })?;
+pub fn create(path: &OsStr, size: usize) -> Result<(ShmKeeper, ShmHandle)> {
+    let size = NonZeroUsize::new(size).ok_or(sigsafe::Errno::INVAL)?;
+    let size_u64 = u64::try_from(size.get()).map_err(|_| sigsafe::Errno::OVERFLOW)?;
     ensure_absolute(path)?;
     let path = PathBuf::from(path);
 
@@ -85,7 +81,7 @@ pub fn create(path: &OsStr, size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
     let keeper = ShmKeeper { path };
 
     // Every byte reads as zero because the file is all holes.
-    sigsafe::fs::ftruncate(&file, size_u64).map_err(errno_to_io)?;
+    sigsafe::fs::ftruncate(&file, size_u64)?;
 
     Ok((keeper, ShmHandle { file, size }))
 }
@@ -99,7 +95,7 @@ pub fn create(path: &OsStr, size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
 ///
 /// Returns an error if `path` is not absolute or the shared memory is
 /// unavailable, which is the common case once its keeper has been dropped.
-pub fn open(path: &OsStr) -> io::Result<ShmHandle> {
+pub fn open(path: &OsStr) -> Result<ShmHandle> {
     ensure_absolute(path)?;
     let file = open_file(
         path,
@@ -109,9 +105,9 @@ pub fn open(path: &OsStr) -> io::Result<ShmHandle> {
     // If another process shrinks the file before `map`, mapping fails. If it
     // resizes afterwards, nothing here touches the mapped pages. A concurrent
     // resize cannot make a mapping access invalid memory.
-    let size = usize::try_from(sigsafe::fs::fstat(&file).map_err(errno_to_io)?.st_size)
-        .map_err(|_| io::ErrorKind::InvalidData)?;
-    let size = NonZeroUsize::new(size).ok_or(io::ErrorKind::InvalidData)?;
+    let size = usize::try_from(sigsafe::fs::fstat(&file)?.st_size)
+        .map_err(|_| sigsafe::Errno::OVERFLOW)?;
+    let size = NonZeroUsize::new(size).ok_or(sigsafe::Errno::INVAL)?;
     Ok(ShmHandle { file, size })
 }
 
@@ -119,27 +115,22 @@ fn open_file(
     path: &OsStr,
     flags: sigsafe::fs::OFlags,
     mode: sigsafe::fs::Mode,
-) -> io::Result<sigsafe::OwnedFd> {
+) -> Result<sigsafe::OwnedFd> {
     let mut path_buf = [0_u8; sigsafe::fs::PATH_MAX];
     let path = copy_path(path, &mut path_buf)?;
-    sigsafe::fs::openat(sigsafe::CWD, path, flags, mode).map_err(errno_to_io)
+    sigsafe::fs::openat(sigsafe::CWD, path, flags, mode)
 }
 
 fn copy_path<'buf>(
     path: &OsStr,
     buf: &'buf mut [u8; sigsafe::fs::PATH_MAX],
-) -> io::Result<sigsafe::CStr<'buf, sigsafe::Fat>> {
+) -> Result<sigsafe::CStr<'buf, sigsafe::Fat>> {
     let path_bytes = path.as_bytes();
-    let len_with_nul = path_bytes.len().checked_add(1).ok_or(io::ErrorKind::InvalidInput)?;
-    let path = buf
-        .get_mut(..len_with_nul)
-        .ok_or_else(|| io::Error::from_raw_os_error(sigsafe::Errno::NAMETOOLONG.raw_os_error()))?;
-    path[..path_bytes.len()].copy_from_slice(path_bytes);
-    sigsafe::CStr::from_bytes_with_nul(path).map_err(|_| io::ErrorKind::InvalidInput.into())
-}
-
-fn errno_to_io(errno: sigsafe::Errno) -> io::Error {
-    io::Error::from_raw_os_error(errno.raw_os_error())
+    let len_with_nul = path_bytes.len().checked_add(1).ok_or(sigsafe::Errno::NAMETOOLONG)?;
+    let path = buf.get_mut(..len_with_nul).ok_or(sigsafe::Errno::NAMETOOLONG)?;
+    let path_without_nul = path.get_mut(..path_bytes.len()).ok_or(sigsafe::Errno::NAMETOOLONG)?;
+    path_without_nul.copy_from_slice(path_bytes);
+    sigsafe::CStr::from_bytes_with_nul(path).map_err(|_| sigsafe::Errno::INVAL)
 }
 
 impl Drop for ShmKeeper {
@@ -158,7 +149,7 @@ impl ShmHandle {
     /// # Errors
     ///
     /// Returns an error if the mapping cannot be established.
-    pub fn map(&self) -> io::Result<Mapping> {
+    pub fn map(&self) -> Result<Mapping> {
         // SAFETY: the address is only a hint, the nonzero length is the
         // validated backing-file size, the descriptor remains borrowed,
         // and the resulting shared mapping is owned by `Mapping`.
@@ -171,14 +162,13 @@ impl ShmHandle {
                 &self.file,
                 0,
             )
-        }
-        .map_err(errno_to_io)?;
+        }?;
         let Some(ptr) = NonNull::new(mapped.cast()) else {
             // A non-fixed mapping should not be placed at address zero,
             // which Rust cannot represent as a non-null allocation.
             // SAFETY: release the successful mapping before rejecting it.
             let _ = unsafe { sigsafe::mm::munmap(mapped, self.size.get()) };
-            return Err(io::ErrorKind::Other.into());
+            return Err(sigsafe::Errno::INVAL);
         };
         Ok(Mapping { ptr, len: self.size })
     }

--- a/crates/fspy_shm/src/unix.rs
+++ b/crates/fspy_shm/src/unix.rs
@@ -1,21 +1,16 @@
-//! Unix shared memory backed by a sparse temporary file and identified by its
-//! path.
+//! Unix shared memory backed by a sparse file at a caller-provided path.
 
 use std::{
-    env::temp_dir,
     ffi::OsStr,
     fs::{self, File, OpenOptions},
     io,
-    os::unix::fs::OpenOptionsExt as _,
+    os::unix::{ffi::OsStrExt as _, fs::OpenOptionsExt as _},
     path::PathBuf,
 };
 
 use memmap2::{MmapOptions, MmapRaw};
-use uuid::Uuid;
 
-use crate::BACKING_PREFIX;
-
-/// Keeps the shared memory's identifier alive and removes it on drop.
+/// Keeps the shared memory's backing-file name alive and removes it on drop.
 ///
 /// Removal is cleanup, not a stop signal: later opens fail, but existing
 /// [`ShmHandle`]s and [`Mapping`]s keep reading and writing. To stop them,
@@ -36,12 +31,20 @@ pub struct ShmHandle {
 /// The mapped shared bytes.
 ///
 /// A `Mapping` keeps the bytes alive until it is dropped and cannot affect the
-/// shared memory's identifier.
+/// shared memory's path.
 pub struct Mapping {
     raw: MmapRaw,
 }
 
-/// Creates `size` bytes of zero-initialized shared memory.
+fn ensure_absolute(path: &OsStr) -> io::Result<()> {
+    if path.as_bytes().starts_with(b"/") {
+        Ok(())
+    } else {
+        Err(io::Error::new(io::ErrorKind::InvalidInput, "shared-memory path must be absolute"))
+    }
+}
+
+/// Creates `size` bytes of zero-initialized shared memory at `path`.
 ///
 /// Returns its [`ShmKeeper`] and an already opened [`ShmHandle`], so the
 /// creating process never has to go through [`open`].
@@ -51,8 +54,9 @@ pub struct Mapping {
 ///
 /// # Errors
 ///
-/// Returns an error if the shared memory cannot be created or sized.
-pub fn create(size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
+/// Returns an error if `path` is not absolute or the shared memory cannot be
+/// created or sized.
+pub fn create(path: &OsStr, size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
     if size == 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -62,12 +66,8 @@ pub fn create(size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
     let size_u64 = u64::try_from(size).map_err(|_| {
         io::Error::new(io::ErrorKind::InvalidInput, "shared-memory size exceeds u64")
     })?;
-
-    // `temp_dir` reflects `TMPDIR` verbatim, which may be relative. The
-    // identifier travels to processes with other working directories, so
-    // resolve it against the creator's current directory first.
-    let path = std::path::absolute(temp_dir())?
-        .join(format!("{BACKING_PREFIX}{}.shm", Uuid::new_v4().simple()));
+    ensure_absolute(path)?;
+    let path = PathBuf::from(path);
 
     let file = OpenOptions::new()
         .read(true)
@@ -85,19 +85,20 @@ pub fn create(size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
     Ok((keeper, ShmHandle { file, size }))
 }
 
-/// Opens the shared memory identified by `id`.
+/// Opens the shared memory at `path`.
 ///
-/// The identifier works from any process, regardless of the process's working
+/// The absolute path works from any process, regardless of the process's working
 /// directory or environment.
 ///
 /// # Errors
 ///
-/// Returns an error if the shared memory is unavailable, which is the common
-/// case once its keeper has been dropped.
-pub fn open(id: &OsStr) -> io::Result<ShmHandle> {
+/// Returns an error if `path` is not absolute or the shared memory is
+/// unavailable, which is the common case once its keeper has been dropped.
+pub fn open(path: &OsStr) -> io::Result<ShmHandle> {
+    ensure_absolute(path)?;
     // Rust opens are `O_CLOEXEC`, so a traced process never leaks this
     // descriptor.
-    let file = OpenOptions::new().read(true).write(true).open(id)?;
+    let file = OpenOptions::new().read(true).write(true).open(path)?;
     // If another process shrinks the file before `map`, mapping fails. If it
     // resizes afterwards, nothing here touches the mapped pages. A concurrent
     // resize cannot make a mapping access invalid memory.
@@ -112,15 +113,6 @@ pub fn open(id: &OsStr) -> io::Result<ShmHandle> {
 impl Drop for ShmKeeper {
     fn drop(&mut self) {
         let _ = fs::remove_file(&self.path);
-    }
-}
-
-impl ShmKeeper {
-    /// Returns the shared memory's opaque identifier, which any process passes
-    /// to [`open`].
-    #[must_use]
-    pub fn id(&self) -> &OsStr {
-        self.path.as_os_str()
     }
 }
 

--- a/crates/fspy_shm/src/unix.rs
+++ b/crates/fspy_shm/src/unix.rs
@@ -2,10 +2,9 @@
 
 use std::{
     ffi::OsStr,
-    fs::{self, File, OpenOptions},
-    io,
+    fs, io,
     num::NonZeroUsize,
-    os::unix::{ffi::OsStrExt as _, fs::OpenOptionsExt as _, io::IntoRawFd as _},
+    os::unix::ffi::OsStrExt as _,
     path::PathBuf,
     ptr::{self, NonNull},
 };
@@ -74,19 +73,19 @@ pub fn create(path: &OsStr, size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
     ensure_absolute(path)?;
     let path = PathBuf::from(path);
 
-    let file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create_new(true)
-        // Only the creating user may open the mapping.
-        .mode(0o600)
-        .open(&path)?;
+    let file = open_file(
+        path.as_os_str(),
+        sigsafe::fs::OFlags::RDWR
+            | sigsafe::fs::OFlags::CREATE
+            | sigsafe::fs::OFlags::EXCL
+            | sigsafe::fs::OFlags::CLOEXEC,
+        sigsafe::fs::Mode::RUSR | sigsafe::fs::Mode::WUSR,
+    )?;
     // The keeper exists from here on, so every error path below cleans up.
     let keeper = ShmKeeper { path };
 
     // Every byte reads as zero because the file is all holes.
-    file.set_len(size_u64)?;
-    let file = into_sigsafe_fd(file);
+    sigsafe::fs::ftruncate(&file, size_u64).map_err(errno_to_io)?;
 
     Ok((keeper, ShmHandle { file, size }))
 }
@@ -102,7 +101,11 @@ pub fn create(path: &OsStr, size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
 /// unavailable, which is the common case once its keeper has been dropped.
 pub fn open(path: &OsStr) -> io::Result<ShmHandle> {
     ensure_absolute(path)?;
-    let file = open_file(path)?;
+    let file = open_file(
+        path,
+        sigsafe::fs::OFlags::RDWR | sigsafe::fs::OFlags::CLOEXEC,
+        sigsafe::fs::Mode::empty(),
+    )?;
     // If another process shrinks the file before `map`, mapping fails. If it
     // resizes afterwards, nothing here touches the mapped pages. A concurrent
     // resize cannot make a mapping access invalid memory.
@@ -112,7 +115,11 @@ pub fn open(path: &OsStr) -> io::Result<ShmHandle> {
     Ok(ShmHandle { file, size })
 }
 
-fn open_file(path: &OsStr) -> io::Result<sigsafe::OwnedFd> {
+fn open_file(
+    path: &OsStr,
+    flags: sigsafe::fs::OFlags,
+    mode: sigsafe::fs::Mode,
+) -> io::Result<sigsafe::OwnedFd> {
     let path_bytes = path.as_bytes();
     let len_with_nul = path_bytes.len().checked_add(1).ok_or(io::ErrorKind::InvalidInput)?;
     let mut path_buf = [0_u8; sigsafe::fs::PATH_MAX];
@@ -121,24 +128,11 @@ fn open_file(path: &OsStr) -> io::Result<sigsafe::OwnedFd> {
         .ok_or_else(|| io::Error::from_raw_os_error(sigsafe::Errno::NAMETOOLONG.raw_os_error()))?;
     path[..path_bytes.len()].copy_from_slice(path_bytes);
     let path = sigsafe::CStr::from_bytes_with_nul(path).map_err(|_| io::ErrorKind::InvalidInput)?;
-    sigsafe::fs::openat(
-        sigsafe::CWD,
-        path,
-        sigsafe::fs::OFlags::RDWR | sigsafe::fs::OFlags::CLOEXEC,
-        sigsafe::fs::Mode::empty(),
-    )
-    .map_err(errno_to_io)
+    sigsafe::fs::openat(sigsafe::CWD, path, flags, mode).map_err(errno_to_io)
 }
 
 fn errno_to_io(errno: sigsafe::Errno) -> io::Error {
     io::Error::from_raw_os_error(errno.raw_os_error())
-}
-
-fn into_sigsafe_fd(file: File) -> sigsafe::OwnedFd {
-    let fd = file.into_raw_fd();
-    // SAFETY: ownership of `file`'s descriptor transfers without closing or
-    // duplicating it.
-    unsafe { sigsafe::FromRawFd::from_raw_fd(fd) }
 }
 
 impl Drop for ShmKeeper {

--- a/crates/fspy_shm/src/unix.rs
+++ b/crates/fspy_shm/src/unix.rs
@@ -4,7 +4,7 @@ use std::{
     ffi::OsStr,
     fs::{self, File, OpenOptions},
     io,
-    os::unix::{ffi::OsStrExt as _, fs::OpenOptionsExt as _},
+    os::unix::{ffi::OsStrExt as _, fs::OpenOptionsExt as _, io::FromRawFd as _},
     path::PathBuf,
 };
 
@@ -96,9 +96,7 @@ pub fn create(path: &OsStr, size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
 /// unavailable, which is the common case once its keeper has been dropped.
 pub fn open(path: &OsStr) -> io::Result<ShmHandle> {
     ensure_absolute(path)?;
-    // Rust opens are `O_CLOEXEC`, so a traced process never leaks this
-    // descriptor.
-    let file = OpenOptions::new().read(true).write(true).open(path)?;
+    let file = open_file(path)?;
     // If another process shrinks the file before `map`, mapping fails. If it
     // resizes afterwards, nothing here touches the mapped pages. A concurrent
     // resize cannot make a mapping access invalid memory.
@@ -108,6 +106,32 @@ pub fn open(path: &OsStr) -> io::Result<ShmHandle> {
         return Err(io::Error::new(io::ErrorKind::InvalidData, "shared-memory size is zero"));
     }
     Ok(ShmHandle { file, size })
+}
+
+fn open_file(path: &OsStr) -> io::Result<File> {
+    let path_bytes = path.as_bytes();
+    let len_with_nul = path_bytes.len().checked_add(1).ok_or(io::ErrorKind::InvalidInput)?;
+    let mut path_buf = [0_u8; sigsafe::fs::PATH_MAX];
+    let path = path_buf
+        .get_mut(..len_with_nul)
+        .ok_or_else(|| io::Error::from_raw_os_error(sigsafe::Errno::NAMETOOLONG.raw_os_error()))?;
+    path[..path_bytes.len()].copy_from_slice(path_bytes);
+    let path = sigsafe::CStr::from_bytes_with_nul(path).map_err(|_| io::ErrorKind::InvalidInput)?;
+    let fd = sigsafe::fs::openat(
+        sigsafe::CWD,
+        path,
+        sigsafe::fs::OFlags::RDWR | sigsafe::fs::OFlags::CLOEXEC,
+        sigsafe::fs::Mode::empty(),
+    )
+    .map_err(errno_to_io)?;
+    let fd = sigsafe::IntoRawFd::into_raw_fd(fd);
+    // SAFETY: ownership of the descriptor returned by `openat` transfers to
+    // this `File` without closing or duplicating it.
+    Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+fn errno_to_io(errno: sigsafe::Errno) -> io::Error {
+    io::Error::from_raw_os_error(errno.raw_os_error())
 }
 
 impl Drop for ShmKeeper {

--- a/crates/fspy_shm/src/unix.rs
+++ b/crates/fspy_shm/src/unix.rs
@@ -4,11 +4,11 @@ use std::{
     ffi::OsStr,
     fs::{self, File, OpenOptions},
     io,
+    num::NonZeroUsize,
     os::unix::{ffi::OsStrExt as _, fs::OpenOptionsExt as _, io::IntoRawFd as _},
     path::PathBuf,
+    ptr::{self, NonNull},
 };
-
-use memmap2::{MmapOptions, MmapRaw};
 
 /// Keeps the shared memory's backing-file name alive and removes it on drop.
 ///
@@ -25,7 +25,7 @@ pub struct ShmKeeper {
 /// view of the same bytes. Drop the handle once the mappings exist.
 pub struct ShmHandle {
     file: sigsafe::OwnedFd,
-    size: usize,
+    size: NonZeroUsize,
 }
 
 /// The mapped shared bytes.
@@ -33,7 +33,8 @@ pub struct ShmHandle {
 /// A `Mapping` keeps the bytes alive until it is dropped and cannot affect the
 /// shared memory's path.
 pub struct Mapping {
-    raw: MmapRaw,
+    ptr: NonNull<u8>,
+    len: NonZeroUsize,
 }
 
 fn ensure_absolute(path: &OsStr) -> io::Result<()> {
@@ -43,6 +44,13 @@ fn ensure_absolute(path: &OsStr) -> io::Result<()> {
         Err(io::Error::new(io::ErrorKind::InvalidInput, "shared-memory path must be absolute"))
     }
 }
+
+// SAFETY: a mapping owns no thread-affine state; access synchronization is
+// supplied by the fspy channel built on top of it.
+unsafe impl Send for Mapping {}
+// SAFETY: sharing a `Mapping` does not itself access its bytes, and all actual
+// concurrent access is synchronized by the fspy channel.
+unsafe impl Sync for Mapping {}
 
 /// Creates `size` bytes of zero-initialized shared memory at `path`.
 ///
@@ -57,13 +65,10 @@ fn ensure_absolute(path: &OsStr) -> io::Result<()> {
 /// Returns an error if `path` is not absolute or the shared memory cannot be
 /// created or sized.
 pub fn create(path: &OsStr, size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
-    if size == 0 {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "shared-memory size must be nonzero",
-        ));
-    }
-    let size_u64 = u64::try_from(size).map_err(|_| {
+    let size = NonZeroUsize::new(size).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "shared-memory size must be nonzero")
+    })?;
+    let size_u64 = u64::try_from(size.get()).map_err(|_| {
         io::Error::new(io::ErrorKind::InvalidInput, "shared-memory size exceeds u64")
     })?;
     ensure_absolute(path)?;
@@ -103,9 +108,7 @@ pub fn open(path: &OsStr) -> io::Result<ShmHandle> {
     // resize cannot make a mapping access invalid memory.
     let size = usize::try_from(sigsafe::fs::fstat(&file).map_err(errno_to_io)?.st_size)
         .map_err(|_| io::ErrorKind::InvalidData)?;
-    if size == 0 {
-        return Err(io::ErrorKind::InvalidData.into());
-    }
+    let size = NonZeroUsize::new(size).ok_or(io::ErrorKind::InvalidData)?;
     Ok(ShmHandle { file, size })
 }
 
@@ -151,8 +154,36 @@ impl ShmHandle {
     ///
     /// Returns an error if the mapping cannot be established.
     pub fn map(&self) -> io::Result<Mapping> {
-        let file = sigsafe::AsRawFd::as_raw_fd(&self.file);
-        Ok(Mapping { raw: MmapOptions::new().len(self.size).map_raw(file)? })
+        // SAFETY: the address is only a hint, the nonzero length is the
+        // validated backing-file size, the descriptor remains borrowed,
+        // and the resulting shared mapping is owned by `Mapping`.
+        let mapped = unsafe {
+            sigsafe::mm::mmap(
+                ptr::null_mut(),
+                self.size.get(),
+                sigsafe::mm::ProtFlags::READ | sigsafe::mm::ProtFlags::WRITE,
+                sigsafe::mm::MapFlags::SHARED,
+                &self.file,
+                0,
+            )
+        }
+        .map_err(errno_to_io)?;
+        let Some(ptr) = NonNull::new(mapped.cast()) else {
+            // A non-fixed mapping should not be placed at address zero,
+            // which Rust cannot represent as a non-null allocation.
+            // SAFETY: release the successful mapping before rejecting it.
+            let _ = unsafe { sigsafe::mm::munmap(mapped, self.size.get()) };
+            return Err(io::ErrorKind::Other.into());
+        };
+        Ok(Mapping { ptr, len: self.size })
+    }
+}
+
+impl Drop for Mapping {
+    fn drop(&mut self) {
+        // SAFETY: this is the complete mapping owned by `self`, and dropping
+        // it proves that no safe borrow through `self` remains.
+        let _ = unsafe { sigsafe::mm::munmap(self.ptr.as_ptr().cast(), self.len.get()) };
     }
 }
 
@@ -160,14 +191,14 @@ impl ShmHandle {
 impl Mapping {
     /// Returns the mapped length in bytes.
     #[must_use]
-    pub fn len(&self) -> usize {
-        self.raw.len()
+    pub const fn len(&self) -> usize {
+        self.len.get()
     }
 
     /// Returns a raw pointer to the first mapped byte.
     #[must_use]
-    pub fn as_ptr(&self) -> *mut u8 {
-        self.raw.as_mut_ptr()
+    pub const fn as_ptr(&self) -> *mut u8 {
+        self.ptr.as_ptr()
     }
 
     /// Returns the mapped bytes as a shared slice.
@@ -177,7 +208,7 @@ impl Mapping {
     /// The caller must ensure that no process or thread mutates the mapping for
     /// the lifetime of the returned slice.
     #[must_use]
-    pub unsafe fn as_slice(&self) -> &[u8] {
+    pub const unsafe fn as_slice(&self) -> &[u8] {
         // SAFETY: The mapping is valid for its full length, and the caller
         // guarantees that it is not mutated while the slice is borrowed.
         unsafe { std::slice::from_raw_parts(self.as_ptr().cast_const(), self.len()) }

--- a/crates/fspy_shm/src/unix.rs
+++ b/crates/fspy_shm/src/unix.rs
@@ -4,7 +4,7 @@ use std::{
     ffi::OsStr,
     fs::{self, File, OpenOptions},
     io,
-    os::unix::{ffi::OsStrExt as _, fs::OpenOptionsExt as _, io::FromRawFd as _},
+    os::unix::{ffi::OsStrExt as _, fs::OpenOptionsExt as _, io::IntoRawFd as _},
     path::PathBuf,
 };
 
@@ -24,7 +24,7 @@ pub struct ShmKeeper {
 /// [`map`](Self::map) can be called more than once; every call returns another
 /// view of the same bytes. Drop the handle once the mappings exist.
 pub struct ShmHandle {
-    file: File,
+    file: sigsafe::OwnedFd,
     size: usize,
 }
 
@@ -81,6 +81,7 @@ pub fn create(path: &OsStr, size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
 
     // Every byte reads as zero because the file is all holes.
     file.set_len(size_u64)?;
+    let file = into_sigsafe_fd(file);
 
     Ok((keeper, ShmHandle { file, size }))
 }
@@ -100,15 +101,15 @@ pub fn open(path: &OsStr) -> io::Result<ShmHandle> {
     // If another process shrinks the file before `map`, mapping fails. If it
     // resizes afterwards, nothing here touches the mapped pages. A concurrent
     // resize cannot make a mapping access invalid memory.
-    let size = usize::try_from(file.metadata()?.len())
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid shared-memory size"))?;
+    let size = usize::try_from(sigsafe::fs::fstat(&file).map_err(errno_to_io)?.st_size)
+        .map_err(|_| io::ErrorKind::InvalidData)?;
     if size == 0 {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "shared-memory size is zero"));
+        return Err(io::ErrorKind::InvalidData.into());
     }
     Ok(ShmHandle { file, size })
 }
 
-fn open_file(path: &OsStr) -> io::Result<File> {
+fn open_file(path: &OsStr) -> io::Result<sigsafe::OwnedFd> {
     let path_bytes = path.as_bytes();
     let len_with_nul = path_bytes.len().checked_add(1).ok_or(io::ErrorKind::InvalidInput)?;
     let mut path_buf = [0_u8; sigsafe::fs::PATH_MAX];
@@ -117,21 +118,24 @@ fn open_file(path: &OsStr) -> io::Result<File> {
         .ok_or_else(|| io::Error::from_raw_os_error(sigsafe::Errno::NAMETOOLONG.raw_os_error()))?;
     path[..path_bytes.len()].copy_from_slice(path_bytes);
     let path = sigsafe::CStr::from_bytes_with_nul(path).map_err(|_| io::ErrorKind::InvalidInput)?;
-    let fd = sigsafe::fs::openat(
+    sigsafe::fs::openat(
         sigsafe::CWD,
         path,
         sigsafe::fs::OFlags::RDWR | sigsafe::fs::OFlags::CLOEXEC,
         sigsafe::fs::Mode::empty(),
     )
-    .map_err(errno_to_io)?;
-    let fd = sigsafe::IntoRawFd::into_raw_fd(fd);
-    // SAFETY: ownership of the descriptor returned by `openat` transfers to
-    // this `File` without closing or duplicating it.
-    Ok(unsafe { File::from_raw_fd(fd) })
+    .map_err(errno_to_io)
 }
 
 fn errno_to_io(errno: sigsafe::Errno) -> io::Error {
     io::Error::from_raw_os_error(errno.raw_os_error())
+}
+
+fn into_sigsafe_fd(file: File) -> sigsafe::OwnedFd {
+    let fd = file.into_raw_fd();
+    // SAFETY: ownership of `file`'s descriptor transfers without closing or
+    // duplicating it.
+    unsafe { sigsafe::FromRawFd::from_raw_fd(fd) }
 }
 
 impl Drop for ShmKeeper {
@@ -147,7 +151,8 @@ impl ShmHandle {
     ///
     /// Returns an error if the mapping cannot be established.
     pub fn map(&self) -> io::Result<Mapping> {
-        Ok(Mapping { raw: MmapOptions::new().len(self.size).map_raw(&self.file)? })
+        let file = sigsafe::AsRawFd::as_raw_fd(&self.file);
+        Ok(Mapping { raw: MmapOptions::new().len(self.size).map_raw(file)? })
     }
 }
 

--- a/crates/fspy_shm/src/unix.rs
+++ b/crates/fspy_shm/src/unix.rs
@@ -2,7 +2,7 @@
 
 use std::{
     ffi::OsStr,
-    fs, io,
+    io,
     num::NonZeroUsize,
     os::unix::ffi::OsStrExt as _,
     path::PathBuf,
@@ -120,15 +120,22 @@ fn open_file(
     flags: sigsafe::fs::OFlags,
     mode: sigsafe::fs::Mode,
 ) -> io::Result<sigsafe::OwnedFd> {
+    let mut path_buf = [0_u8; sigsafe::fs::PATH_MAX];
+    let path = copy_path(path, &mut path_buf)?;
+    sigsafe::fs::openat(sigsafe::CWD, path, flags, mode).map_err(errno_to_io)
+}
+
+fn copy_path<'buf>(
+    path: &OsStr,
+    buf: &'buf mut [u8; sigsafe::fs::PATH_MAX],
+) -> io::Result<sigsafe::CStr<'buf, sigsafe::Fat>> {
     let path_bytes = path.as_bytes();
     let len_with_nul = path_bytes.len().checked_add(1).ok_or(io::ErrorKind::InvalidInput)?;
-    let mut path_buf = [0_u8; sigsafe::fs::PATH_MAX];
-    let path = path_buf
+    let path = buf
         .get_mut(..len_with_nul)
         .ok_or_else(|| io::Error::from_raw_os_error(sigsafe::Errno::NAMETOOLONG.raw_os_error()))?;
     path[..path_bytes.len()].copy_from_slice(path_bytes);
-    let path = sigsafe::CStr::from_bytes_with_nul(path).map_err(|_| io::ErrorKind::InvalidInput)?;
-    sigsafe::fs::openat(sigsafe::CWD, path, flags, mode).map_err(errno_to_io)
+    sigsafe::CStr::from_bytes_with_nul(path).map_err(|_| io::ErrorKind::InvalidInput.into())
 }
 
 fn errno_to_io(errno: sigsafe::Errno) -> io::Error {
@@ -137,7 +144,11 @@ fn errno_to_io(errno: sigsafe::Errno) -> io::Error {
 
 impl Drop for ShmKeeper {
     fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
+        let mut path = [0_u8; sigsafe::fs::PATH_MAX];
+        let Ok(path) = copy_path(self.path.as_os_str(), &mut path) else {
+            return;
+        };
+        let _ = sigsafe::fs::unlinkat(sigsafe::CWD, path, sigsafe::fs::AtFlags::empty());
     }
 }
 

--- a/crates/fspy_shm/src/unix.rs
+++ b/crates/fspy_shm/src/unix.rs
@@ -1,17 +1,40 @@
 //! Unix shared memory backed by a sparse file at a caller-provided path.
 
-use std::{
-    ffi::OsStr,
+use core::{
     num::NonZeroUsize,
-    os::unix::ffi::OsStrExt as _,
-    path::PathBuf,
     ptr::{self, NonNull},
+    slice,
 };
+use std::{ffi::OsStr, os::unix::ffi::OsStrExt as _};
 
 /// Error returned by shared-memory operations on Unix.
 pub type Error = sigsafe::Error;
 /// Result returned by shared-memory operations on Unix.
 pub type Result<T> = sigsafe::Result<T>;
+
+struct BackingPath {
+    bytes: [u8; sigsafe::fs::PATH_MAX],
+    len_with_nul: NonZeroUsize,
+}
+
+impl BackingPath {
+    fn new(path: &OsStr) -> Result<Self> {
+        ensure_absolute(path)?;
+        let mut bytes = [0; sigsafe::fs::PATH_MAX];
+        let path = copy_path(path, &mut bytes)?;
+        let len_with_nul = NonZeroUsize::new(path.len_with_nul()).ok_or(sigsafe::Errno::INVAL)?;
+        Ok(Self { bytes, len_with_nul })
+    }
+
+    fn as_c_str(&self) -> sigsafe::CStr<'_, sigsafe::Fat> {
+        let Some(bytes) = self.bytes.get(..self.len_with_nul.get()) else {
+            unreachable!("backing path length exceeds its storage");
+        };
+        // SAFETY: `new` validates this exact prefix as one C string, and the
+        // private fields prevent its bytes or retained length from changing.
+        unsafe { sigsafe::CStr::from_bytes_with_nul_unchecked(bytes) }
+    }
+}
 
 /// Keeps the shared memory's backing-file name alive and removes it on drop.
 ///
@@ -19,7 +42,7 @@ pub type Result<T> = sigsafe::Result<T>;
 /// [`ShmHandle`]s and [`Mapping`]s keep reading and writing. To stop them,
 /// store a flag in the shared bytes, as the fspy channel's close gate does.
 pub struct ShmKeeper {
-    path: PathBuf,
+    path: BackingPath,
 }
 
 /// Opened shared memory that is not mapped yet.
@@ -66,11 +89,11 @@ unsafe impl Sync for Mapping {}
 pub fn create(path: &OsStr, size: usize) -> Result<(ShmKeeper, ShmHandle)> {
     let size = NonZeroUsize::new(size).ok_or(sigsafe::Errno::INVAL)?;
     let size_u64 = u64::try_from(size.get()).map_err(|_| sigsafe::Errno::OVERFLOW)?;
-    ensure_absolute(path)?;
-    let path = PathBuf::from(path);
+    let path = BackingPath::new(path)?;
 
-    let file = open_file(
-        path.as_os_str(),
+    let file = sigsafe::fs::openat(
+        sigsafe::CWD,
+        path.as_c_str(),
         sigsafe::fs::OFlags::RDWR
             | sigsafe::fs::OFlags::CREATE
             | sigsafe::fs::OFlags::EXCL
@@ -135,11 +158,11 @@ fn copy_path<'buf>(
 
 impl Drop for ShmKeeper {
     fn drop(&mut self) {
-        let mut path = [0_u8; sigsafe::fs::PATH_MAX];
-        let Ok(path) = copy_path(self.path.as_os_str(), &mut path) else {
-            return;
-        };
-        let _ = sigsafe::fs::unlinkat(sigsafe::CWD, path, sigsafe::fs::AtFlags::empty());
+        let _ = sigsafe::fs::unlinkat(
+            sigsafe::CWD,
+            self.path.as_c_str(),
+            sigsafe::fs::AtFlags::empty(),
+        );
     }
 }
 
@@ -206,6 +229,6 @@ impl Mapping {
     pub const unsafe fn as_slice(&self) -> &[u8] {
         // SAFETY: The mapping is valid for its full length, and the caller
         // guarantees that it is not mutated while the slice is borrowed.
-        unsafe { std::slice::from_raw_parts(self.as_ptr().cast_const(), self.len()) }
+        unsafe { slice::from_raw_parts(self.as_ptr().cast_const(), self.len()) }
     }
 }

--- a/crates/fspy_shm/src/windows.rs
+++ b/crates/fspy_shm/src/windows.rs
@@ -21,6 +21,11 @@ use windows_sys::Win32::{
     System::{IO::DeviceIoControl, Ioctl::FSCTL_SET_SPARSE},
 };
 
+/// Error returned by shared-memory operations on Windows.
+pub type Error = io::Error;
+/// Result returned by shared-memory operations on Windows.
+pub type Result<T> = io::Result<T>;
+
 const SHARE_ALL: u32 = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
 const TEMPORARY: u32 = FILE_ATTRIBUTE_TEMPORARY;
 const DELETE_ON_CLOSE: u32 = FILE_FLAG_DELETE_ON_CLOSE;
@@ -52,7 +57,7 @@ pub struct Mapping {
     raw: MmapRaw,
 }
 
-fn ensure_absolute(path: &OsStr) -> io::Result<()> {
+fn ensure_absolute(path: &OsStr) -> Result<()> {
     if Path::new(path).is_absolute() {
         Ok(())
     } else {
@@ -72,7 +77,7 @@ fn ensure_absolute(path: &OsStr) -> io::Result<()> {
 ///
 /// Returns an error if `path` is not absolute, the shared memory cannot be
 /// created or sized, or the containing volume does not support sparse files.
-pub fn create(path: &OsStr, size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
+pub fn create(path: &OsStr, size: usize) -> Result<(ShmKeeper, ShmHandle)> {
     if size == 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -115,7 +120,7 @@ pub fn create(path: &OsStr, size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
 ///
 /// Returns an error if `path` is not absolute or the shared memory is
 /// unavailable, which is the common case once its keeper has been dropped.
-pub fn open(path: &OsStr) -> io::Result<ShmHandle> {
+pub fn open(path: &OsStr) -> Result<ShmHandle> {
     ensure_absolute(path)?;
     // Rust handles are non-inheritable, and its default share mode permits
     // concurrent read, write and delete access.
@@ -153,7 +158,7 @@ impl ShmHandle {
     /// # Errors
     ///
     /// Returns an error if the mapping cannot be established.
-    pub fn map(&self) -> io::Result<Mapping> {
+    pub fn map(&self) -> Result<Mapping> {
         Ok(Mapping { raw: MmapOptions::new().len(self.size).map_raw(&self.file)? })
     }
 }
@@ -187,7 +192,7 @@ impl Mapping {
 }
 
 /// Marks `file` sparse so that setting its length reserves no clusters.
-fn set_sparse(file: &File) -> io::Result<()> {
+fn set_sparse(file: &File) -> Result<()> {
     let mut bytes_returned = 0;
     // SAFETY: `file` supplies a valid synchronous file handle. FSCTL_SET_SPARSE
     // requires no input or output buffers, and `bytes_returned` is writable for
@@ -209,7 +214,7 @@ fn set_sparse(file: &File) -> io::Result<()> {
 
 /// Returns the backing file's logical size and allocated byte count.
 #[cfg(test)]
-pub fn file_sizes(file: &File) -> io::Result<(u64, u64)> {
+pub fn file_sizes(file: &File) -> Result<(u64, u64)> {
     let mut info = FILE_STANDARD_INFO::default();
     let info_size = u32::try_from(std::mem::size_of::<FILE_STANDARD_INFO>())
         .map_err(|_| io::Error::other("file size information is too large"))?;

--- a/crates/fspy_shm/src/windows.rs
+++ b/crates/fspy_shm/src/windows.rs
@@ -1,17 +1,14 @@
-//! Windows shared memory backed by a sparse temporary file and identified by
-//! its path.
+//! Windows shared memory backed by a sparse file at a caller-provided path.
 
 use std::{
-    env::temp_dir,
     ffi::OsStr,
     fs::{self, File, OpenOptions},
     io,
     os::windows::{fs::OpenOptionsExt as _, io::AsRawHandle as _},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use memmap2::{MmapOptions, MmapRaw};
-use uuid::Uuid;
 #[cfg(test)]
 use windows_sys::Win32::Storage::FileSystem::{
     FILE_STANDARD_INFO, FileStandardInfo, GetFileInformationByHandleEx,
@@ -24,14 +21,12 @@ use windows_sys::Win32::{
     System::{IO::DeviceIoControl, Ioctl::FSCTL_SET_SPARSE},
 };
 
-use crate::BACKING_PREFIX;
-
 const SHARE_ALL: u32 = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
 const TEMPORARY: u32 = FILE_ATTRIBUTE_TEMPORARY;
 const DELETE_ON_CLOSE: u32 = FILE_FLAG_DELETE_ON_CLOSE;
 const DELETE_ACCESS: u32 = windows_sys::Win32::Storage::FileSystem::DELETE;
 
-/// Keeps the shared memory's identifier alive and removes it on drop.
+/// Keeps the shared memory's backing-file name alive and removes it on drop.
 ///
 /// Removal is cleanup, not a stop signal: later opens fail, but existing
 /// [`ShmHandle`]s and [`Mapping`]s keep reading and writing. To stop them,
@@ -52,12 +47,20 @@ pub struct ShmHandle {
 /// The mapped shared bytes.
 ///
 /// A `Mapping` keeps the bytes alive until it is dropped and cannot affect the
-/// shared memory's identifier.
+/// shared memory's path.
 pub struct Mapping {
     raw: MmapRaw,
 }
 
-/// Creates `size` bytes of zero-initialized shared memory.
+fn ensure_absolute(path: &OsStr) -> io::Result<()> {
+    if Path::new(path).is_absolute() {
+        Ok(())
+    } else {
+        Err(io::Error::new(io::ErrorKind::InvalidInput, "shared-memory path must be absolute"))
+    }
+}
+
+/// Creates `size` bytes of zero-initialized shared memory at `path`.
 ///
 /// Returns its [`ShmKeeper`] and an already opened [`ShmHandle`], so the
 /// creating process never has to go through [`open`].
@@ -67,9 +70,9 @@ pub struct Mapping {
 ///
 /// # Errors
 ///
-/// Returns an error if the shared memory cannot be created or sized. Creation
-/// fails on volumes without sparse-file support.
-pub fn create(size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
+/// Returns an error if `path` is not absolute, the shared memory cannot be
+/// created or sized, or the containing volume does not support sparse files.
+pub fn create(path: &OsStr, size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
     if size == 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -79,11 +82,9 @@ pub fn create(size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
     let size_u64 = u64::try_from(size).map_err(|_| {
         io::Error::new(io::ErrorKind::InvalidInput, "shared-memory size exceeds u64")
     })?;
+    ensure_absolute(path)?;
+    let path = PathBuf::from(path);
 
-    // The per-user `%TEMP%` ACL provides same-user gating. The identifier is
-    // absolute so it keeps working after a working-directory change.
-    let path = std::path::absolute(temp_dir())?
-        .join(format!("{BACKING_PREFIX}{}.shm", Uuid::new_v4().simple()));
     let file = OpenOptions::new()
         .read(true)
         .write(true)
@@ -105,19 +106,20 @@ pub fn create(size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
     Ok((keeper, ShmHandle { file, size }))
 }
 
-/// Opens the shared memory identified by `id`.
+/// Opens the shared memory at `path`.
 ///
-/// The identifier works from any process, regardless of the process's working
+/// The absolute path works from any process, regardless of the process's working
 /// directory or environment.
 ///
 /// # Errors
 ///
-/// Returns an error if the shared memory is unavailable, which is the common
-/// case once its keeper has been dropped.
-pub fn open(id: &OsStr) -> io::Result<ShmHandle> {
+/// Returns an error if `path` is not absolute or the shared memory is
+/// unavailable, which is the common case once its keeper has been dropped.
+pub fn open(path: &OsStr) -> io::Result<ShmHandle> {
+    ensure_absolute(path)?;
     // Rust handles are non-inheritable, and its default share mode permits
     // concurrent read, write and delete access.
-    let file = OpenOptions::new().read(true).write(true).open(id)?;
+    let file = OpenOptions::new().read(true).write(true).open(path)?;
     // If another process shrinks the file before `map`, mapping fails. If it
     // resizes afterwards, nothing here touches the mapped pages. A concurrent
     // resize cannot make a mapping access invalid memory.
@@ -142,15 +144,6 @@ impl Drop for ShmKeeper {
                 .custom_flags(DELETE_ON_CLOSE)
                 .open(&self.path);
         }
-    }
-}
-
-impl ShmKeeper {
-    /// Returns the shared memory's opaque identifier, which any process passes
-    /// to [`open`].
-    #[must_use]
-    pub fn id(&self) -> &OsStr {
-        self.path.as_os_str()
     }
 }
 

--- a/crates/sigsafe/README.md
+++ b/crates/sigsafe/README.md
@@ -28,9 +28,9 @@ rustix can be built with a libc backend instead of raw syscalls, and anything in
 
 Functions whose rustix implementation already meets the rules are re-exposed as-is; being listed in a module here is what marks a call as allowed, and the backend check above is what keeps that true.
 
-- `mm` — anonymous memory mappings: `mmap_anonymous`, `munmap`.
+- `mm` — anonymous and file-backed memory mappings, protection changes, and unmapping.
 - `env` — allocation-free iteration over process arguments and environment entries.
-- `fs` — caller-buffer filesystem operations: `getcwd`, plus macOS `fcntl_getpath`.
+- `fs` — caller-buffer and descriptor operations such as `openat`, `fstat`, `getcwd`, and `readlinkat`.
 - `param` — `page_size`.
 
 Allocation without malloc lives in [`sigsafe_alloc`](../sigsafe_alloc).

--- a/crates/sigsafe/src/c_str.rs
+++ b/crates/sigsafe/src/c_str.rs
@@ -130,6 +130,18 @@ impl<'a> CStr<'a, Thin> {
 }
 
 impl<'a> CStr<'a, Fat> {
+    /// Creates a length-retaining C string after validating its bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error unless `bytes` contains exactly one NUL byte at the
+    /// end.
+    pub fn from_bytes_with_nul(bytes: &'a [u8]) -> Result<Self, core::ffi::FromBytesWithNulError> {
+        core::ffi::CStr::from_bytes_with_nul(bytes)?;
+        // SAFETY: validation above established exactly one trailing NUL.
+        Ok(unsafe { Self::from_bytes_with_nul_unchecked(bytes) })
+    }
+
     /// Creates a length-retaining C string from bytes without validation.
     ///
     /// # Safety
@@ -189,6 +201,13 @@ mod tests {
         assert_eq!(fat.as_bytes(), b"abc");
         assert_eq!(fat.as_bytes_with_nul(), b"abc\0");
         assert_eq!(counted.as_bytes_with_nul(), fat.as_bytes_with_nul());
+    }
+
+    #[test]
+    fn checked_fat_constructor_validates_the_terminator() {
+        assert_eq!(CStr::<Fat>::from_bytes_with_nul(b"abc\0").unwrap().as_bytes(), b"abc");
+        assert!(CStr::<Fat>::from_bytes_with_nul(b"abc").is_err());
+        assert!(CStr::<Fat>::from_bytes_with_nul(b"a\0bc\0").is_err());
     }
 
     #[test]

--- a/crates/sigsafe/src/fs/linux.rs
+++ b/crates/sigsafe/src/fs/linux.rs
@@ -1,9 +1,45 @@
 use core::{mem::MaybeUninit, slice};
 
-use crate::{AsRawFd as _, BorrowedFd, CStr, Errno, Fat, Result, Thin};
+use rustix::fd::FromRawFd as _;
+
+use crate::{
+    AsRawFd as _, BorrowedFd, CStr, Errno, Fat, OwnedFd, Result, Thin,
+    fs::{Mode, OFlags},
+};
 
 // Linux UAPI `PATH_MAX`.
 pub(super) const PATH_MAX: usize = 4096;
+
+fn syscall_fd(fd: BorrowedFd<'_>) -> Result<usize> {
+    let fd = isize::try_from(fd.as_raw_fd()).map_err(|_| Errno::OVERFLOW)?;
+    Ok(fd.cast_unsigned())
+}
+
+#[expect(clippy::needless_pass_by_value, reason = "CStr is a borrowed value type")]
+pub(super) fn openat<R>(
+    dirfd: BorrowedFd<'_>,
+    path: CStr<'_, R>,
+    flags: OFlags,
+    mode: Mode,
+) -> Result<OwnedFd> {
+    // SAFETY: `dirfd` remains borrowed and `path` is NUL-terminated. The
+    // kernel reads no variadic arguments; all four syscall arguments are
+    // passed explicitly.
+    let fd = unsafe {
+        syscalls::syscall4(
+            syscalls::Sysno::openat,
+            syscall_fd(dirfd)?,
+            path.as_ptr().addr(),
+            usize::try_from(flags.bits()).map_err(|_| Errno::INVAL)?,
+            usize::try_from(mode.bits()).map_err(|_| Errno::INVAL)?,
+        )
+    }
+    .map_err(|errno| Errno::from_raw_os_error(errno.into_raw()))?;
+    let fd = i32::try_from(fd).map_err(|_| Errno::OVERFLOW)?;
+
+    // SAFETY: a successful `openat` returns a new owned descriptor.
+    Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+}
 
 /// Reads the target of `path` relative to `dirfd` into `buf`.
 ///
@@ -27,7 +63,7 @@ pub fn readlinkat<'buf>(
     let initialized = unsafe {
         syscalls::syscall4(
             syscalls::Sysno::readlinkat,
-            (dirfd.as_raw_fd() as isize).cast_unsigned(),
+            syscall_fd(dirfd)?,
             path.as_ptr().addr(),
             buf.as_mut_ptr().addr(),
             buf.len(),

--- a/crates/sigsafe/src/fs/mac.rs
+++ b/crates/sigsafe/src/fs/mac.rs
@@ -7,10 +7,13 @@ use rustix::{
 
 use crate::{BorrowedFd, CStr, CWD, Errno, Fat, Result, Thin};
 
-pub(super) const PATH_MAX: usize = libc::PATH_MAX as usize;
+// Darwin UAPI `MAXPATHLEN`. Keep the Rust array length checked against libc's
+// declaration without using an unchecked integer cast.
+pub(super) const PATH_MAX: usize = 1024;
+const _: () = assert!(libc::PATH_MAX == 1024);
 
 #[expect(clippy::needless_pass_by_value, reason = "CStr is a borrowed value type")]
-fn openat<R>(
+pub(super) fn openat<R>(
     dirfd: BorrowedFd<'_>,
     path: CStr<'_, R>,
     flags: OFlags,

--- a/crates/sigsafe/src/fs/mod.rs
+++ b/crates/sigsafe/src/fs/mod.rs
@@ -2,7 +2,7 @@
 
 use core::mem::MaybeUninit;
 
-pub use rustix::fs::{Mode, OFlags, Stat, fstat};
+pub use rustix::fs::{Mode, OFlags, Stat, fstat, ftruncate};
 
 use crate::{BorrowedFd, CStr, Fat, OwnedFd, Result};
 

--- a/crates/sigsafe/src/fs/mod.rs
+++ b/crates/sigsafe/src/fs/mod.rs
@@ -1,8 +1,8 @@
 //! Filesystem calls with caller-owned storage.
 
-use core::mem::MaybeUninit;
+use core::{ffi::CStr as CoreCStr, mem::MaybeUninit};
 
-pub use rustix::fs::{Mode, OFlags, Stat, fstat, ftruncate};
+pub use rustix::fs::{AtFlags, Mode, OFlags, Stat, fstat, ftruncate};
 
 use crate::{BorrowedFd, CStr, Fat, OwnedFd, Result};
 
@@ -35,6 +35,17 @@ pub fn openat<R>(
     mode: Mode,
 ) -> Result<OwnedFd> {
     imp::openat(dirfd, path, flags, mode)
+}
+
+/// Removes `path` relative to `dirfd`.
+///
+/// # Errors
+///
+/// Returns the error reported by `unlinkat`.
+pub fn unlinkat(dirfd: BorrowedFd<'_>, path: CStr<'_, Fat>, flags: AtFlags) -> Result<()> {
+    // SAFETY: `path` already guarantees exactly one trailing NUL.
+    let path = unsafe { CoreCStr::from_bytes_with_nul_unchecked(path.as_bytes_with_nul()) };
+    rustix::fs::unlinkat(dirfd, path, flags)
 }
 
 /// Writes the absolute pathname of the current working directory into `buf`.

--- a/crates/sigsafe/src/fs/mod.rs
+++ b/crates/sigsafe/src/fs/mod.rs
@@ -2,7 +2,7 @@
 
 use core::mem::MaybeUninit;
 
-pub use rustix::fs::{Mode, OFlags};
+pub use rustix::fs::{Mode, OFlags, Stat, fstat};
 
 use crate::{BorrowedFd, CStr, Fat, OwnedFd, Result};
 

--- a/crates/sigsafe/src/fs/mod.rs
+++ b/crates/sigsafe/src/fs/mod.rs
@@ -2,7 +2,9 @@
 
 use core::mem::MaybeUninit;
 
-use crate::{CStr, Fat, Result};
+pub use rustix::fs::{Mode, OFlags};
+
+use crate::{BorrowedFd, CStr, Fat, OwnedFd, Result};
 
 #[cfg(target_os = "linux")]
 mod linux;
@@ -20,6 +22,20 @@ pub use mac::fcntl_getpath;
 
 /// The platform's maximum pathname size, including the terminating NUL.
 pub const PATH_MAX: usize = imp::PATH_MAX;
+
+/// Opens `path` relative to `dirfd` and returns its owned descriptor.
+///
+/// # Errors
+///
+/// Returns the error reported by `openat`.
+pub fn openat<R>(
+    dirfd: BorrowedFd<'_>,
+    path: CStr<'_, R>,
+    flags: OFlags,
+    mode: Mode,
+) -> Result<OwnedFd> {
+    imp::openat(dirfd, path, flags, mode)
+}
 
 /// Writes the absolute pathname of the current working directory into `buf`.
 ///

--- a/crates/sigsafe/src/lib.rs
+++ b/crates/sigsafe/src/lib.rs
@@ -13,6 +13,7 @@
 // preload library.
 #![cfg(unix)]
 #![cfg_attr(not(test), no_std)]
+#![deny(clippy::as_conversions)]
 
 mod c_str;
 pub mod env;
@@ -22,7 +23,7 @@ pub mod param;
 
 pub use c_str::{Bytes, CStr, Fat, Thin};
 pub use rustix::{
-    fd::{AsRawFd, BorrowedFd},
+    fd::{AsRawFd, BorrowedFd, IntoRawFd, OwnedFd},
     fs::CWD,
     io::{Errno, Errno as Error, Result},
 };

--- a/crates/sigsafe/src/lib.rs
+++ b/crates/sigsafe/src/lib.rs
@@ -23,7 +23,7 @@ pub mod param;
 
 pub use c_str::{Bytes, CStr, Fat, Thin};
 pub use rustix::{
-    fd::{AsRawFd, BorrowedFd, IntoRawFd, OwnedFd},
+    fd::{AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd},
     fs::CWD,
     io::{Errno, Errno as Error, Result},
 };

--- a/crates/sigsafe/src/mm.rs
+++ b/crates/sigsafe/src/mm.rs
@@ -8,4 +8,4 @@
 //! pre-libc startup) and the crate-level backend check, which guarantees
 //! they cannot silently turn into libc calls on Linux.
 
-pub use rustix::mm::{MapFlags, MprotectFlags, ProtFlags, mmap_anonymous, mprotect, munmap};
+pub use rustix::mm::{MapFlags, MprotectFlags, ProtFlags, mmap, mmap_anonymous, mprotect, munmap};


### PR DESCRIPTION
## Motivation

After `fspy_shm` accepts a caller-owned path and exposes `sigsafe` errors on Unix, `ShmKeeper` still stores that path in an allocating `PathBuf` and reconstructs a C string during cleanup. Store the validated absolute path in fixed-capacity inline storage so creation and drop need no heap allocation and the keeper is usable by the injected runtime.