### PR TITLE
fix(fspy): record file accesses made inside signal handlers

### DIFF
--- a/crates/fspy_preload_unix/src/client.rs
+++ b/crates/fspy_preload_unix/src/client.rs
@@ -1,43 +1,28 @@
-use std::{cell::Cell, sync::OnceLock};
+use std::sync::OnceLock;
 
 use convert::{ToAbsolutePath, ToAccessMode};
 pub use fspy_client_unix::{Client, convert, raw_exec};
 
 static CLIENT: OnceLock<Client<'static>> = OnceLock::new();
 
-// Resolving and reporting a file access can call another interposed function.
-// Suppress same-thread re-entry to prevent recursive access handling while
-// still recording accesses from other threads.
-thread_local! {
-    static HANDLING_OPEN: Cell<bool> = const { Cell::new(false) };
-}
-
-struct ResetHandling<'a>(&'a Cell<bool>);
-impl Drop for ResetHandling<'_> {
-    fn drop(&mut self) {
-        self.0.set(false);
-    }
-}
-
 pub fn global_client() -> Option<&'static Client<'static>> {
     CLIENT.get()
 }
 
+// The handler needs no re-entry guard: on Linux everything it calls is a
+// raw syscall — nothing binds through the PLT, where LD_PRELOAD would
+// resolve to our own interposers — and on macOS dyld never applies
+// `__interpose` tuples to the interposing image's own bindings, the same
+// exemption every `original()` forward relies on. Keep the handler free of
+// bindable libc calls on Linux: a call that binds to an interposer here
+// recurses until the traced process overflows its stack.
 pub unsafe fn handle_open(path: impl ToAbsolutePath, mode: impl ToAccessMode) {
-    HANDLING_OPEN.with(|handling| {
-        if handling.replace(true) {
-            return;
-        }
-
-        let _reset = ResetHandling(handling);
-
-        if let Some(client) = global_client() {
-            let allocator = fspy_nostd_alloc::pooled_bump();
-            // SAFETY: path and mode contain valid pointers/values forwarded
-            // from the interposed function's caller.
-            unsafe { client.try_handle_open(path, mode, allocator) }.unwrap();
-        }
-    });
+    if let Some(client) = global_client() {
+        let allocator = fspy_nostd_alloc::pooled_bump();
+        // SAFETY: path and mode contain valid pointers/values forwarded
+        // from the interposed function's caller.
+        unsafe { client.try_handle_open(path, mode, allocator) }.unwrap();
+    }
 }
 
 #[cfg(not(test))]


### PR DESCRIPTION
## Motivation

The `HANDLING_OPEN` thread-local guard (#540) suppressed same-thread re-entry into `handle_open` because, at the time, resolving and reporting an access called interposable libc symbols — `getcwd`, `readlink`, `fcntl` through nix, plus `CString::new(format!(...))` — and on Linux an LD_PRELOAD library's own PLT calls resolve to its own exported interposers, recursing until the traced process overflowed its stack.

That vector no longer exists, on either platform for its own reason:

- **Linux**: the handler's entire call graph is now raw syscalls — path resolution through `fspy_nostd`'s rustix/`linux_raw` wrappers, fd formatting through `itoa`, allocation through the mmap-backed pooled bump, reporting through atomics on the shared mapping. Nothing binds through the PLT.
- **macOS**: the handler still calls libSystem symbols, but interposition is dyld's `__interpose` section, and dyld never applies interposing tuples to the image that provides them — the same exemption every `original()` forward has always relied on.

Dropping the guard also fixes a real gap: it silently discarded legitimate accesses made by signal handlers that interrupt an in-flight interception — exactly the case the signal-safe allocator work exists to support — and it removes a std TLS dependency from the hot path, which the std-free preload roadmap has to shed anyway.

A comment on `handle_open` now records the invariant this rests on: the handler must stay free of bindable libc calls on Linux, and the macOS argument holds only under `__interpose`-style interposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
