### PR TITLE
refactor(fspy-shm): accept platform-native paths

### DIFF
--- a/crates/fspy_shared/src/ipc/channel/mod.rs
+++ b/crates/fspy_shared/src/ipc/channel/mod.rs
@@ -2,7 +2,9 @@
 
 mod shm_io;
 
-use std::{env::temp_dir, fs::File, io, ops::Deref, path::PathBuf};
+use std::{env::temp_dir, ffi::OsStr, fs::File, io, ops::Deref, path::PathBuf};
+#[cfg(unix)]
+use std::{ffi::CString, os::unix::ffi::OsStrExt as _};
 
 use fspy_shm::Mapping;
 pub use shm_io::FrameMut;
@@ -28,11 +30,11 @@ pub fn channel(capacity: usize) -> io::Result<(ChannelConf, Receiver)> {
     let lock_file_path = temp_dir.join(format!("fspy_ipc_{id}.lock"));
     let shm_path = temp_dir.join(format!("fspy_ipc_{id}.shm"));
 
-    let handle = fspy_shm::create(shm_path.as_os_str(), capacity)?;
+    let handle = with_shm_path(shm_path.as_os_str(), |path| fspy_shm::create(path, capacity))?;
     let mapping = match handle.map() {
         Ok(mapping) => mapping,
         Err(error) => {
-            let _ = fspy_shm::remove(shm_path.as_os_str());
+            let _ = with_shm_path(shm_path.as_os_str(), fspy_shm::remove);
             return Err(error);
         }
     };
@@ -58,7 +60,8 @@ impl ChannelConf {
         let lock_file = File::open(self.lock_file_path.to_cow_os_str())?;
         lock_file.try_lock_shared()?;
 
-        let mapping = fspy_shm::open(&self.shm_path.to_cow_os_str())?.map()?;
+        let handle = with_shm_path(self.shm_path.to_cow_os_str().as_ref(), fspy_shm::open)?;
+        let mapping = handle.map()?;
         // SAFETY: `mapping` is a freshly mapped shared memory region with valid
         // pointer and size. Exclusive write access is ensured by the shared
         // file lock held by this sender.
@@ -116,7 +119,7 @@ impl Drop for Receiver {
         if let Err(err) = std::fs::remove_file(&self.lock_file_path) {
             debug!("Failed to remove IPC lock file {}: {}", self.lock_file_path.display(), err);
         }
-        if let Err(err) = fspy_shm::remove(self.shm_path.as_os_str()) {
+        if let Err(err) = with_shm_path(self.shm_path.as_os_str(), fspy_shm::remove) {
             debug!("Failed to remove IPC shared memory {}: {}", self.shm_path.display(), err);
         }
     }
@@ -127,7 +130,7 @@ impl Receiver {
         let lock_file = match File::create(&lock_file_path) {
             Ok(lock_file) => lock_file,
             Err(error) => {
-                let _ = fspy_shm::remove(shm_path.as_os_str());
+                let _ = with_shm_path(shm_path.as_os_str(), fspy_shm::remove);
                 return Err(error);
             }
         };
@@ -148,6 +151,28 @@ impl Receiver {
         let reader = ShmReader::new(unsafe { self.mapping.as_slice() });
         Ok(ReceiverLockGuard { reader, lock_file: &self.lock_file })
     }
+}
+
+#[cfg(unix)]
+fn with_shm_path<T>(
+    path: &OsStr,
+    call: impl FnOnce(fspy_shm::Path<'_>) -> io::Result<T>,
+) -> io::Result<T> {
+    let path = CString::new(path.as_bytes()).map_err(|_| {
+        io::Error::new(io::ErrorKind::InvalidInput, "shared-memory path contains NUL")
+    })?;
+    // SAFETY: `CString` owns an immutable NUL-terminated string through
+    // `call`.
+    let path = unsafe { fspy_shm::Path::from_ptr(path.as_ptr()) };
+    call(path)
+}
+
+#[cfg(windows)]
+fn with_shm_path<T>(
+    path: &OsStr,
+    call: impl FnOnce(fspy_shm::Path<'_>) -> io::Result<T>,
+) -> io::Result<T> {
+    call(path)
 }
 
 pub struct ReceiverLockGuard<'a> {

--- a/crates/fspy_shared/src/ipc/channel/shm_io.rs
+++ b/crates/fspy_shared/src/ipc/channel/shm_io.rs
@@ -675,7 +675,10 @@ mod tests {
         let shm_path = std::path::absolute(std::env::temp_dir())
             .unwrap()
             .join(format!("fspy_ipc_test_{}.shm", uuid::Uuid::new_v4()));
-        let handle = fspy_shm::create(shm_path.as_os_str(), SHM_SIZE).unwrap();
+        let handle = super::super::with_shm_path(shm_path.as_os_str(), |path| {
+            fspy_shm::create(path, SHM_SIZE)
+        })
+        .unwrap();
         let shm_name = shm_path.to_str().expect("test temp dir is UTF-8").to_owned();
         // Map before the children run. Windows keeps views coherent while they
         // exist at the same time; a view created after every writer exited can
@@ -687,8 +690,12 @@ mod tests {
                 let cmd = command_for_fn!(
                     (shm_name.clone(), child_index),
                     |(shm_name, child_index): (String, usize)| {
-                        let mapping =
-                            fspy_shm::open(std::ffi::OsStr::new(&shm_name)).unwrap().map().unwrap();
+                        let handle = super::super::with_shm_path(
+                            std::ffi::OsStr::new(&shm_name),
+                            fspy_shm::open,
+                        )
+                        .unwrap();
+                        let mapping = handle.map().unwrap();
                         // SAFETY: `mapping` is a freshly mapped shared memory region with a
                         // valid pointer and size. Concurrent write access is safe because
                         // `ShmWriter` uses atomic operations.
@@ -720,6 +727,6 @@ mod tests {
                 assert!(frames.contains(&BStr::new(frame_data.as_bytes())));
             }
         }
-        fspy_shm::remove(shm_path.as_os_str()).unwrap();
+        super::super::with_shm_path(shm_path.as_os_str(), fspy_shm::remove).unwrap();
     }
 }

--- a/crates/fspy_shm/src/lib.rs
+++ b/crates/fspy_shm/src/lib.rs
@@ -5,7 +5,7 @@ mod unix;
 #[cfg(windows)]
 mod windows;
 
-pub use platform::{Mapping, ShmHandle, create, open, remove};
+pub use platform::{Mapping, Path, ShmHandle, create, open, remove};
 #[cfg(unix)]
 use unix as platform;
 #[cfg(windows)]
@@ -18,16 +18,18 @@ mod tests {
     use std::{
         env::temp_dir,
         ffi::{OsStr, OsString},
-        fs,
+        fs, io,
         mem::align_of,
         path::Path,
         process::Command,
     };
+    #[cfg(unix)]
+    use std::{ffi::CString, os::unix::ffi::OsStrExt as _};
 
     use subprocess_test::command_for_fn;
     use uuid::Uuid;
 
-    use super::{Mapping, ShmHandle, create as create_at, open, remove};
+    use super::{Mapping, ShmHandle};
 
     const TEST_BACKING_PREFIX: &str = "vite-task-fspy-test-";
     // Page-aligned on all supported targets.
@@ -39,7 +41,7 @@ mod tests {
     fn new_mapping_is_zero_initialized_in_all_views() {
         let (id, _cleanup, handle) = create(ZERO_INITIALIZED_SIZE);
         let first = handle.map().unwrap();
-        let second = open(&id).unwrap().map().unwrap();
+        let second = with_path(&id, super::open).unwrap().map().unwrap();
 
         assert_zero_initialized(&first);
         assert_zero_initialized(&second);
@@ -52,7 +54,7 @@ mod tests {
         assert_eq!(first.len(), SIZE);
         assert_eq!(first.as_ptr() as usize % align_of::<usize>(), 0);
 
-        let second = open(&id).unwrap().map().unwrap();
+        let second = with_path(&id, super::open).unwrap().map().unwrap();
         assert_eq!(second.len(), SIZE);
 
         write_byte(&first, 0, 17);
@@ -79,7 +81,7 @@ mod tests {
 
         let id = id.to_str().expect("test temp dir is UTF-8").to_owned();
         let command = command_for_fn!(id, |id: String| {
-            let opened = open(OsStr::new(&id)).unwrap().map().unwrap();
+            let opened = with_path(OsStr::new(&id), super::open).unwrap().map().unwrap();
             assert_eq!(read_byte(&opened, 0), 17);
             write_byte(&opened, SIZE - 1, 29);
         });
@@ -98,7 +100,7 @@ mod tests {
 
         let id = id.to_str().expect("test temp dir is UTF-8").to_owned();
         let mut command = command_for_fn!(id, |id: String| {
-            let opened = open(OsStr::new(&id)).unwrap().map().unwrap();
+            let opened = with_path(OsStr::new(&id), super::open).unwrap().map().unwrap();
             assert_eq!(read_byte(&opened, 0), 17);
             write_byte(&opened, SIZE - 1, 29);
         });
@@ -119,20 +121,20 @@ mod tests {
     fn remove_prevents_new_opens() {
         let (id, _cleanup, handle) = create(SIZE);
         drop(handle);
-        remove(&id).unwrap();
+        with_path(&id, super::remove).unwrap();
 
-        assert!(open(&id).is_err());
+        assert!(with_path(&id, super::open).is_err());
     }
 
     #[test]
     fn opened_mapping_survives_remove() {
         let (id, _cleanup, handle) = create(SIZE);
-        let opened = open(&id).unwrap().map().unwrap();
+        let opened = with_path(&id, super::open).unwrap().map().unwrap();
         write_byte(&opened, 0, 17);
         drop(handle);
-        remove(&id).unwrap();
+        with_path(&id, super::remove).unwrap();
 
-        assert!(open(&id).is_err());
+        assert!(with_path(&id, super::open).is_err());
         assert_eq!(read_byte(&opened, 0), 17);
         write_byte(&opened, SIZE - 1, 29);
         assert_eq!(read_byte(&opened, SIZE - 1), 29);
@@ -144,14 +146,14 @@ mod tests {
     fn remove_backing_file_preserves_existing_mappings() {
         let (id, _cleanup, handle) = create(SIZE);
         let path = Path::new(&id).to_owned();
-        let opened = open(&id).unwrap().map().unwrap();
+        let opened = with_path(&id, super::open).unwrap().map().unwrap();
         drop(handle);
         assert!(path.exists());
 
-        remove(&id).unwrap();
+        with_path(&id, super::remove).unwrap();
 
         assert!(!path.exists());
-        assert!(open(&id).is_err());
+        assert!(with_path(&id, super::open).is_err());
         write_byte(&opened, 0, 17);
         assert_eq!(read_byte(&opened, 0), 17);
     }
@@ -164,10 +166,10 @@ mod tests {
         let before = handle.map().unwrap();
         write_byte(&before, 0, 17);
 
-        remove(&id).unwrap();
+        with_path(&id, super::remove).unwrap();
 
         assert!(!Path::new(&id).exists());
-        assert!(open(&id).is_err());
+        assert!(with_path(&id, super::open).is_err());
 
         let after = handle.map().unwrap();
         assert_eq!(read_byte(&after, 0), 17);
@@ -191,7 +193,7 @@ mod tests {
         }
 
         let first = handle.map().unwrap();
-        let opened = open(&id).unwrap().map().unwrap();
+        let opened = with_path(&id, super::open).unwrap().map().unwrap();
         write_byte(&first, 0, 17);
         write_byte(&first, PRODUCTION_SIZE - 1, 29);
         assert_eq!(read_byte(&opened, 0), 17);
@@ -216,7 +218,7 @@ mod tests {
 
     impl Drop for Cleanup {
         fn drop(&mut self) {
-            let _ = remove(&self.0);
+            let _ = with_path(&self.0, super::remove);
         }
     }
 
@@ -225,9 +227,29 @@ mod tests {
             .unwrap()
             .join(format!("{TEST_BACKING_PREFIX}{}.shm", Uuid::new_v4().simple()));
         let id = path.into_os_string();
-        let handle = create_at(&id, size).unwrap();
+        let handle = with_path(&id, |path| super::create(path, size)).unwrap();
         let cleanup = Cleanup(id.clone());
         (id, cleanup, handle)
+    }
+
+    #[cfg(unix)]
+    fn with_path<T>(
+        path: &OsStr,
+        call: impl FnOnce(super::Path<'_>) -> io::Result<T>,
+    ) -> io::Result<T> {
+        let path = CString::new(path.as_bytes()).map_err(|_| io::ErrorKind::InvalidInput)?;
+        // SAFETY: `CString` owns one NUL-terminated string for the duration of
+        // `call`.
+        let path = unsafe { super::Path::from_ptr(path.as_ptr()) };
+        call(path)
+    }
+
+    #[cfg(windows)]
+    fn with_path<T>(
+        path: &OsStr,
+        call: impl FnOnce(super::Path<'_>) -> io::Result<T>,
+    ) -> io::Result<T> {
+        call(path)
     }
 
     fn read_byte(mapping: &Mapping, index: usize) -> u8 {

--- a/crates/fspy_shm/src/unix.rs
+++ b/crates/fspy_shm/src/unix.rs
@@ -1,12 +1,13 @@
 //! Unix shared memory backed by a sparse file at a caller-provided path.
 
 use std::{
-    ffi::OsStr,
     io,
     num::NonZeroUsize,
-    os::unix::ffi::OsStrExt as _,
     ptr::{self, NonNull},
 };
+
+/// Borrowed path accepted by shared-memory operations on Unix.
+pub type Path<'a> = sigsafe::CStr<'a, sigsafe::Thin>;
 
 /// Opened shared memory that is not mapped yet.
 ///
@@ -44,7 +45,7 @@ unsafe impl Sync for Mapping {}
 /// # Errors
 ///
 /// Returns an error if the shared memory cannot be created or sized.
-pub fn create(path: &OsStr, size: usize) -> io::Result<ShmHandle> {
+pub fn create(path: Path<'_>, size: usize) -> io::Result<ShmHandle> {
     let size = NonZeroUsize::new(size).ok_or_else(|| {
         io::Error::new(io::ErrorKind::InvalidInput, "shared-memory size must be nonzero")
     })?;
@@ -75,7 +76,7 @@ pub fn create(path: &OsStr, size: usize) -> io::Result<ShmHandle> {
 ///
 /// Returns an error if the shared memory is unavailable, including after its
 /// backing-file name has been removed.
-pub fn open(path: &OsStr) -> io::Result<ShmHandle> {
+pub fn open(path: Path<'_>) -> io::Result<ShmHandle> {
     let file = open_file(
         path,
         sigsafe::fs::OFlags::RDWR | sigsafe::fs::OFlags::CLOEXEC,
@@ -98,33 +99,17 @@ pub fn open(path: &OsStr) -> io::Result<ShmHandle> {
 /// # Errors
 ///
 /// Returns an error if the backing-file name cannot be removed.
-pub fn remove(path: &OsStr) -> io::Result<()> {
-    let mut path_buf = [0_u8; sigsafe::fs::PATH_MAX];
-    let path = copy_path(path, &mut path_buf)?;
-    sigsafe::fs::unlinkat(sigsafe::CWD, path, sigsafe::fs::AtFlags::empty()).map_err(errno_to_io)
+pub fn remove(path: Path<'_>) -> io::Result<()> {
+    sigsafe::fs::unlinkat(sigsafe::CWD, path.count(), sigsafe::fs::AtFlags::empty())
+        .map_err(errno_to_io)
 }
 
 fn open_file(
-    path: &OsStr,
+    path: Path<'_>,
     flags: sigsafe::fs::OFlags,
     mode: sigsafe::fs::Mode,
 ) -> io::Result<sigsafe::OwnedFd> {
-    let mut path_buf = [0_u8; sigsafe::fs::PATH_MAX];
-    let path = copy_path(path, &mut path_buf)?;
     sigsafe::fs::openat(sigsafe::CWD, path, flags, mode).map_err(errno_to_io)
-}
-
-fn copy_path<'buf>(
-    path: &OsStr,
-    buf: &'buf mut [u8; sigsafe::fs::PATH_MAX],
-) -> io::Result<sigsafe::CStr<'buf, sigsafe::Fat>> {
-    let path_bytes = path.as_bytes();
-    let len_with_nul = path_bytes.len().checked_add(1).ok_or(io::ErrorKind::InvalidInput)?;
-    let path = buf
-        .get_mut(..len_with_nul)
-        .ok_or_else(|| io::Error::from_raw_os_error(sigsafe::Errno::NAMETOOLONG.raw_os_error()))?;
-    path[..path_bytes.len()].copy_from_slice(path_bytes);
-    sigsafe::CStr::from_bytes_with_nul(path).map_err(|_| io::ErrorKind::InvalidInput.into())
 }
 
 fn errno_to_io(errno: sigsafe::Errno) -> io::Error {

--- a/crates/fspy_shm/src/windows.rs
+++ b/crates/fspy_shm/src/windows.rs
@@ -20,6 +20,9 @@ use windows_sys::Win32::{
     System::{IO::DeviceIoControl, Ioctl::FSCTL_SET_SPARSE},
 };
 
+/// Borrowed path accepted by shared-memory operations on Windows.
+pub type Path<'a> = &'a OsStr;
+
 const SHARE_ALL: u32 = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
 const TEMPORARY: u32 = FILE_ATTRIBUTE_TEMPORARY;
 const DELETE_ON_CLOSE: u32 = FILE_FLAG_DELETE_ON_CLOSE;
@@ -55,7 +58,7 @@ pub struct Mapping {
 ///
 /// Returns an error if the shared memory cannot be created or sized, or the
 /// containing volume does not support sparse files.
-pub fn create(path: &OsStr, size: usize) -> io::Result<ShmHandle> {
+pub fn create(path: Path<'_>, size: usize) -> io::Result<ShmHandle> {
     if size == 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -96,7 +99,7 @@ pub fn create(path: &OsStr, size: usize) -> io::Result<ShmHandle> {
 ///
 /// Returns an error if the shared memory is unavailable, including after its
 /// backing-file name has been removed.
-pub fn open(path: &OsStr) -> io::Result<ShmHandle> {
+pub fn open(path: Path<'_>) -> io::Result<ShmHandle> {
     // Rust handles are non-inheritable, and its default share mode permits
     // concurrent read, write and delete access.
     let file = OpenOptions::new().read(true).write(true).open(path)?;
@@ -119,7 +122,7 @@ pub fn open(path: &OsStr) -> io::Result<ShmHandle> {
 /// # Errors
 ///
 /// Returns an error if removal cannot be performed or scheduled.
-pub fn remove(path: &OsStr) -> io::Result<()> {
+pub fn remove(path: Path<'_>) -> io::Result<()> {
     if fs::remove_file(path).is_ok() {
         return Ok(());
     }


### PR DESCRIPTION
## Motivation

fspy_shm needs one path-shaped API for both ordinary std callers and the injected Unix runtime. Expose the generic Path alias as sigsafe::CStr<Thin> on Unix and a borrowed OsStr on Windows so every operation accepts Path with an inferred lifetime. Keep OsStr conversion outside fspy_shm: the existing std caller uses one platform-specific with_shm_path boundary, allocating a CString only on Unix, while injected code can pass its C string directly.