### PR TITLE
refactor(fspy-shm): let callers choose backing paths

### DIFF
--- a/crates/fspy_shared/src/ipc/channel/mod.rs
+++ b/crates/fspy_shared/src/ipc/channel/mod.rs
@@ -17,21 +17,23 @@ use super::NativeStr;
 #[derive(SchemaWrite, SchemaRead, Clone, Debug)]
 pub struct ChannelConf {
     lock_file_path: Box<NativeStr>,
-    shm_id: Box<NativeStr>,
+    shm_path: Box<NativeStr>,
 }
 
 /// Creates a mpsc IPC channel with one receiver and a `ChannelConf` that can be passed around processes and used to create multiple senders
 #[expect(clippy::missing_errors_doc, reason = "non-vt crate: cannot use vt_str/vt_path types")]
 pub fn channel(capacity: usize) -> io::Result<(ChannelConf, Receiver)> {
-    // Initialize the lock file with a unique name.
-    let lock_file_path = temp_dir().join(format!("fspy_ipc_{}.lock", Uuid::new_v4()));
+    let id = Uuid::new_v4();
+    let temp_dir = std::path::absolute(temp_dir())?;
+    let lock_file_path = temp_dir.join(format!("fspy_ipc_{id}.lock"));
+    let shm_path = temp_dir.join(format!("fspy_ipc_{id}.shm"));
 
-    let (keeper, handle) = fspy_shm::create(capacity)?;
+    let (keeper, handle) = fspy_shm::create(shm_path.as_os_str(), capacity)?;
     let mapping = handle.map()?;
 
     let conf = ChannelConf {
         lock_file_path: lock_file_path.as_os_str().into(),
-        shm_id: keeper.id().into(),
+        shm_path: shm_path.as_os_str().into(),
     };
 
     let receiver = Receiver::new(lock_file_path, keeper, mapping)?;
@@ -50,7 +52,7 @@ impl ChannelConf {
         let lock_file = File::open(self.lock_file_path.to_cow_os_str())?;
         lock_file.try_lock_shared()?;
 
-        let mapping = fspy_shm::open(&self.shm_id.to_cow_os_str())?.map()?;
+        let mapping = fspy_shm::open(&self.shm_path.to_cow_os_str())?.map()?;
         // SAFETY: `mapping` is a freshly mapped shared memory region with valid
         // pointer and size. Exclusive write access is ensured by the shared
         // file lock held by this sender.

--- a/crates/fspy_shared/src/ipc/channel/shm_io.rs
+++ b/crates/fspy_shared/src/ipc/channel/shm_io.rs
@@ -672,8 +672,11 @@ mod tests {
 
         const SHM_SIZE: usize = 1024 * 1024;
 
-        let (keeper, handle) = fspy_shm::create(SHM_SIZE).unwrap();
-        let shm_name = keeper.id().to_str().expect("test temp dir is UTF-8").to_owned();
+        let shm_path = std::path::absolute(std::env::temp_dir())
+            .unwrap()
+            .join(format!("fspy_ipc_test_{}.shm", uuid::Uuid::new_v4()));
+        let (_keeper, handle) = fspy_shm::create(shm_path.as_os_str(), SHM_SIZE).unwrap();
+        let shm_name = shm_path.to_str().expect("test temp dir is UTF-8").to_owned();
         // Map before the children run. Windows keeps views coherent while they
         // exist at the same time; a view created after every writer exited can
         // observe the file before the writers' dirty pages reach it.

--- a/crates/fspy_shm/Cargo.toml
+++ b/crates/fspy_shm/Cargo.toml
@@ -9,7 +9,6 @@ rust-version.workspace = true
 
 [dependencies]
 memmap2 = { workspace = true }
-uuid = { workspace = true, features = ["v4"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = [
@@ -22,6 +21,7 @@ windows-sys = { workspace = true, features = [
 [dev-dependencies]
 ctor = { workspace = true }
 subprocess_test = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 
 [lints]
 workspace = true

--- a/crates/fspy_shm/README.md
+++ b/crates/fspy_shm/README.md
@@ -1,8 +1,8 @@
 # `fspy_shm`
 
-`fspy_shm` is the private shared-memory layer used by fspy IPC channels. It gives the channel one API for creating a mapping, passing its identifier to another process, and opening additional views of the same bytes.
+`fspy_shm` is the private shared-memory layer used by fspy IPC channels. It gives the channel one API for creating a mapping at a caller-chosen path and opening additional views of the same bytes.
 
-`fspy_shm` exposes only the operations used by fspy. Treat an identifier as an opaque `OsStr`; do not depend on how it is built.
+`fspy_shm` exposes only the operations used by fspy. The caller owns the path and passes it to both `create` and `open`; choosing a path that remains meaningful across processes is the caller's responsibility.
 
 ## API
 
@@ -10,21 +10,20 @@ The public API is defined in [`src/lib.rs`](src/lib.rs).
 
 | API                   | Contract                                                                                |
 | --------------------- | --------------------------------------------------------------------------------------- |
-| `create(size)`        | Creates a zero-initialized backing file and returns its `ShmKeeper` and an `ShmHandle`. |
-| `open(id)`            | Opens an `ShmHandle` on the shared memory identified by `id`.                           |
-| `ShmKeeper::id()`     | Returns the identifier another process passes to `open`.                                |
+| `create(path, size)`  | Creates a zero-initialized backing file and returns its `ShmKeeper` and an `ShmHandle`. |
+| `open(path)`          | Opens an `ShmHandle` on the shared memory at the same path.                             |
 | `ShmHandle::map()`    | Maps the shared bytes. Callable more than once.                                         |
 | `Mapping::len()`      | Returns the mapped size.                                                                |
 | `Mapping::as_ptr()`   | Returns a mutable raw pointer to the first byte.                                        |
 | `Mapping::as_slice()` | Returns the bytes as a shared slice. The caller must prevent mutation for its lifetime. |
 
-`ShmKeeper` is the name: while it lives, `open` succeeds, and dropping it removes the backing file. `ShmHandle` is the opened file: `create` returns one so the creator never looks its own file up by name, and `open` returns one to everybody else. `Mapping` is the bytes: it keeps them alive until dropped and can do nothing else. None of the three synchronizes memory access. The fspy channel adds that on top with atomic frame headers and a lock file: senders hold a shared file lock while writing, and the receiver takes the exclusive lock before reading, which waits for existing senders and rejects new ones.
+`ShmKeeper` owns the name's lifetime: while it lives, `open` succeeds, and dropping it removes the backing file. `ShmHandle` is the opened file: `create` returns one so the creator never looks its own file up by name, and `open` returns one to everybody else. `Mapping` is the bytes: it keeps them alive until dropped and can do nothing else. None of the three synchronizes memory access. The fspy channel adds that on top with atomic frame headers and a lock file: senders hold a shared file lock while writing, and the receiver takes the exclusive lock before reading, which waits for existing senders and rejects new ones.
 
 Every byte in a mapping returned by `create` is initially zero. `open` exposes the mapping's current contents and does not reinitialize them.
 
 ## Implementation
 
-One implementation serves every platform: a sparse file named `vite-task-fspy-<uuid>.shm` directly in the system temporary directory. The identifier is the file's absolute path, so another process opens the mapping by opening that path. There is no broker, no global object name, and no asynchronous runtime. The files sit in the temporary directory itself rather than a shared subdirectory: a subdirectory would belong to whichever user created it first and block everyone else, while uniquely named `0o600` files in a sticky-bit directory work for all users.
+One implementation serves every platform: a sparse file at the full path supplied by the caller. The fspy channel chooses a unique name directly in the system temporary directory and passes that path to every process. There is no broker, no global object name, and no asynchronous runtime. On Unix, files sit in the temporary directory itself rather than a shared subdirectory: a subdirectory would belong to whichever user created it first and block everyone else, while uniquely named `0o600` files in a sticky-bit directory work for all users.
 
 Only written pages ever occupy memory or disk. The multi-gigabyte capacity fspy asks for therefore costs about as much as the data a run actually records.
 
@@ -61,12 +60,12 @@ Earlier revisions rejected temporary files because dirty pages can reach disk. O
 
 ## Lifetime semantics
 
-`create` returns the only keeper. `open` returns `ShmHandle`s.
+`create(path, size)` returns the only keeper. `open(path)` returns `ShmHandle`s.
 
-- While the keeper is alive, a process that knows the identifier can open the shared memory.
+- While the keeper is alive, a process that knows the path can open the shared memory.
 - Dropping the keeper removes the backing file's name, so later opens fail. This is cleanup, not a stop signal: processes that already opened the shared memory keep reading and writing. The fspy channel stops writers with the close gate it stores in the shared bytes.
-- An `ShmHandle` and its `Mapping`s stay usable after the keeper is gone. They keep the bytes alive and cannot extend the identifier's validity.
+- An `ShmHandle` and its `Mapping`s stay usable after the keeper is gone. They keep the bytes alive and cannot extend the path's validity.
 
 The channel guards the same window from its own side: [`ChannelConf::sender`](../fspy_shared/src/ipc/channel/mod.rs) opens and locks the receiver's exact lock-file path before it calls `fspy_shm::open`, and the receiver removes that path before dropping the keeper, so a sender that starts later fails before opening shared memory.
 
-If the keeper's process is killed, its `Drop` never runs and the file stays behind: on Unix for the system's temporary-file reaper, on Windows until a cleanup tool runs. The file costs about as much disk as the run wrote into it.
+If the keeper's process is killed, its `Drop` never runs and the file stays behind. The fspy channel places it in the system temporary directory, where Unix temporary-file reapers or Windows cleanup tools can remove it. The file costs about as much disk as the run wrote into it.

--- a/crates/fspy_shm/src/lib.rs
+++ b/crates/fspy_shm/src/lib.rs
@@ -11,13 +11,6 @@ use unix as platform;
 #[cfg(windows)]
 use windows as platform;
 
-/// Prefix of backing file names inside the system temporary directory.
-///
-/// The files sit directly in the temporary directory. A shared subdirectory
-/// would belong to whichever user created it first and block everyone else;
-/// uniquely named `0o600` files in the sticky-bit temp directory avoid that.
-const BACKING_PREFIX: &str = "vite-task-fspy-";
-
 #[cfg(test)]
 mod tests {
     #[cfg(windows)]
@@ -34,8 +27,9 @@ mod tests {
     use subprocess_test::command_for_fn;
     use uuid::Uuid;
 
-    use super::{BACKING_PREFIX, Mapping, create, open};
+    use super::{Mapping, ShmHandle, ShmKeeper, create as create_at, open};
 
+    const TEST_BACKING_PREFIX: &str = "vite-task-fspy-test-";
     // Page-aligned on all supported targets.
     const SIZE: usize = 64 * 1024;
     // Use one byte more than 64 KiB to test multiple pages and a partial last page.
@@ -43,9 +37,9 @@ mod tests {
 
     #[test]
     fn new_mapping_is_zero_initialized_in_all_views() {
-        let (keeper, handle) = create(ZERO_INITIALIZED_SIZE).unwrap();
+        let (id, _keeper, handle) = create(ZERO_INITIALIZED_SIZE);
         let first = handle.map().unwrap();
-        let second = open(keeper.id()).unwrap().map().unwrap();
+        let second = open(&id).unwrap().map().unwrap();
 
         assert_zero_initialized(&first);
         assert_zero_initialized(&second);
@@ -53,12 +47,12 @@ mod tests {
 
     #[test]
     fn mappings_of_one_keeper_are_shared() {
-        let (keeper, handle) = create(SIZE).unwrap();
+        let (id, _keeper, handle) = create(SIZE);
         let first = handle.map().unwrap();
         assert_eq!(first.len(), SIZE);
         assert_eq!(first.as_ptr() as usize % align_of::<usize>(), 0);
 
-        let second = open(keeper.id()).unwrap().map().unwrap();
+        let second = open(&id).unwrap().map().unwrap();
         assert_eq!(second.len(), SIZE);
 
         write_byte(&first, 0, 17);
@@ -69,7 +63,7 @@ mod tests {
 
     #[test]
     fn one_handle_maps_repeatedly() {
-        let (_keeper, handle) = create(SIZE).unwrap();
+        let (_id, _keeper, handle) = create(SIZE);
         let first = handle.map().unwrap();
         let second = handle.map().unwrap();
 
@@ -79,11 +73,11 @@ mod tests {
 
     #[test]
     fn mapping_is_visible_across_processes() {
-        let (keeper, handle) = create(SIZE).unwrap();
+        let (id, _keeper, handle) = create(SIZE);
         let mapping = handle.map().unwrap();
         write_byte(&mapping, 0, 17);
 
-        let id = keeper.id().to_str().expect("test temp dir is UTF-8").to_owned();
+        let id = id.to_str().expect("test temp dir is UTF-8").to_owned();
         let command = command_for_fn!(id, |id: String| {
             let opened = open(OsStr::new(&id)).unwrap().map().unwrap();
             assert_eq!(read_byte(&opened, 0), 17);
@@ -95,21 +89,21 @@ mod tests {
 
     #[test]
     fn subprocess_open_ignores_changed_temp_and_working_directory() {
-        let (keeper, handle) = create(SIZE).unwrap();
+        let (id, _keeper, handle) = create(SIZE);
         let mapping = handle.map().unwrap();
         let changed_cwd =
-            temp_dir().join(format!("{BACKING_PREFIX}changed-cwd-{}", Uuid::new_v4()));
+            temp_dir().join(format!("{TEST_BACKING_PREFIX}changed-cwd-{}", Uuid::new_v4()));
         fs::create_dir(&changed_cwd).unwrap();
         write_byte(&mapping, 0, 17);
 
-        let id = keeper.id().to_str().expect("test temp dir is UTF-8").to_owned();
+        let id = id.to_str().expect("test temp dir is UTF-8").to_owned();
         let mut command = command_for_fn!(id, |id: String| {
             let opened = open(OsStr::new(&id)).unwrap().map().unwrap();
             assert_eq!(read_byte(&opened, 0), 17);
             write_byte(&opened, SIZE - 1, 29);
         });
         command.cwd = changed_cwd.clone();
-        // The identifier is an absolute path, so a relative temporary directory
+        // The shared-memory path is absolute, so a relative temporary directory
         // in the child must make no difference on any platform.
         for name in ["TMPDIR", "TMP", "TEMP"] {
             command.envs.insert(OsString::from(name), OsString::from("changed-relative-tmp"));
@@ -123,8 +117,7 @@ mod tests {
 
     #[test]
     fn keeper_drop_prevents_new_opens() {
-        let (keeper, handle) = create(SIZE).unwrap();
-        let id = keeper.id().to_owned();
+        let (id, keeper, handle) = create(SIZE);
         drop(handle);
         drop(keeper);
 
@@ -133,8 +126,7 @@ mod tests {
 
     #[test]
     fn opened_mapping_survives_keeper_drop() {
-        let (keeper, handle) = create(SIZE).unwrap();
-        let id = keeper.id().to_owned();
+        let (id, keeper, handle) = create(SIZE);
         let opened = open(&id).unwrap().map().unwrap();
         write_byte(&opened, 0, 17);
         drop(handle);
@@ -150,8 +142,7 @@ mod tests {
     /// bytes alive across the keeper's removal of the name.
     #[test]
     fn keeper_drop_removes_backing_file_and_preserves_existing_mappings() {
-        let (keeper, handle) = create(SIZE).unwrap();
-        let id = keeper.id().to_owned();
+        let (id, keeper, handle) = create(SIZE);
         let path = Path::new(&id).to_owned();
         let opened = open(&id).unwrap().map().unwrap();
         drop(handle);
@@ -169,8 +160,7 @@ mod tests {
     /// still open, and that handle keeps mapping the same bytes afterwards.
     #[test]
     fn keeper_drop_with_open_handle_removes_name_and_handle_still_maps() {
-        let (keeper, handle) = create(SIZE).unwrap();
-        let id = keeper.id().to_owned();
+        let (id, keeper, handle) = create(SIZE);
         let before = handle.map().unwrap();
         write_byte(&before, 0, 17);
 
@@ -192,16 +182,16 @@ mod tests {
         #[cfg(windows)]
         const MAX_ENDPOINT_ALLOCATION: u64 = 16 * 1024 * 1024;
 
-        let (keeper, handle) = create(PRODUCTION_SIZE).unwrap();
+        let (id, _keeper, handle) = create(PRODUCTION_SIZE);
         #[cfg(windows)]
         {
-            let (logical_size, initial_allocation) = backing_file_sizes(keeper.id());
+            let (logical_size, initial_allocation) = backing_file_sizes(&id);
             assert_eq!(logical_size, PRODUCTION_SIZE as u64);
             assert!(initial_allocation < MAX_ENDPOINT_ALLOCATION);
         }
 
         let first = handle.map().unwrap();
-        let opened = open(keeper.id()).unwrap().map().unwrap();
+        let opened = open(&id).unwrap().map().unwrap();
         write_byte(&first, 0, 17);
         write_byte(&first, PRODUCTION_SIZE - 1, 29);
         assert_eq!(read_byte(&opened, 0), 17);
@@ -210,7 +200,7 @@ mod tests {
         // Touching both endpoints must not have allocated the range between them.
         #[cfg(windows)]
         {
-            let (logical_size, endpoint_allocation) = backing_file_sizes(keeper.id());
+            let (logical_size, endpoint_allocation) = backing_file_sizes(&id);
             assert_eq!(logical_size, PRODUCTION_SIZE as u64);
             assert!(endpoint_allocation < MAX_ENDPOINT_ALLOCATION);
         }
@@ -220,6 +210,15 @@ mod tests {
     fn backing_file_sizes(id: &OsStr) -> (u64, u64) {
         let file = File::open(id).unwrap();
         super::windows::file_sizes(&file).unwrap()
+    }
+
+    fn create(size: usize) -> (OsString, ShmKeeper, ShmHandle) {
+        let path = std::path::absolute(temp_dir())
+            .unwrap()
+            .join(format!("{TEST_BACKING_PREFIX}{}.shm", Uuid::new_v4().simple()));
+        let id = path.into_os_string();
+        let (keeper, handle) = create_at(&id, size).unwrap();
+        (id, keeper, handle)
     }
 
     fn read_byte(mapping: &Mapping, index: usize) -> u8 {

--- a/crates/fspy_shm/src/unix.rs
+++ b/crates/fspy_shm/src/unix.rs
@@ -1,8 +1,6 @@
-//! Unix shared memory backed by a sparse temporary file and identified by its
-//! path.
+//! Unix shared memory backed by a sparse file at a caller-provided path.
 
 use std::{
-    env::temp_dir,
     ffi::OsStr,
     fs::{self, File, OpenOptions},
     io,
@@ -11,11 +9,8 @@ use std::{
 };
 
 use memmap2::{MmapOptions, MmapRaw};
-use uuid::Uuid;
 
-use crate::BACKING_PREFIX;
-
-/// Keeps the shared memory's identifier alive and removes it on drop.
+/// Keeps the shared memory's backing-file name alive and removes it on drop.
 ///
 /// Removal is cleanup, not a stop signal: later opens fail, but existing
 /// [`ShmHandle`]s and [`Mapping`]s keep reading and writing. To stop them,
@@ -36,12 +31,12 @@ pub struct ShmHandle {
 /// The mapped shared bytes.
 ///
 /// A `Mapping` keeps the bytes alive until it is dropped and cannot affect the
-/// shared memory's identifier.
+/// shared memory's path.
 pub struct Mapping {
     raw: MmapRaw,
 }
 
-/// Creates `size` bytes of zero-initialized shared memory.
+/// Creates `size` bytes of zero-initialized shared memory at `path`.
 ///
 /// Returns its [`ShmKeeper`] and an already opened [`ShmHandle`], so the
 /// creating process never has to go through [`open`].
@@ -52,7 +47,7 @@ pub struct Mapping {
 /// # Errors
 ///
 /// Returns an error if the shared memory cannot be created or sized.
-pub fn create(size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
+pub fn create(path: &OsStr, size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
     if size == 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -62,12 +57,7 @@ pub fn create(size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
     let size_u64 = u64::try_from(size).map_err(|_| {
         io::Error::new(io::ErrorKind::InvalidInput, "shared-memory size exceeds u64")
     })?;
-
-    // `temp_dir` reflects `TMPDIR` verbatim, which may be relative. The
-    // identifier travels to processes with other working directories, so
-    // resolve it against the creator's current directory first.
-    let path = std::path::absolute(temp_dir())?
-        .join(format!("{BACKING_PREFIX}{}.shm", Uuid::new_v4().simple()));
+    let path = PathBuf::from(path);
 
     let file = OpenOptions::new()
         .read(true)
@@ -85,19 +75,16 @@ pub fn create(size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
     Ok((keeper, ShmHandle { file, size }))
 }
 
-/// Opens the shared memory identified by `id`.
-///
-/// The identifier works from any process, regardless of the process's working
-/// directory or environment.
+/// Opens the shared memory at `path`.
 ///
 /// # Errors
 ///
 /// Returns an error if the shared memory is unavailable, which is the common
 /// case once its keeper has been dropped.
-pub fn open(id: &OsStr) -> io::Result<ShmHandle> {
+pub fn open(path: &OsStr) -> io::Result<ShmHandle> {
     // Rust opens are `O_CLOEXEC`, so a traced process never leaks this
     // descriptor.
-    let file = OpenOptions::new().read(true).write(true).open(id)?;
+    let file = OpenOptions::new().read(true).write(true).open(path)?;
     // If another process shrinks the file before `map`, mapping fails. If it
     // resizes afterwards, nothing here touches the mapped pages. A concurrent
     // resize cannot make a mapping access invalid memory.
@@ -112,15 +99,6 @@ pub fn open(id: &OsStr) -> io::Result<ShmHandle> {
 impl Drop for ShmKeeper {
     fn drop(&mut self) {
         let _ = fs::remove_file(&self.path);
-    }
-}
-
-impl ShmKeeper {
-    /// Returns the shared memory's opaque identifier, which any process passes
-    /// to [`open`].
-    #[must_use]
-    pub fn id(&self) -> &OsStr {
-        self.path.as_os_str()
     }
 }
 

--- a/crates/fspy_shm/src/windows.rs
+++ b/crates/fspy_shm/src/windows.rs
@@ -1,8 +1,6 @@
-//! Windows shared memory backed by a sparse temporary file and identified by
-//! its path.
+//! Windows shared memory backed by a sparse file at a caller-provided path.
 
 use std::{
-    env::temp_dir,
     ffi::OsStr,
     fs::{self, File, OpenOptions},
     io,
@@ -11,7 +9,6 @@ use std::{
 };
 
 use memmap2::{MmapOptions, MmapRaw};
-use uuid::Uuid;
 #[cfg(test)]
 use windows_sys::Win32::Storage::FileSystem::{
     FILE_STANDARD_INFO, FileStandardInfo, GetFileInformationByHandleEx,
@@ -24,14 +21,12 @@ use windows_sys::Win32::{
     System::{IO::DeviceIoControl, Ioctl::FSCTL_SET_SPARSE},
 };
 
-use crate::BACKING_PREFIX;
-
 const SHARE_ALL: u32 = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
 const TEMPORARY: u32 = FILE_ATTRIBUTE_TEMPORARY;
 const DELETE_ON_CLOSE: u32 = FILE_FLAG_DELETE_ON_CLOSE;
 const DELETE_ACCESS: u32 = windows_sys::Win32::Storage::FileSystem::DELETE;
 
-/// Keeps the shared memory's identifier alive and removes it on drop.
+/// Keeps the shared memory's backing-file name alive and removes it on drop.
 ///
 /// Removal is cleanup, not a stop signal: later opens fail, but existing
 /// [`ShmHandle`]s and [`Mapping`]s keep reading and writing. To stop them,
@@ -52,12 +47,12 @@ pub struct ShmHandle {
 /// The mapped shared bytes.
 ///
 /// A `Mapping` keeps the bytes alive until it is dropped and cannot affect the
-/// shared memory's identifier.
+/// shared memory's path.
 pub struct Mapping {
     raw: MmapRaw,
 }
 
-/// Creates `size` bytes of zero-initialized shared memory.
+/// Creates `size` bytes of zero-initialized shared memory at `path`.
 ///
 /// Returns its [`ShmKeeper`] and an already opened [`ShmHandle`], so the
 /// creating process never has to go through [`open`].
@@ -67,9 +62,9 @@ pub struct Mapping {
 ///
 /// # Errors
 ///
-/// Returns an error if the shared memory cannot be created or sized. Creation
-/// fails on volumes without sparse-file support.
-pub fn create(size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
+/// Returns an error if the shared memory cannot be created or sized, or the
+/// containing volume does not support sparse files.
+pub fn create(path: &OsStr, size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
     if size == 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -79,11 +74,8 @@ pub fn create(size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
     let size_u64 = u64::try_from(size).map_err(|_| {
         io::Error::new(io::ErrorKind::InvalidInput, "shared-memory size exceeds u64")
     })?;
+    let path = PathBuf::from(path);
 
-    // The per-user `%TEMP%` ACL provides same-user gating. The identifier is
-    // absolute so it keeps working after a working-directory change.
-    let path = std::path::absolute(temp_dir())?
-        .join(format!("{BACKING_PREFIX}{}.shm", Uuid::new_v4().simple()));
     let file = OpenOptions::new()
         .read(true)
         .write(true)
@@ -105,19 +97,16 @@ pub fn create(size: usize) -> io::Result<(ShmKeeper, ShmHandle)> {
     Ok((keeper, ShmHandle { file, size }))
 }
 
-/// Opens the shared memory identified by `id`.
-///
-/// The identifier works from any process, regardless of the process's working
-/// directory or environment.
+/// Opens the shared memory at `path`.
 ///
 /// # Errors
 ///
 /// Returns an error if the shared memory is unavailable, which is the common
 /// case once its keeper has been dropped.
-pub fn open(id: &OsStr) -> io::Result<ShmHandle> {
+pub fn open(path: &OsStr) -> io::Result<ShmHandle> {
     // Rust handles are non-inheritable, and its default share mode permits
     // concurrent read, write and delete access.
-    let file = OpenOptions::new().read(true).write(true).open(id)?;
+    let file = OpenOptions::new().read(true).write(true).open(path)?;
     // If another process shrinks the file before `map`, mapping fails. If it
     // resizes afterwards, nothing here touches the mapped pages. A concurrent
     // resize cannot make a mapping access invalid memory.
@@ -142,15 +131,6 @@ impl Drop for ShmKeeper {
                 .custom_flags(DELETE_ON_CLOSE)
                 .open(&self.path);
         }
-    }
-}
-
-impl ShmKeeper {
-    /// Returns the shared memory's opaque identifier, which any process passes
-    /// to [`open`].
-    #[must_use]
-    pub fn id(&self) -> &OsStr {
-        self.path.as_os_str()
     }
 }
 


### PR DESCRIPTION
## Motivation

fspy_shm should not own temporary-directory or naming policy. Let the channel choose the complete backing path and pass that same path to create and open, avoiding a duplicate identifier in ShmKeeper and allowing callers to select a sandbox-accessible location. Path stability and whether a path must be absolute are caller policy.