### PR TITLE
test(e2e): support Rust cfg filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
+name = "cargo-platform"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4252,6 +4262,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "cargo-platform",
  "clap",
  "cow-utils",
  "cp_r",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ bstr = { version = "1.12.0", default-features = false }
 bump-scope = { version = "2", default-features = false, features = ["allocator-api2-02"] }
 bumpalo = { version = "3.17.0", features = ["collections"] }
 bytemuck = { version = "1.23.0", features = ["extern_crate_alloc", "must_cast"] }
+cargo-platform = "=0.3.2"
 cc = "1.2.39"
 clap = "4.5.53"
 color-eyre = "0.6.5"

--- a/crates/vt_bin/Cargo.toml
+++ b/crates/vt_bin/Cargo.toml
@@ -35,6 +35,7 @@ which = { workspace = true }
 nix = { workspace = true, features = ["mount", "sched", "user"] }
 
 [dev-dependencies]
+cargo-platform = { workspace = true }
 cow-utils = { workspace = true }
 cp_r = { workspace = true }
 libtest-mimic = { workspace = true }

--- a/crates/vt_bin/tests/e2e_snapshots/fixtures/constrained_dev_shm/snapshots.toml
+++ b/crates/vt_bin/tests/e2e_snapshots/fixtures/constrained_dev_shm/snapshots.toml
@@ -3,6 +3,6 @@ name = "constrained_dev_shm"
 comment = """
 With fspy's shared-memory backing moved to memfd, file-access tracking succeeds without consuming a one-page `/dev/shm` mount.
 """
-platform = "linux-gnu"
+cfg = 'all(target_os = "linux", target_env = "gnu")'
 ignore = true
 steps = [["vtt", "small_dev_shm", "vt", "run", "stress"]]

--- a/crates/vt_bin/tests/e2e_snapshots/fixtures/preexisting_ld_preload/snapshots.toml
+++ b/crates/vt_bin/tests/e2e_snapshots/fixtures/preexisting_ld_preload/snapshots.toml
@@ -4,7 +4,7 @@ name = "preexisting_ld_preload"
 # glibc-Linux. On musl fspy uses seccomp-unotify instead and strips
 # LD_PRELOAD from spawned children, so the fixture's interposer-chain
 # assumptions don't hold.
-platform = "linux-gnu"
+cfg = 'all(target_os = "linux", target_env = "gnu")'
 comment = """
 Reproduces #340 and verifies that fspy tolerates a user-supplied `LD_PRELOAD` by appending its shim instead of rejecting the spawn. Appending (not prepending) also preserves symbol-interposition order: the user's preload runs first, so short-circuited calls remain invisible to fspy — what the OS actually executed is what fspy records.
 

--- a/crates/vt_bin/tests/e2e_snapshots/fixtures/sandboxed_fspy/snapshots.toml
+++ b/crates/vt_bin/tests/e2e_snapshots/fixtures/sandboxed_fspy/snapshots.toml
@@ -5,7 +5,7 @@ Runs `vt run inner` under Codex CLI's built-in `:workspace` permission profile, 
 
 The nested `vt` enables fspy for automatic input inference; changing the file read inside the sandbox checks whether it invalidates the cache.
 """
-platform = "macos"
+cfg = 'target_os = "macos"'
 ignore = true
 steps = [
   [
@@ -44,7 +44,7 @@ Claude Code normally creates the writable session temp before invoking Sandbox R
 
 The nested `vt` enables fspy for automatic input inference; changing the file read inside the sandbox checks whether it invalidates the cache.
 """
-platform = "macos"
+cfg = 'target_os = "macos"'
 ignore = true
 steps = [
   { argv = [

--- a/crates/vt_bin/tests/e2e_snapshots/fixtures/signal_exit/snapshots.toml
+++ b/crates/vt_bin/tests/e2e_snapshots/fixtures/signal_exit/snapshots.toml
@@ -3,6 +3,6 @@ name = "signal_terminated_task_returns_non_zero_exit_code"
 comment = """
 Tests exit code behavior for signal-terminated processes Unix-only: Windows doesn't have Unix signals, so exit codes differ
 """
-platform = "unix"
+cfg = "unix"
 ignore = true
 steps = [{ argv = ["vt", "run", "abort"], comment = "SIGABRT -> exit code 134" }]

--- a/crates/vt_bin/tests/e2e_snapshots/fixtures/vitest_browser_cache/snapshots.toml
+++ b/crates/vt_bin/tests/e2e_snapshots/fixtures/vitest_browser_cache/snapshots.toml
@@ -3,7 +3,7 @@ name = "vitest_browser_caches_inputs_and_restores_outputs"
 comment = """
 Vitest browser mode runs in headless Chromium with explicit automatic input and output tracking. A source change must invalidate the cache, while an unchanged run must restore the browser command's generated output without rerunning Vitest. Playwright's bundled Chromium is unavailable on musl, so this browser-specific case is skipped only there.
 """
-platform = "non-musl"
+cfg = 'not(target_env = "musl")'
 ignore = true
 steps = [
   { argv = [

--- a/crates/vt_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/snapshots.toml
+++ b/crates/vt_bin/tests/e2e_snapshots/fixtures/windows_powershell_shim_pathext/snapshots.toml
@@ -1,6 +1,6 @@
 [[e2e]]
 name = "powershell_package_shim_keeps_pathext"
-platform = "windows"
+cfg = "windows"
 comment = """
 Cached Windows tasks run with a sanitized environment, and pnpm-style package `.cmd` shims in `node_modules/.bin` are rewritten at plan time to invoke their `.ps1` sibling via `powershell.exe -File`. PowerShell needs `PATHEXT` in that environment to launch native executables — even when the executable name is written out with a `.exe` extension — so `PATHEXT` must be preserved in the default untracked env passthrough.
 """

--- a/crates/vt_bin/tests/e2e_snapshots/main.rs
+++ b/crates/vt_bin/tests/e2e_snapshots/main.rs
@@ -221,6 +221,16 @@ impl WriteKey {
     }
 }
 
+fn deserialize_cfg_expr<'de, D>(
+    deserializer: D,
+) -> Result<Option<cargo_platform::CfgExpr>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = <Str as serde::Deserialize>::deserialize(deserializer)?;
+    value.parse().map(Some).map_err(serde::de::Error::custom)
+}
+
 #[derive(serde::Deserialize, Debug)]
 struct E2e {
     pub name: Str,
@@ -230,10 +240,10 @@ struct E2e {
     #[serde(default)]
     pub cwd: RelativePathBuf,
     pub steps: Vec<Step>,
-    /// Optional platform filter: "unix", "linux", "linux-gnu", "non-musl",
-    /// "macos", or "windows". If set, test only runs on that platform.
-    #[serde(default)]
-    pub platform: Option<Str>,
+    /// Optional Rust cfg expression. The test only runs when it matches the
+    /// current compilation target.
+    #[serde(default, deserialize_with = "deserialize_cfg_expr")]
+    pub cfg: Option<cargo_platform::CfgExpr>,
     /// When true, the generated libtest-mimic trial is marked `#[ignore]`
     /// (skipped by default, runnable with `cargo test -- --ignored`).
     #[serde(default)]
@@ -267,6 +277,28 @@ fn load_snapshots_file(fixture_path: &std::path::Path) -> SnapshotsFile {
             panic!("Failed to read cases.toml for fixture {fixture_name}: {err}");
         }
     }
+}
+
+fn cfg_ident(name: &str) -> cargo_platform::Ident {
+    cargo_platform::Ident { name: name.to_owned(), raw: false }
+}
+
+fn compile_time_cfgs() -> Vec<cargo_platform::Cfg> {
+    let target_env = if cfg!(target_env = "gnu") {
+        "gnu"
+    } else if cfg!(target_env = "msvc") {
+        "msvc"
+    } else if cfg!(target_env = "musl") {
+        "musl"
+    } else {
+        ""
+    };
+
+    vec![
+        cargo_platform::Cfg::Name(cfg_ident(std::env::consts::FAMILY)),
+        cargo_platform::Cfg::KeyPair(cfg_ident("target_os"), std::env::consts::OS.to_owned()),
+        cargo_platform::Cfg::KeyPair(cfg_ident("target_env"), target_env.to_owned()),
+    ]
 }
 
 enum TerminationState {
@@ -647,9 +679,12 @@ fn main() {
         args.test_threads = Some(1);
     }
 
+    let compile_time_cfgs = compile_time_cfgs();
+
     let tests: Vec<libtest_mimic::Trial> = fixture_paths
         .into_iter()
         .flat_map(|fixture_path| {
+            let compile_time_cfgs = compile_time_cfgs.clone();
             let fixture_path = Arc::<std::path::Path>::from(fixture_path);
             let fixture_name: Arc<str> =
                 Arc::from(fixture_path.file_name().unwrap().to_str().unwrap());
@@ -661,27 +696,9 @@ fn main() {
                 let tmp_dir_path = tmp_dir_path.clone();
                 move |(case_index, e2e)| {
                     assert_identifier_like("e2e case name", e2e.name.as_str());
-                    // Skip cases whose platform filter doesn't match this build.
-                    if let Some(platform) = &e2e.platform {
-                        let should_run = match platform.as_str() {
-                            "unix" => cfg!(unix),
-                            "windows" => cfg!(windows),
-                            "linux" => cfg!(target_os = "linux"),
-                            "macos" => cfg!(target_os = "macos"),
-                            // fspy's LD_PRELOAD injection path is only active
-                            // on glibc-Linux; on musl, fspy switches to
-                            // seccomp-unotify and strips LD_PRELOAD from
-                            // spawned children, which breaks fixtures that
-                            // depend on interposer ordering.
-                            "linux-gnu" => cfg!(target_os = "linux") && !cfg!(target_env = "musl"),
-                            // Playwright's bundled browser binaries do not
-                            // support musl targets.
-                            "non-musl" => !cfg!(target_env = "musl"),
-                            other => panic!("Unknown platform '{}' in test '{}'", other, e2e.name),
-                        };
-                        if !should_run {
-                            return None;
-                        }
+                    // Skip cases whose cfg filter doesn't match this build.
+                    if e2e.cfg.as_ref().is_some_and(|cfg| !cfg.matches(&compile_time_cfgs)) {
+                        return None;
                     }
                     let trial_name = vt_str::format!("{fixture_name}::{}", e2e.name);
                     let ignored = e2e.ignore;


### PR DESCRIPTION
## Motivation

E2E snapshots used a small hard-coded platform vocabulary, which could not express Rust target conditions such as operating systems, target environments, or boolean combinations. This made cross-platform fixture selection increasingly brittle.

## Summary

- Replace the snapshot `platform` field with an optional `cargo_platform::CfgExpr` parsed from `cfg`.
- Match expressions against `target_os`, `target_env`, and the free `unix`/`windows` target-family cfg without spawning `rustc`.
- Source the target family from `std::env::consts::FAMILY` and construct the target cfg values directly from compile-time information.
- Migrate the existing platform-specific snapshot filters to Rust cfg expressions.