### PR TITLE
refactor(deps): declare dependency features in member crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,9 @@ bindgen = "0.72.1"
 bitflags = "2.10.0"
 brush-parser = "0.4.0"
 bstr = { version = "1.12.0", default-features = false }
-bump-scope = { version = "2", default-features = false, features = ["allocator-api2-02"] }
-bumpalo = { version = "3.17.0", features = ["allocator-api2", "collections"] }
-bytemuck = { version = "1.23.0", features = ["extern_crate_alloc", "must_cast"] }
+bump-scope = { version = "2", default-features = false }
+bumpalo = "3.17.0"
+bytemuck = "1.23.0"
 cargo-platform = "=0.3.2"
 cc = "1.2.39"
 clap = "4.5.53"
@@ -63,8 +63,8 @@ constcat = "0.6.1"
 copy_dir = "0.1.3"
 cow-utils = "0.1.3"
 cp_r = "0.5.2"
-crossterm = { version = "0.29.0", features = ["event-stream"] }
-csv-async = { version = "1.3.1", features = ["tokio"] }
+crossterm = "0.29.0"
+csv-async = "1.3.1"
 ctor = "1.0"
 ctrlc = "3.5.2"
 derive_more = "2.0.1"
@@ -90,7 +90,7 @@ futures-util = "0.3.31"
 globset = "0.4.18"
 getrandom = "0.4.2"
 itoa = "1.0.17"
-jsonc-parser = { version = "0.32.0", features = ["serde"] }
+jsonc-parser = "0.32.0"
 libc = "0.2.185"
 libtest-mimic = "0.8.2"
 memmap2 = "0.9.11"
@@ -99,20 +99,20 @@ napi = "3"
 napi-build = "2"
 napi-derive = "3"
 fspy_ipc_str = { path = "crates/fspy_ipc_str" }
-nix = { version = "0.31.2", features = ["dir", "signal"] }
+nix = "0.31.2"
 ntapi = "0.4.1"
 nucleo-matcher = "0.3.1"
 omnipath = "0.1.6"
 once_cell = "1.19"
 os_str_bytes = "7.1.1"
 ouroboros = "0.18.5"
-owo-colors = { version = "4.1.0", features = ["supports-colors"] }
+owo-colors = "4.1.0"
 passfd = { git = "https://github.com/polachok/passfd", rev = "d55881752c16aced1a49a75f9c428d38d3767213", default-features = false }
 notify = "8.0.0"
 path-clean = "1.0.1"
 pathdiff = "0.2.3"
 petgraph = "0.8.2"
-phf = { version = "0.13.0", features = ["macros"] }
+phf = "0.13.0"
 portable-pty = "0.9.0"
 pretty_assertions = "1.4.1"
 proc-macro2 = "1"
@@ -126,7 +126,7 @@ ref-cast = "1.0.24"
 regex = "1.11.3"
 rusqlite = "0.39.0"
 rustc-hash = "2.1.1"
-rustix = { version = "1", default-features = false, features = ["mm"] }
+rustix = { version = "1", default-features = false }
 # SeccompAction::UserNotif (SECCOMP_RET_USER_NOTIF) was added after the latest published release (v0.5.0)
 seccompiler = { git = "https://github.com/rust-vmm/seccompiler", rev = "08587106340b8e3cb361c7561411510039436857" }
 serde = "1.0.219"
@@ -137,7 +137,7 @@ shell-escape = "0.1.5"
 fspy_nostd = { path = "crates/fspy_nostd" }
 fspy_nostd_alloc = { path = "crates/fspy_nostd_alloc" }
 similar = "3.0.0"
-smallvec = { version = "2.0.0-alpha.12", features = ["std"] }
+smallvec = "2.0.0-alpha.12"
 static_cell = "2"
 snapshot_test = { path = "crates/snapshot_test" }
 socket_ipc = { path = "crates/socket_ipc" }
@@ -148,14 +148,14 @@ syn = "2"
 syscalls = { version = "0.8.0", default-features = false }
 tar = "0.4.45"
 tempfile = "3.14.0"
-test-log = { version = "0.2.18", features = ["trace"] }
+test-log = "0.2.18"
 thiserror = "2"
 tokio = "1.48.0"
 tokio-util = "0.7.17"
 toml = "1.0.0"
 tracing = "0.1.43"
 tracing-error = "0.2.1"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter", "serde"] }
+tracing-subscriber = "0.3.19"
 ts-rs = { version = "12.0.0" }
 tui-term = "0.3.1"
 twox-hash = "2.1.1"
@@ -183,8 +183,8 @@ which = "8.0.0"
 widestring = "1.2.0"
 winapi = "0.3.9"
 windows-sys = "0.61"
-winsafe = { version = "0.0.27", features = ["kernel"] }
-xxhash-rust = { version = "0.8.15", features = ["const_xxh3"] }
+winsafe = { version = "0.0.27" }
+xxhash-rust = "0.8.15"
 ntest = "0.9.5"
 terminal_size = "0.4"
 zstd = "0.13"

--- a/crates/fspy/Cargo.toml
+++ b/crates/fspy/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 allocator-api2 = { workspace = true, features = ["alloc"] }
 wincode = { workspace = true }
 bstr = { workspace = true, features = ["alloc", "std"] }
-bumpalo = { workspace = true }
+bumpalo = { workspace = true, features = ["allocator-api2", "collections"] }
 derive_more = { workspace = true, features = ["debug"] }
 materialized_artifact = { workspace = true }
 fspy_shared = { workspace = true }
@@ -50,18 +50,18 @@ fspy_preload_unix = { workspace = true }
 fspy_detours_sys = { workspace = true }
 fspy_preload_windows = { workspace = true }
 winapi = { workspace = true, features = ["winbase", "securitybaseapi", "handleapi"] }
-winsafe = { workspace = true }
+winsafe = { workspace = true, features = ["kernel"] }
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 tempfile = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-csv-async = { workspace = true }
+csv-async = { workspace = true, features = ["tokio"] }
 ctor = { workspace = true }
 ntest = { workspace = true }
 subprocess_test = { workspace = true, features = ["fspy"] }
-test-log = { workspace = true }
+test-log = { workspace = true, features = ["trace"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "io-std"] }
 
 [target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dev-dependencies]

--- a/crates/fspy_ipc_str/Cargo.toml
+++ b/crates/fspy_ipc_str/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 [dependencies]
 allocator-api2 = { workspace = true, features = ["alloc"] }
 bumpalo = { workspace = true }
-bytemuck = { workspace = true, features = ["must_cast", "derive"] }
+bytemuck = { workspace = true, features = ["derive", "extern_crate_alloc", "must_cast"] }
 fspy_nostd = { workspace = true }
 fspy_nostd_alloc = { workspace = true }
 wincode = { workspace = true }

--- a/crates/fspy_nostd/Cargo.toml
+++ b/crates/fspy_nostd/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 bstr = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-rustix = { workspace = true, features = ["fs"] }
+rustix = { workspace = true, features = ["fs", "mm"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = { workspace = true }

--- a/crates/fspy_nostd_alloc/Cargo.toml
+++ b/crates/fspy_nostd_alloc/Cargo.toml
@@ -9,7 +9,7 @@ doctest = false
 
 [dependencies]
 allocator-api2 = { workspace = true, features = ["alloc"] }
-bump-scope = { workspace = true }
+bump-scope = { workspace = true, features = ["allocator-api2-02"] }
 fspy_nostd = { workspace = true }
 
 [lints]

--- a/crates/fspy_preload_windows/Cargo.toml
+++ b/crates/fspy_preload_windows/Cargo.toml
@@ -17,7 +17,7 @@ allocator-api2 = { workspace = true }
 fspy_nostd_alloc = { workspace = true }
 fspy_shared = { workspace = true }
 ntapi = { workspace = true }
-smallvec = { workspace = true }
+smallvec = { workspace = true, features = ["std"] }
 widestring = { workspace = true }
 winapi = { workspace = true, features = [
   "winerror",
@@ -27,7 +27,7 @@ winapi = { workspace = true, features = [
   "std",
 ] }
 windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_UI_Shell"] }
-winsafe = { workspace = true }
+winsafe = { workspace = true, features = ["kernel"] }
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/fspy_seccomp_unotify/Cargo.toml
+++ b/crates/fspy_seccomp_unotify/Cargo.toml
@@ -21,7 +21,7 @@ futures-util = { workspace = true }
 assertables = { workspace = true }
 futures-util = { workspace = true }
 nix = { workspace = true, features = ["fs"] }
-test-log = { workspace = true }
+test-log = { workspace = true, features = ["trace"] }
 tokio = { workspace = true, features = ["macros", "time"] }
 
 [features]

--- a/crates/fspy_shared_unix/Cargo.toml
+++ b/crates/fspy_shared_unix/Cargo.toml
@@ -24,7 +24,7 @@ fspy_seccomp_unotify = { workspace = true, features = ["target"] }
 memmap2 = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-phf = { workspace = true }
+phf = { workspace = true, features = ["macros"] }
 
 [lints]
 workspace = true

--- a/crates/fspy_test_bin/Cargo.toml
+++ b/crates/fspy_test_bin/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-nix = { workspace = true }
+nix = { workspace = true, features = ["fs"] }
 
 [lints]
 workspace = true

--- a/crates/pty_terminal/Cargo.toml
+++ b/crates/pty_terminal/Cargo.toml
@@ -20,7 +20,7 @@ subprocess_test = { workspace = true, features = ["portable-pty"] }
 terminal_size = { workspace = true }
 
 [target.'cfg(unix)'.dev-dependencies]
-nix = { workspace = true }
+nix = { workspace = true, features = ["signal"] }
 signal-hook = "0.4"
 
 [lints]

--- a/crates/vt/Cargo.toml
+++ b/crates/vt/Cargo.toml
@@ -21,7 +21,7 @@ ctrlc = { workspace = true }
 derive_more = { workspace = true, features = ["debug", "from"] }
 futures-util = { workspace = true }
 once_cell = { workspace = true }
-owo-colors = { workspace = true }
+owo-colors = { workspace = true, features = ["supports-colors"] }
 petgraph = { workspace = true }
 pty_terminal_test_client = { workspace = true }
 rayon = { workspace = true }
@@ -70,7 +70,7 @@ tempfile = { workspace = true }
 fspy = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-nix = { workspace = true }
+nix = { workspace = true, features = ["dir"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { workspace = true, features = ["handleapi", "jobapi2", "winnt"] }

--- a/crates/vt_bin/Cargo.toml
+++ b/crates/vt_bin/Cargo.toml
@@ -23,7 +23,7 @@ notify = { workspace = true }
 pty_terminal_test_client = { workspace = true }
 async-trait = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-jsonc-parser = { workspace = true }
+jsonc-parser = { workspace = true, features = ["serde"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 vt_path = { workspace = true }

--- a/crates/vt_tui/Cargo.toml
+++ b/crates/vt_tui/Cargo.toml
@@ -17,7 +17,7 @@ test = false
 
 [dependencies]
 color-eyre = { workspace = true }
-crossterm = { workspace = true }
+crossterm = { workspace = true, features = ["event-stream"] }
 directories = { workspace = true }
 futures = { workspace = true }
 portable-pty = { workspace = true }
@@ -29,4 +29,4 @@ tui-term = { workspace = true }
 
 tracing = { workspace = true }
 tracing-error = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "serde"] }


### PR DESCRIPTION
## Motivation

Features declared on `[workspace.dependencies]` entries are forced on every member that uses the dependency — a member can add features but never subtract them — so the workspace manifest quietly over-featured most crates and hid which crate actually needs what. Every `features = [...]` list moves from the workspace manifest to the member crates that use it; `default-features = false` stays at the workspace level, where it is the only place it can take effect.

Moving them exposed two kinds of rot:

- **Dead features**: `bumpalo/collections` was declared workspace-wide for one brace-grouped import in fspy's arena (now declared there); `nix/dir` was used only by vt's fingerprinting; `nix/signal` only by pty_terminal's tests; `xxhash-rust/const_xxh3` had no users at all and is gone.
- **Masked under-declarations**: fspy_ipc_str uses `TransparentWrapperAlloc` (`extern_crate_alloc`) but only compiled because the workspace forced the feature; it now declares it.

Every affected member was checked individually (`cargo check -p … --all-targets`) on the host plus the Linux and Windows targets, so no member relies on feature unification from a sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
